### PR TITLE
Fixed add_angle

### DIFF
--- a/src/position.rs
+++ b/src/position.rs
@@ -408,8 +408,7 @@ impl Rotation {
     #[must_use]
     /// Adds the given counterclockiwise angle in radians to the [`Rotation`].
     pub fn add_angle(&self, radians: Scalar) -> Self {
-        Rotation::from_sin_cos(self.sin + radians * self.cos, self.cos - radians * self.sin)
-            .normalize()
+        Rotation::radians(radians) * *self
     }
 
     /// Performs a linear interpolation between `self` and `rhs` based on


### PR DESCRIPTION
# Objective

Fixes [415](https://github.com/Jondolf/avian/issues/415) and [416](https://github.com/Jondolf/avian/issues/416)

## Solution# Objective

Old implementation was only for small angles. When impact on `RevoluteJoint` is big, XPBD [tries to apply](https://github.com/Jondolf/avian/blob/main/src/dynamics/solver/xpbd/positional_constraint.rs#L70) a big update on angles and fails

## Solution

Implemented `add_angle` function using precise computation of sin and cos