### PR TITLE
Make `HierarchyPlugin` optional

### DIFF
--- a/src/sync/ancestor_marker.rs
+++ b/src/sync/ancestor_marker.rs
@@ -78,6 +78,9 @@ impl<C: Component> Plugin for AncestorMarkerPlugin<C> {
             },
         );
 
+        // Initialize `HierarchyEvent` in case `HierarchyPlugin` is not added.
+        app.add_event::<HierarchyEvent>();
+
         // Update markers when changes are made to the hierarchy.
         // TODO: This should be an observer. It'd remove the need for this scheduling nonsense
         //       and make the implementation more robust.
@@ -89,13 +92,6 @@ impl<C: Component> Plugin for AncestorMarkerPlugin<C> {
         } else {
             app.add_systems(self.schedule, update_markers_on_hierarchy_changes::<C>);
         }
-    }
-
-    fn finish(&self, app: &mut App) {
-        assert!(
-            app.is_plugin_added::<HierarchyPlugin>(),
-            "`AncestorMarkerPlugin` requires Bevy's `HierarchyPlugin` to function.",
-        );
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -35,8 +35,9 @@ fn create_app() -> App {
     app.add_plugins((
         MinimalPlugins,
         TransformPlugin,
-        HierarchyPlugin,
-        PhysicsPlugins::default(),
+        PhysicsPlugins::default()
+            .build()
+            .disable::<ColliderHierarchyPlugin>(),
         bevy::asset::AssetPlugin::default(),
         #[cfg(feature = "bevy_scene")]
         bevy::scene::ScenePlugin,
@@ -256,8 +257,9 @@ fn no_ambiguity_errors() {
     App::new()
         .add_plugins((
             MinimalPlugins,
-            HierarchyPlugin,
-            PhysicsPlugins::new(DeterministicSchedule),
+            PhysicsPlugins::new(DeterministicSchedule)
+                .build()
+                .disable::<ColliderHierarchyPlugin>(),
             bevy::asset::AssetPlugin::default(),
             #[cfg(feature = "bevy_scene")]
             bevy::scene::ScenePlugin,


### PR DESCRIPTION
# Objective

Avian 0.1.0 introduced a regression where `HierarchyPlugin` and `ColliderHierarchyPlugin` are needed for colliders to function, as `ColliderParent` was only inserted by `ColliderHierarchyPlugin`. Hierarchies shouldn't be necessary.

## Solution

Update `ColliderParent` for colliders that are on the `RigidBody` entity in the `ColliderBackendPlugin`, and change panics to warnings when using `ColliderHierarchyPlugin` without `HierarchyPlugin`.