### PR TITLE
docs: Point users to `NarrowPhaseConfig::prediction_distance`

### DIFF
--- a/src/plugins/collision/contact_reporting.rs
+++ b/src/plugins/collision/contact_reporting.rs
@@ -17,6 +17,9 @@ use crate::prelude::*;
 ///
 /// You can listen to them with normal event readers:
 ///
+/// Colliders are considered as colliding if they are closer than
+/// [`NarrowPhaseConfig::prediction_distance`] away from each other.
+///
 /// ```no_run
 /// use bevy::prelude::*;
 #[cfg_attr(feature = "2d", doc = "use bevy_xpbd_2d::prelude::*;")]


### PR DESCRIPTION
# Objective

I tripped up on collisions, because I considered the units as meters, but the default value for prediction distance is 1 (presumably pixels)

## Solution

Most of the documentation links to the `ContactReportingPlugin` when talking about contacts.

So link from there to `NarrowPhaseConfig::prediction_distance`, so they can follow the trail.
