### PR TITLE
Allow not overwriting entity visibility with debug renderer

### DIFF
--- a/src/debug_render/configuration.rs
+++ b/src/debug_render/configuration.rs
@@ -83,9 +83,8 @@ pub struct PhysicsGizmos {
     pub shapecast_point_color: Option<Color>,
     /// The color used for the hit normals in [shapecasts](spatial_query#shapecasting).
     pub shapecast_normal_color: Option<Color>,
-    /// Determines if the visibility of entities with [colliders](Collider) should be set to `Visibility::Hidden`,
-    /// which will only show the debug renders.
-    pub hide_meshes: bool,
+    /// Determines if the visibility of entities with [colliders](Collider).
+    pub mesh_visibility: MeshVisibility,
 }
 
 impl Default for PhysicsGizmos {
@@ -107,7 +106,7 @@ impl Default for PhysicsGizmos {
             shapecast_shape_color: Some(Color::srgb(0.4, 0.6, 1.0)),
             shapecast_point_color: Some(YELLOW.into()),
             shapecast_normal_color: Some(PINK.into()),
-            hide_meshes: false,
+            mesh_visibility: MeshVisibility::Ignore,
         }
     }
 }
@@ -127,6 +126,32 @@ pub enum ContactGizmoScale {
 impl Default for ContactGizmoScale {
     fn default() -> Self {
         Self::Scaled(0.025)
+    }
+}
+
+/// Determines if the visibility of entities with [colliders](Collider) should
+/// be overwritten. Setting this to `MeshVisibility::Overwrite(Visibility::Hidden)`,
+/// will only show the debug renders.
+#[derive(Reflect, Clone, Copy, PartialEq, Default)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(PartialEq)]
+pub enum MeshVisibility {
+    /// Do not change the visibility of the entity's mesh.
+    #[default]
+    Ignore,
+    /// Always overwrite the visibility of the entity's mesh.
+    Overwrite(Visibility),
+}
+
+impl MeshVisibility {
+    /// Returns the first non-ignore visibility.
+    pub fn or(self, other: Self) -> Self {
+        if self == Self::Ignore {
+            other
+        } else {
+            self
+        }
     }
 }
 
@@ -150,7 +175,7 @@ impl PhysicsGizmos {
             shapecast_shape_color: Some(Color::srgb(0.4, 0.6, 1.0)),
             shapecast_point_color: Some(YELLOW.into()),
             shapecast_normal_color: Some(PINK.into()),
-            hide_meshes: true,
+            mesh_visibility: MeshVisibility::Overwrite(Visibility::Hidden),
         }
     }
 
@@ -175,7 +200,7 @@ impl PhysicsGizmos {
             shapecast_shape_color: None,
             shapecast_point_color: None,
             shapecast_normal_color: None,
-            hide_meshes: false,
+            mesh_visibility: MeshVisibility::Ignore,
         }
     }
 
@@ -314,8 +339,8 @@ impl PhysicsGizmos {
     }
 
     /// Sets the visibility of the entity's visual mesh.
-    pub fn with_mesh_visibility(mut self, is_visible: bool) -> Self {
-        self.hide_meshes = !is_visible;
+    pub fn with_mesh_visibility(mut self, visibility: MeshVisibility) -> Self {
+        self.mesh_visibility = visibility;
         self
     }
 
@@ -421,8 +446,8 @@ pub struct DebugRender {
     /// If the entity is [sleeping](Sleeping), its colors (in HSLA) will be multiplied by this array.
     /// If `None`, sleeping will have no effect on the colors.
     pub sleeping_color_multiplier: Option<[f32; 4]>,
-    /// Determines if the entity's visibility should be set to `Visibility::Hidden`, which will only show the debug render.
-    pub hide_mesh: bool,
+    /// Determines if the entity's visibility should be overwritten.
+    pub mesh_visibility: MeshVisibility,
 }
 
 impl Default for DebugRender {
@@ -435,7 +460,7 @@ impl Default for DebugRender {
             aabb_color: None,
             collider_color: Some(ORANGE.into()),
             sleeping_color_multiplier: Some([1.0, 1.0, 0.4, 1.0]),
-            hide_mesh: false,
+            mesh_visibility: MeshVisibility::Ignore,
         }
     }
 }
