### PR TITLE
Handle sleeping logic before physics

### DIFF
--- a/src/dynamics/integrator/mod.rs
+++ b/src/dynamics/integrator/mod.rs
@@ -61,12 +61,12 @@ impl Plugin for IntegratorPlugin {
         app.get_schedule_mut(PhysicsSchedule)
             .expect("add PhysicsSchedule first")
             .add_systems(
-                apply_impulses
-                    .before(PhysicsStepSet::Solver)
-                    // The scheduling shouldn't matter as long as it's before the solver.
-                    .ambiguous_with_all(),
-            )
-            .add_systems(clear_forces_and_impulses.after(PhysicsStepSet::SpatialQuery));
+                (
+                    apply_impulses.before(SolverSet::Substep),
+                    clear_forces_and_impulses.after(SolverSet::Substep),
+                )
+                    .in_set(PhysicsStepSet::Solver),
+            );
     }
 }
 

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -9,7 +9,6 @@ use bevy::{
     ecs::{intern::Interned, query::QueryFilter, schedule::ScheduleLabel},
     prelude::*,
 };
-use dynamics::sleeping::PhysicsChangeTicks;
 
 /// Runs systems at the start of each physics frame. Initializes [rigid bodies](RigidBody)
 /// and updates components.
@@ -417,7 +416,6 @@ fn init_rigid_bodies(
             *restitution.unwrap_or(&Restitution::default()),
             *friction.unwrap_or(&Friction::default()),
             *time_sleeping.unwrap_or(&TimeSleeping::default()),
-            PhysicsChangeTicks::default(),
         ));
     }
 }


### PR DESCRIPTION
# Objective

Currently, sleeping and waking is handled after physics. This leads to a one frame delay before bodies are woken up by things like velocity changes or applied external forces. It can even cause `ExternalImpulse` to do nothing, because the body is only woken up by the time the impulse should've already been applied and cleared.

## Solution

Run sleeping logic before physics. User changes are detected by comparing component change ticks to a `LastPhysicsTick` resource. This refactor also lets us get rid of the `PhysicsChangeTicks` component, which was previously stored and updated for all physics entities.

`PhysicsStepSet::Sleeping` now technically doesn't have much sleeping logic anymore, but that can be reworked in a follow-up.