### PR TITLE
[+]Avian(Backend) - GravityScale::Default changed to 1.0f32

### DIFF
--- a/src/dynamics/rigid_body/mod.rs
+++ b/src/dynamics/rigid_body/mod.rs
@@ -431,12 +431,18 @@ pub(crate) struct PreSolveAngularVelocity(pub Vector);
 /// }
 /// ```
 #[derive(
-    Component, Reflect, Debug, Clone, Copy, PartialEq, PartialOrd, Default, Deref, DerefMut, From,
+    Component, Reflect, Debug, Clone, Copy, PartialEq, PartialOrd, Deref, DerefMut, From,
 )]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, Component, Default, PartialEq)]
 pub struct GravityScale(pub Scalar);
+
+impl Default for GravityScale{
+    fn default() -> Self {
+        Self(1.0f32)
+    }
+}
 
 /// Determines how coefficients are combined for [`Restitution`] and [`Friction`].
 /// The default is `Average`.

--- a/src/dynamics/rigid_body/mod.rs
+++ b/src/dynamics/rigid_body/mod.rs
@@ -436,7 +436,7 @@ pub(crate) struct PreSolveAngularVelocity(pub Vector);
 #[reflect(Debug, Component, Default, PartialEq)]
 pub struct GravityScale(pub Scalar);
 
-impl Default for GravityScale{
+impl Default for GravityScale {
     fn default() -> Self {
         Self(1.0)
     }

--- a/src/dynamics/rigid_body/mod.rs
+++ b/src/dynamics/rigid_body/mod.rs
@@ -430,9 +430,7 @@ pub(crate) struct PreSolveAngularVelocity(pub Vector);
 ///     ));
 /// }
 /// ```
-#[derive(
-    Component, Reflect, Debug, Clone, Copy, PartialEq, PartialOrd, Deref, DerefMut, From,
-)]
+#[derive(Component, Reflect, Debug, Clone, Copy, PartialEq, PartialOrd, Deref, DerefMut, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, Component, Default, PartialEq)]
@@ -440,7 +438,7 @@ pub struct GravityScale(pub Scalar);
 
 impl Default for GravityScale{
     fn default() -> Self {
-        Self(1.0f32)
+        Self(1.0)
     }
 }
 


### PR DESCRIPTION
# Objective

Fixes #463 

## Solution

Default implemented with 1.0f32