@@ -451,7 +476,7 @@ impl DebugRender {
             aabb_color: Some(Color::srgb(0.8, 0.8, 0.8)),
             collider_color: Some(ORANGE.into()),
             sleeping_color_multiplier: Some([1.0, 1.0, 0.4, 1.0]),
-            hide_mesh: true,
+            mesh_visibility: MeshVisibility::Overwrite(Visibility::Hidden),
         }
     }
 
@@ -462,7 +487,7 @@ impl DebugRender {
             aabb_color: None,
             collider_color: None,
             sleeping_color_multiplier: None,
-            hide_mesh: false,
+            mesh_visibility: MeshVisibility::Ignore,
         }
     }
 
@@ -518,8 +543,8 @@ impl DebugRender {
     }
 
     /// Sets the visibility of the entity's visual mesh.
-    pub fn with_mesh_visibility(mut self, is_visible: bool) -> Self {
-        self.hide_mesh = !is_visible;
+    pub fn with_mesh_visibility(mut self, visibility: MeshVisibility) -> Self {
+        self.mesh_visibility = visibility;
         self
     }
 

--- a/src/debug_render/mod.rs
+++ b/src/debug_render/mod.rs
@@ -482,12 +482,17 @@ fn change_mesh_visibility(
     let config = store.config::<PhysicsGizmos>();
     if store.is_changed() {
         for (mut visibility, render_config) in &mut meshes {
-            let hide_mesh =
-                config.0.enabled && render_config.map_or(config.1.hide_meshes, |c| c.hide_mesh);
-            if hide_mesh {
-                *visibility = Visibility::Hidden;
-            } else {
-                *visibility = Visibility::Visible;
+            if !config.0.enabled {
+                continue;
+            }
+
+            let mesh_visibility = render_config
+                .map(|global_config| global_config.mesh_visibility)
+                .unwrap_or_default()
+                .or(config.1.mesh_visibility);
+
+            if let MeshVisibility::Overwrite(value) = mesh_visibility {
+                *visibility = value;
             }
         }
     }


### PR DESCRIPTION
# Objective

Currently `PhysicsDebugPlugin` always overwrites `Visibility` component of the entity with `Collider`. This is sometimes undesirable, as I want to have entities whose visibilty is part of the game logic. 

## Solution

This PR allows the debug renderer to instead not overwrite the visibilty when configured to do so. The PR also changes the default value to not overwrite, as it always forced colliders to be visibile before.

## Alternatives

An `Option<Visibility>` could be used instead of an enum, but I hope this version is more readable. We could also just not change visibility if `hide_meshes` is set to `false`, but this would unexpectedly affect visibility if this is toggled.

---

## Changelog

> This section is optional. If this was a trivial fix, or has no externally-visible impact, you can delete this section.

- What changed as a result of this PR?
- If applicable, organize changes under "Added", "Changed", or "Fixed" sub-headings
- Stick to one or two sentences. If more detail is needed for a particular change, consider adding it to the "Solution" section
  - If you can't summarize the work, your change may be unreasonably large / unrelated. Consider splitting your PR to make it easier to review and merge!

## Migration Guide

The `hide_meshes: bool` field of `PhysicsGizmos` (global) and `DebugRender` (entity) has been replaced with `mesh_visibility: MeshVisibility`. The old value `false` should be `MeshVisibility::Overwrite(Visibility::Visible)`, and `true` should be `MeshVisibility::Overwrite(Visibility::Hidden)`.

The debug renderer no longer forces entities with `Collider` to be visible by default To restore old behavior, we have to set the `mesh_visibility` field to one of the variants described above.
