### PR TITLE
Fix `Mesh` not being optional

### DIFF
--- a/src/collision/collider/backend.rs
+++ b/src/collision/collider/backend.rs
@@ -284,8 +284,8 @@ pub(crate) fn init_colliders<C: AnyCollider>(
 /// Panics if the [`ColliderConstructor`] requires a mesh but no mesh handle is found.
 fn init_collider_constructors(
     mut commands: Commands,
-    #[cfg(all(feature = "3d", feature = "collider-from-mesh"))] meshes: Res<Assets<Mesh>>,
-    #[cfg(all(feature = "3d", feature = "collider-from-mesh"))] mesh_handles: Query<&Handle<Mesh>>,
+    #[cfg(feature = "collider-from-mesh")] meshes: Res<Assets<Mesh>>,
+    #[cfg(feature = "collider-from-mesh")] mesh_handles: Query<&Handle<Mesh>>,
     constructors: Query<(
         Entity,
         Option<&Collider>,
@@ -303,7 +303,7 @@ fn init_collider_constructors(
             commands.entity(entity).remove::<ColliderConstructor>();
             continue;
         }
-        #[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
+        #[cfg(feature = "collider-from-mesh")]
         let mesh = if constructor.requires_mesh() {
             let mesh_handle = mesh_handles.get(entity).unwrap_or_else(|_| panic!(
                 "Tried to add a collider to entity {name} via {constructor:#?} that requires a mesh, \
@@ -318,9 +318,9 @@ fn init_collider_constructors(
             None
         };
 
-        #[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
+        #[cfg(feature = "collider-from-mesh")]
         let collider = Collider::try_from_constructor(constructor.clone(), mesh);
-        #[cfg(not(all(feature = "3d", feature = "collider-from-mesh")))]
+        #[cfg(not(feature = "collider-from-mesh"))]
         let collider = Collider::try_from_constructor(constructor.clone());
 
         if let Some(collider) = collider {
@@ -340,8 +340,8 @@ fn init_collider_constructors(
 /// If an entity has a `SceneInstance`, its collider hierarchy is only generated once the scene is ready.
 fn init_collider_constructor_hierarchies(
     mut commands: Commands,
-    #[cfg(all(feature = "3d", feature = "collider-from-mesh"))] meshes: Res<Assets<Mesh>>,
-    #[cfg(all(feature = "3d", feature = "collider-from-mesh"))] mesh_handles: Query<&Handle<Mesh>>,
+    #[cfg(feature = "collider-from-mesh")] meshes: Res<Assets<Mesh>>,
+    #[cfg(feature = "collider-from-mesh")] mesh_handles: Query<&Handle<Mesh>>,
     #[cfg(feature = "bevy_scene")] scene_spawner: Res<SceneSpawner>,
     #[cfg(feature = "bevy_scene")] scenes: Query<&Handle<Scene>>,
     #[cfg(feature = "bevy_scene")] scene_instances: Query<&SceneInstance>,
@@ -408,7 +408,7 @@ fn init_collider_constructor_hierarchies(
                 continue;
             };
 
-            #[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
+            #[cfg(feature = "collider-from-mesh")]
             let mesh = if constructor.requires_mesh() {
                 if let Ok(handle) = mesh_handles.get(child_entity) {
                     meshes.get(handle)
@@ -419,9 +419,9 @@ fn init_collider_constructor_hierarchies(
                 None
             };
 
-            #[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
+            #[cfg(feature = "collider-from-mesh")]
             let collider = Collider::try_from_constructor(constructor, mesh);
-            #[cfg(not(all(feature = "3d", feature = "collider-from-mesh")))]
+            #[cfg(not(feature = "collider-from-mesh"))]
             let collider = Collider::try_from_constructor(constructor);
 
             if let Some(collider) = collider {

--- a/src/collision/collider/constructor.rs
+++ b/src/collision/collider/constructor.rs
@@ -281,8 +281,8 @@ pub struct ColliderConstructorHierarchyConfig {
 #[derive(Clone, Debug, PartialEq, Reflect, Component)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[cfg_attr(all(feature = "3d", feature = "collider-from-mesh"), derive(Default))]
-#[cfg_attr(all(feature = "3d", feature = "collider-from-mesh"), reflect(Default))]
+#[cfg_attr(feature = "collider-from-mesh", derive(Default))]
+#[cfg_attr(feature = "collider-from-mesh", reflect(Default))]
 #[reflect(Debug, Component, PartialEq)]
 #[non_exhaustive]
 #[allow(missing_docs)]
@@ -405,7 +405,7 @@ pub enum ColliderConstructor {
         scale: Vector,
     },
     /// Constructs a collider with [`Collider::trimesh_from_mesh`].
-    #[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
+    #[cfg(feature = "collider-from-mesh")]
     #[default]
     TrimeshFromMesh,
     /// Constructs a collider with [`Collider::trimesh_from_mesh_with_config`].
@@ -416,7 +416,7 @@ pub enum ColliderConstructor {
     ))]
     TrimeshFromMeshWithConfig(TrimeshFlags),
     /// Constructs a collider with [`Collider::convex_decomposition_from_mesh`].
-    #[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
+    #[cfg(feature = "collider-from-mesh")]
     ConvexDecompositionFromMesh,
     /// Constructs a collider with [`Collider::convex_decomposition_from_mesh_with_config`].
     #[cfg(all(
@@ -426,13 +426,13 @@ pub enum ColliderConstructor {
     ))]
     ConvexDecompositionFromMeshWithConfig(VhacdParameters),
     /// Constructs a collider with [`Collider::convex_hull_from_mesh`].
-    #[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
+    #[cfg(feature = "collider-from-mesh")]
     ConvexHullFromMesh,
 }
 
 impl ColliderConstructor {
     /// Returns `true` if the collider type requires a mesh to be generated.
-    #[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
+    #[cfg(feature = "collider-from-mesh")]
     pub fn requires_mesh(&self) -> bool {
         matches!(
             self,
@@ -464,7 +464,7 @@ mod tests {
         assert!(app.query_err::<&ColliderConstructor>(entity));
     }
 
-    #[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
+    #[cfg(feature = "collider-from-mesh")]
     #[test]
     #[should_panic]
     fn collider_constructor_requires_mesh_on_computed() {
@@ -475,7 +475,7 @@ mod tests {
         app.update();
     }
 
-    #[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
+    #[cfg(feature = "collider-from-mesh")]
     #[test]
     fn collider_constructor_converts_mesh_on_computed() {
         let mut app = create_test_app();
@@ -510,7 +510,7 @@ mod tests {
         assert!(app.query_err::<&Collider>(entity));
     }
 
-    #[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
+    #[cfg(feature = "collider-from-mesh")]
     #[test]
     fn collider_constructor_hierarchy_does_nothing_on_self_with_computed() {
         let mut app = create_test_app();
@@ -531,7 +531,7 @@ mod tests {
         assert!(app.query_err::<&Collider>(entity));
     }
 
-    #[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
+    #[cfg(feature = "collider-from-mesh")]
     #[test]
     fn collider_constructor_hierarchy_does_not_require_mesh_on_self_with_computed() {
         let mut app = create_test_app();
@@ -586,7 +586,7 @@ mod tests {
         assert!(app.query_ok::<&Collider>(child3));
     }
 
-    #[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
+    #[cfg(feature = "collider-from-mesh")]
     #[test]
     fn collider_constructor_hierarchy_inserts_computed_colliders_only_on_descendants_with_mesh() {
         let mut app = create_test_app();
@@ -647,7 +647,7 @@ mod tests {
         assert!(app.query_ok::<&Collider>(child8));
     }
 
-    #[cfg(all(feature = "3d", feature = "collider-from-mesh", feature = "bevy_scene"))]
+    #[cfg(all(feature = "collider-from-mesh", feature = "bevy_scene"))]
     #[test]
     fn collider_constructor_hierarchy_inserts_correct_configs_on_scene() {
         use parry::shape::ShapeType;
@@ -724,7 +724,7 @@ mod tests {
         radius: 0.5,
     };
 
-    #[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
+    #[cfg(feature = "collider-from-mesh")]
     const COMPUTED_COLLIDER: ColliderConstructor = ColliderConstructor::TrimeshFromMesh;
 
     fn create_test_app() -> App {
@@ -742,7 +742,7 @@ mod tests {
         app
     }
 
-    #[cfg(all(feature = "3d", feature = "collider-from-mesh", feature = "bevy_scene"))]
+    #[cfg(all(feature = "collider-from-mesh", feature = "bevy_scene"))]
     fn create_gltf_test_app() -> App {
         use bevy::{diagnostic::DiagnosticsPlugin, winit::WinitPlugin};
 
@@ -765,7 +765,7 @@ mod tests {
             !self.query_ok::<D>(entity)
         }
 
-        #[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
+        #[cfg(feature = "collider-from-mesh")]
         fn add_mesh(&mut self) -> Handle<Mesh>;
     }
 
@@ -776,7 +776,7 @@ mod tests {
             component.is_ok()
         }
 
-        #[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
+        #[cfg(feature = "collider-from-mesh")]
         fn add_mesh(&mut self) -> Handle<Mesh> {
             self.world_mut()
                 .get_resource_mut::<Assets<Mesh>>()

--- a/src/collision/collider/constructor.rs
+++ b/src/collision/collider/constructor.rs
@@ -432,22 +432,16 @@ pub enum ColliderConstructor {
 
 impl ColliderConstructor {
     /// Returns `true` if the collider type requires a mesh to be generated.
+    #[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
     pub fn requires_mesh(&self) -> bool {
-        #[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
-        {
-            matches!(
-                self,
-                Self::TrimeshFromMesh
-                    | Self::TrimeshFromMeshWithConfig(_)
-                    | Self::ConvexDecompositionFromMesh
-                    | Self::ConvexDecompositionFromMeshWithConfig(_)
-                    | Self::ConvexHullFromMesh
-            )
-        }
-        #[cfg(not(all(feature = "3d", feature = "collider-from-mesh")))]
-        {
-            false
-        }
+        matches!(
+            self,
+            Self::TrimeshFromMesh
+                | Self::TrimeshFromMeshWithConfig(_)
+                | Self::ConvexDecompositionFromMesh
+                | Self::ConvexDecompositionFromMeshWithConfig(_)
+                | Self::ConvexHullFromMesh
+        )
     }
 }
 

--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -1073,16 +1073,23 @@ impl Collider {
         })
     }
 
-    /// Attempts to create a collider from an optional mesh with the given [`ColliderConstructor`].
+    /// Attempts to create a collider with the given [`ColliderConstructor`].
     /// By using this, you can serialize and deserialize the collider's creation method
     /// separately from the collider itself via the [`ColliderConstructor`] enum.
     ///
-    /// Returns `None` in the following cases:
-    /// - The given [`ColliderConstructor`] requires a mesh, but none was provided.
-    /// - Creating the collider from the given [`ColliderConstructor`] failed.
+    #[cfg_attr(
+        all(feature = "3d", feature = "collider-from-mesh"),
+        doc = "Returns `None` in the following cases:
+- The given [`ColliderConstructor`] requires a mesh, but none was provided.
+- Creating the collider from the given [`ColliderConstructor`] failed."
+    )]
+    #[cfg_attr(
+        not(all(feature = "3d", feature = "collider-from-mesh")),
+        doc = "Returns `None` if creating the collider from the given [`ColliderConstructor`] failed."
+    )]
     pub fn try_from_constructor(
         collider_constructor: ColliderConstructor,
-        #[allow(unused_variables)] mesh: Option<&Mesh>,
+        #[cfg(all(feature = "3d", feature = "collider-from-mesh"))] mesh: Option<&Mesh>,
     ) -> Option<Self> {
         match collider_constructor {
             #[cfg(feature = "2d")]

--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::unnecessary_cast)]
 
 use crate::{make_isometry, prelude::*};
-#[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
+#[cfg(feature = "collider-from-mesh")]
 use bevy::render::mesh::{Indices, VertexAttributeValues};
 use bevy::{log, prelude::*};
 use collision::contact_query::UnsupportedShape;
@@ -939,7 +939,7 @@ impl Collider {
     ///     ));
     /// }
     /// ```
-    #[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
+    #[cfg(feature = "collider-from-mesh")]
     pub fn trimesh_from_mesh(mesh: &Mesh) -> Option<Self> {
         extract_mesh_vertices_indices(mesh).map(|(vertices, indices)| {
             SharedShape::trimesh_with_flags(
@@ -976,7 +976,7 @@ impl Collider {
     ///     ));
     /// }
     /// ```
-    #[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
+    #[cfg(feature = "collider-from-mesh")]
     pub fn trimesh_from_mesh_with_config(mesh: &Mesh, flags: TrimeshFlags) -> Option<Self> {
         extract_mesh_vertices_indices(mesh).map(|(vertices, indices)| {
             SharedShape::trimesh_with_flags(vertices, indices, flags.into()).into()
@@ -1002,7 +1002,7 @@ impl Collider {
     ///     ));
     /// }
     /// ```
-    #[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
+    #[cfg(feature = "collider-from-mesh")]
     pub fn convex_hull_from_mesh(mesh: &Mesh) -> Option<Self> {
         extract_mesh_vertices_indices(mesh)
             .and_then(|(vertices, _)| SharedShape::convex_hull(&vertices).map(|shape| shape.into()))
@@ -1027,7 +1027,7 @@ impl Collider {
     ///     ));
     /// }
     /// ```
-    #[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
+    #[cfg(feature = "collider-from-mesh")]
     pub fn convex_decomposition_from_mesh(mesh: &Mesh) -> Option<Self> {
         extract_mesh_vertices_indices(mesh).map(|(vertices, indices)| {
             SharedShape::convex_decomposition(&vertices, &indices).into()
@@ -1058,7 +1058,7 @@ impl Collider {
     ///     ));
     /// }
     /// ```
-    #[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
+    #[cfg(feature = "collider-from-mesh")]
     pub fn convex_decomposition_from_mesh_with_config(
         mesh: &Mesh,
         parameters: &VhacdParameters,
@@ -1078,18 +1078,18 @@ impl Collider {
     /// separately from the collider itself via the [`ColliderConstructor`] enum.
     ///
     #[cfg_attr(
-        all(feature = "3d", feature = "collider-from-mesh"),
+        feature = "collider-from-mesh",
         doc = "Returns `None` in the following cases:
 - The given [`ColliderConstructor`] requires a mesh, but none was provided.
 - Creating the collider from the given [`ColliderConstructor`] failed."
     )]
     #[cfg_attr(
-        not(all(feature = "3d", feature = "collider-from-mesh")),
+        not(feature = "collider-from-mesh"),
         doc = "Returns `None` if creating the collider from the given [`ColliderConstructor`] failed."
     )]
     pub fn try_from_constructor(
         collider_constructor: ColliderConstructor,
-        #[cfg(all(feature = "3d", feature = "collider-from-mesh"))] mesh: Option<&Mesh>,
+        #[cfg(feature = "collider-from-mesh")] mesh: Option<&Mesh>,
     ) -> Option<Self> {
         match collider_constructor {
             #[cfg(feature = "2d")]
@@ -1196,38 +1196,30 @@ impl Collider {
             ColliderConstructor::Heightfield { heights, scale } => {
                 Some(Self::heightfield(heights, scale))
             }
-            #[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
+            #[cfg(feature = "collider-from-mesh")]
             ColliderConstructor::TrimeshFromMesh => Self::trimesh_from_mesh(mesh?),
-            #[cfg(all(
-                feature = "3d",
-                feature = "collider-from-mesh",
-                feature = "default-collider"
-            ))]
+            #[cfg(all(feature = "collider-from-mesh", feature = "default-collider"))]
             ColliderConstructor::TrimeshFromMeshWithConfig(flags) => {
                 Self::trimesh_from_mesh_with_config(mesh?, flags)
             }
-            #[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
+            #[cfg(feature = "collider-from-mesh")]
             ColliderConstructor::ConvexDecompositionFromMesh => {
                 Self::convex_decomposition_from_mesh(mesh?)
             }
-            #[cfg(all(
-                feature = "3d",
-                feature = "collider-from-mesh",
-                feature = "default-collider"
-            ))]
+            #[cfg(all(feature = "collider-from-mesh", feature = "default-collider"))]
             ColliderConstructor::ConvexDecompositionFromMeshWithConfig(params) => {
                 Self::convex_decomposition_from_mesh_with_config(mesh?, &params)
             }
-            #[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
+            #[cfg(feature = "collider-from-mesh")]
             ColliderConstructor::ConvexHullFromMesh => Self::convex_hull_from_mesh(mesh?),
         }
     }
 }
 
-#[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
+#[cfg(feature = "collider-from-mesh")]
 type VerticesIndices = (Vec<nalgebra::Point3<Scalar>>, Vec<[u32; 3]>);
 
-#[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
+#[cfg(feature = "collider-from-mesh")]
 fn extract_mesh_vertices_indices(mesh: &Mesh) -> Option<VerticesIndices> {
     let vertices = mesh.attribute(Mesh::ATTRIBUTE_POSITION)?;
     let indices = mesh.indices()?;


### PR DESCRIPTION
# Objective

Avian 0.1.0 introduced a regression where `bevy_render` is now needed because `Mesh` is not optional. It should be feature-gated behind `collider-from-mesh`.

## Solution

Put all mentions of `Mesh` behind the `collider-from-mesh` feature.