### PR TITLE
Disable overlap warning for sensors

### DIFF
--- a/src/collision/narrow_phase.rs
+++ b/src/collision/narrow_phase.rs
@@ -689,7 +689,7 @@ impl<'w, 's, C: AnyCollider> NarrowPhase<'w, 's, C> {
 #[cfg(debug_assertions)]
 fn log_overlap_at_spawn(
     collisions: Res<Collisions>,
-    added_bodies: Query<(Ref<RigidBody>, Option<&Name>, &Position)>,
+    added_bodies: Query<(Ref<RigidBody>, Option<&Name>, &Position), Without<Sensor>>,
 ) {
     for contacts in collisions.get_internal().values() {
         let Ok([(rb1, name1, position1), (rb2, name2, position2)]) = added_bodies.get_many([


### PR DESCRIPTION
# Objective

There is a warning that looks like this:
```
WARN avian2d::collision::narrow_phase: Entity { index: 8, generation: 1 } and Entity { index: 20, generation: 1 } are overlapping at spawn, which can result in explosive behavior.
```

In my opinion it shouldn't show up when we are spawning `Sensor`s. They may overlap without explosive behavior.

## Solution

Sensors are filtered out from the `log_overlap_at_spawn` system