### PR TITLE
Fix `f64` support with `debug-plugin` feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: dtolnay/rust-toolchain@stable
             - name: Run cargo test
-              run: cargo test --no-default-features --features enhanced-determinism,collider-from-mesh,serialize,avian2d/2d,avian3d/3d,avian2d/f64,avian3d/f64,default-collider,parry-f64,bevy_scene
+              run: cargo test --no-default-features --features enhanced-determinism,collider-from-mesh,serialize,debug-plugin,avian2d/2d,avian3d/3d,avian2d/f64,avian3d/f64,default-collider,parry-f64,bevy_scene
 
     lints:
         name: Lints

--- a/src/debug_render/gizmos.rs
+++ b/src/debug_render/gizmos.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unnecessary_cast)]
+
 use crate::prelude::*;
 use bevy::prelude::*;
 #[cfg(all(
@@ -157,7 +159,6 @@ impl<'w, 's> PhysicsGizmoExt for Gizmos<'w, 's, PhysicsGizmos> {
         feature = "default-collider",
         any(feature = "parry-f32", feature = "parry-f64")
     ))]
-    #[allow(clippy::unnecessary_cast)]
     fn draw_collider(
         &mut self,
         collider: &Collider,
@@ -484,9 +485,14 @@ impl<'w, 's> PhysicsGizmoExt for Gizmos<'w, 's, PhysicsGizmos> {
 
             // Draw hit point
             #[cfg(feature = "2d")]
-            self.circle_2d(point.f32(), 0.1 * length_unit, point_color);
+            self.circle_2d(point.f32(), 0.1 * length_unit as f32, point_color);
             #[cfg(feature = "3d")]
-            self.sphere(point.f32(), default(), 0.1 * length_unit, point_color);
+            self.sphere(
+                point.f32(),
+                default(),
+                0.1 * length_unit as f32,
+                point_color,
+            );
 
             // Draw hit normal as arrow
             self.draw_arrow(
@@ -543,9 +549,14 @@ impl<'w, 's> PhysicsGizmoExt for Gizmos<'w, 's, PhysicsGizmos> {
         for hit in hits {
             // Draw hit point
             #[cfg(feature = "2d")]
-            self.circle_2d(hit.point1.f32(), 0.1 * length_unit, point_color);
+            self.circle_2d(hit.point1.f32(), 0.1 * length_unit as f32, point_color);
             #[cfg(feature = "3d")]
-            self.sphere(hit.point1.f32(), default(), 0.1 * length_unit, point_color);
+            self.sphere(
+                hit.point1.f32(),
+                default(),
+                0.1 * length_unit as f32,
+                point_color,
+            );
 
             // Draw hit normal as arrow
             self.draw_arrow(

--- a/src/debug_render/mod.rs
+++ b/src/debug_render/mod.rs
@@ -331,13 +331,13 @@ fn debug_render_contacts(
                 if let Some(color) = config.contact_point_color {
                     #[cfg(feature = "2d")]
                     {
-                        gizmos.circle_2d(p1.f32(), 0.1 * length_unit.0, color);
-                        gizmos.circle_2d(p2.f32(), 0.1 * length_unit.0, color);
+                        gizmos.circle_2d(p1.f32(), 0.1 * length_unit.0 as f32, color);
+                        gizmos.circle_2d(p2.f32(), 0.1 * length_unit.0 as f32, color);
                     }
                     #[cfg(feature = "3d")]
                     {
-                        gizmos.sphere(p1.f32(), default(), 0.1 * length_unit.0, color);
-                        gizmos.sphere(p2.f32(), default(), 0.1 * length_unit.0, color);
+                        gizmos.sphere(p1.f32(), default(), 0.1 * length_unit.0 as f32, color);
+                        gizmos.sphere(p2.f32(), default(), 0.1 * length_unit.0 as f32, color);
                     }
                 }
 


### PR DESCRIPTION
# Objective

The debug rendering is using some incorrect math types when the `f64` feature is enabled, causing compilation to fail.

## Solution

Fix the types and add `debug-plugin` to CI so it hopefully catches this in the future.