### PR TITLE
Fix collider scale propagation issues

### DIFF
--- a/src/collision/collider/hierarchy.rs
+++ b/src/collision/collider/hierarchy.rs
@@ -301,9 +301,9 @@ pub(crate) fn propagate_collider_transforms(
 /// # Safety
 ///
 /// - While this function is running, `collider_query` must not have any fetches for `entity`,
-/// nor any of its descendants.
+///   nor any of its descendants.
 /// - The caller must ensure that the hierarchy leading to `entity`
-/// is well-formed and must remain as a tree or a forest. Each entity must have at most one parent.
+///   is well-formed and must remain as a tree or a forest. Each entity must have at most one parent.
 #[allow(clippy::type_complexity)]
 unsafe fn propagate_collider_transforms_recursive(
     transform: ColliderTransform,

--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -1261,13 +1261,14 @@ fn scale_shape(
     scale: Vector,
     num_subdivisions: u32,
 ) -> Result<SharedShape, UnsupportedShape> {
+    let scale = scale.abs();
     match shape.as_typed_shape() {
-        TypedShape::Cuboid(s) => Ok(SharedShape::new(s.scaled(&scale.into()))),
+        TypedShape::Cuboid(s) => Ok(SharedShape::new(s.scaled(&scale.abs().into()))),
         TypedShape::RoundCuboid(s) => Ok(SharedShape::new(RoundShape {
             border_radius: s.border_radius,
-            inner_shape: s.inner_shape.scaled(&scale.into()),
+            inner_shape: s.inner_shape.scaled(&scale.abs().into()),
         })),
-        TypedShape::Capsule(c) => match c.scaled(&scale.into(), num_subdivisions) {
+        TypedShape::Capsule(c) => match c.scaled(&scale.abs().into(), num_subdivisions) {
             None => {
                 log::error!("Failed to apply scale {} to Capsule shape.", scale);
                 Ok(SharedShape::ball(0.0))
@@ -1279,16 +1280,16 @@ fn scale_shape(
             #[cfg(feature = "2d")]
             {
                 if scale.x == scale.y {
-                    Ok(SharedShape::ball(b.radius * scale.x))
+                    Ok(SharedShape::ball(b.radius * scale.x.abs()))
                 } else {
                     // A 2D circle becomes an ellipse when scaled non-uniformly.
                     Ok(SharedShape::new(EllipseWrapper(Ellipse {
-                        half_size: Vec2::splat(b.radius as f32) * scale.f32(),
+                        half_size: Vec2::splat(b.radius as f32) * scale.f32().abs(),
                     })))
                 }
             }
             #[cfg(feature = "3d")]
-            match b.scaled(&scale.into(), num_subdivisions) {
+            match b.scaled(&scale.abs().into(), num_subdivisions) {
                 None => {
                     log::error!("Failed to apply scale {} to Ball shape.", scale);
                     Ok(SharedShape::ball(0.0))
@@ -1360,7 +1361,7 @@ fn scale_shape(
             }
         }
         #[cfg(feature = "3d")]
-        TypedShape::Cylinder(c) => match c.scaled(&scale.into(), num_subdivisions) {
+        TypedShape::Cylinder(c) => match c.scaled(&scale.abs().into(), num_subdivisions) {
             None => {
                 log::error!("Failed to apply scale {} to Cylinder shape.", scale);
                 Ok(SharedShape::ball(0.0))
@@ -1370,7 +1371,7 @@ fn scale_shape(
         },
         #[cfg(feature = "3d")]
         TypedShape::RoundCylinder(c) => {
-            match c.inner_shape.scaled(&scale.into(), num_subdivisions) {
+            match c.inner_shape.scaled(&scale.abs().into(), num_subdivisions) {
                 None => {
                     log::error!("Failed to apply scale {} to RoundCylinder shape.", scale);
                     Ok(SharedShape::ball(0.0))
@@ -1434,7 +1435,7 @@ fn scale_shape(
             if _id == 1 {
                 if let Some(ellipse) = shape.as_shape::<EllipseWrapper>() {
                     return Ok(SharedShape::new(EllipseWrapper(Ellipse {
-                        half_size: ellipse.half_size * scale.f32(),
+                        half_size: ellipse.half_size * scale.f32().abs(),
                     })));
                 }
             } else if _id == 2 {
@@ -1442,7 +1443,7 @@ fn scale_shape(
                     if scale.x == scale.y {
                         return Ok(SharedShape::new(RegularPolygonWrapper(
                             RegularPolygon::new(
-                                polygon.circumradius() * scale.x as f32,
+                                polygon.circumradius() * scale.x.abs() as f32,
                                 polygon.sides,
                             ),
                         )));

--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -617,7 +617,7 @@ impl Collider {
     /// - `ray_direction`: What direction the ray is cast in.
     /// - `max_time_of_impact`: The maximum distance that the ray can travel.
     /// - `solid`: If true and the ray origin is inside of a collider, the hit point will be the ray origin itself.
-    /// Otherwise, the collider will be treated as hollow, and the hit point will be at the collider's boundary.
+    ///   Otherwise, the collider will be treated as hollow, and the hit point will be at the collider's boundary.
     pub fn cast_ray(
         &self,
         translation: impl Into<Position>,

--- a/src/collision/mod.rs
+++ b/src/collision/mod.rs
@@ -66,7 +66,7 @@ pub type PackedFeatureId = parry::shape::PackedFeatureId;
 /// - [`iter`](Self::iter) and [`iter_mut`](Self::iter_mut)
 /// - [`contains`](Self::contains)
 /// - [`collisions_with_entity`](Self::collisions_with_entity) and
-/// [`collisions_with_entity_mut`](Self::collisions_with_entity_mut)
+///   [`collisions_with_entity_mut`](Self::collisions_with_entity_mut)
 ///
 /// The collisions can be accessed at any time, but modifications to contacts should be performed
 /// in the [`PostProcessCollisions`] schedule. Otherwise, the physics solver will use the old contact data.

--- a/src/dynamics/rigid_body/forces.rs
+++ b/src/dynamics/rigid_body/forces.rs
@@ -9,10 +9,12 @@ pub(crate) type Torque = Scalar;
 #[cfg(feature = "3d")]
 pub(crate) type Torque = Vector;
 
+#[cfg(feature = "2d")]
 pub(crate) trait FloatZero {
     const ZERO: Self;
 }
 
+#[cfg(feature = "2d")]
 impl FloatZero for Scalar {
     const ZERO: Self = 0.0;
 }

--- a/src/dynamics/solver/xpbd/mod.rs
+++ b/src/dynamics/solver/xpbd/mod.rs
@@ -238,7 +238,7 @@ pub trait XpbdConstraint<const ENTITY_COUNT: usize>: MapEntities {
     /// There are two main steps to solving a constraint:
     ///
     /// 1. Compute the generalized inverse masses, [gradients](self#constraint-gradients)
-    /// and the [Lagrange multiplier](self#lagrange-multipliers) update.
+    ///    and the [Lagrange multiplier](self#lagrange-multipliers) update.
     /// 2. Apply corrections along the gradients using the Lagrange multiplier update.
     ///
     /// [`XpbdConstraint`] provides the [`compute_lagrange_update`](XpbdConstraint::compute_lagrange_update)

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -57,7 +57,7 @@ impl Default for PreparePlugin {
 /// 4. `PropagateTransforms`: Responsible for propagating transforms.
 /// 5. `InitMassProperties`: Responsible for initializing missing mass properties for [`RigidBody`] components.
 /// 6. `InitTransforms`: Responsible for initializing [`Transform`] based on [`Position`] and [`Rotation`]
-/// or vice versa.
+///    or vice versa.
 /// 7. `Finalize`: Responsible for performing final updates after everything is initialized.
 #[derive(SystemSet, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum PrepareSet {

--- a/src/schedule/mod.rs
+++ b/src/schedule/mod.rs
@@ -25,11 +25,11 @@ use bevy::{
 /// This plugin initializes and configures the following schedules and system sets:
 ///
 /// - [`PhysicsSet`]: High-level system sets for the main phases of the physics engine.
-/// You can use these to schedule your own systems before or after physics is run without
-/// having to worry about implementation details.
+///   You can use these to schedule your own systems before or after physics is run without
+///   having to worry about implementation details.
 /// - [`PhysicsSchedule`]: Responsible for advancing the simulation in [`PhysicsSet::StepSimulation`].
 /// - [`PhysicsStepSet`]: System sets for the steps of the actual physics simulation loop, like
-/// the broad phase and the substepping loop.
+///   the broad phase and the substepping loop.
 /// - [`SubstepSchedule`]: Responsible for running the substepping loop in [`SolverSet::Substep`].
 pub struct PhysicsSchedulePlugin {
     schedule: Interned<dyn ScheduleLabel>,
@@ -191,10 +191,10 @@ pub struct PostProcessCollisions;
 /// having to worry about implementation details.
 ///
 /// 1. `Prepare`: Responsible for initializing [rigid bodies](RigidBody) and [colliders](Collider) and
-/// updating several components.
+///    updating several components.
 /// 2. `StepSimulation`: Responsible for advancing the simulation by running the steps in [`PhysicsStepSet`].
 /// 3. `Sync`: Responsible for synchronizing physics components with other data, like keeping [`Position`]
-/// and [`Rotation`] in sync with `Transform`.
+///    and [`Rotation`] in sync with `Transform`.
 ///
 /// ## See also
 ///

--- a/src/spatial_query/mod.rs
+++ b/src/spatial_query/mod.rs
@@ -27,11 +27,11 @@
 //! There are two ways to perform raycasts.
 //!
 //! 1. For simple raycasts, use the [`RayCaster`] component. It returns the results of the raycast
-//! in the [`RayHits`] component every frame. It uses local coordinates, so it will automatically follow the entity
-//! it's attached to or its parent.
+//!    in the [`RayHits`] component every frame. It uses local coordinates, so it will automatically follow the entity
+//!    it's attached to or its parent.
 //! 2. When you need more control or don't want to cast every frame, use the raycasting methods provided by
-//! [`SpatialQuery`], like [`cast_ray`](SpatialQuery::cast_ray), [`ray_hits`](SpatialQuery::ray_hits) or
-//! [`ray_hits_callback`](SpatialQuery::ray_hits_callback).
+//!    [`SpatialQuery`], like [`cast_ray`](SpatialQuery::cast_ray), [`ray_hits`](SpatialQuery::ray_hits) or
+//!    [`ray_hits_callback`](SpatialQuery::ray_hits_callback).
 //!
 //! See the documentation of the components and methods for more information.
 //!
@@ -83,11 +83,11 @@
 //! There are two ways to perform shapecasts.
 //!
 //! 1. For simple shapecasts, use the [`ShapeCaster`] component. It returns the results of the shapecast
-//! in the [`ShapeHits`] component every frame. It uses local coordinates, so it will automatically follow the entity
-//! it's attached to or its parent.
+//!    in the [`ShapeHits`] component every frame. It uses local coordinates, so it will automatically follow the entity
+//!    it's attached to or its parent.
 //! 2. When you need more control or don't want to cast every frame, use the shapecasting methods provided by
-//! [`SpatialQuery`], like [`cast_shape`](SpatialQuery::cast_shape), [`shape_hits`](SpatialQuery::shape_hits) or
-//! [`shape_hits_callback`](SpatialQuery::shape_hits_callback).
+//!    [`SpatialQuery`], like [`cast_shape`](SpatialQuery::cast_shape), [`shape_hits`](SpatialQuery::shape_hits) or
+//!    [`shape_hits_callback`](SpatialQuery::shape_hits_callback).
 //!
 //! See the documentation of the components and methods for more information.
 //!
@@ -142,11 +142,11 @@
 //! and they all have callback variants that call a given callback on each intersection.
 //!
 //! - [`point_intersections`](SpatialQuery::point_intersections): Finds all entities with a collider that contains
-//! the given point.
+//!   the given point.
 //! - [`aabb_intersections_with_aabb`](SpatialQuery::aabb_intersections_with_aabb):
-//! Finds all entities with a [`ColliderAabb`] that is intersecting the given [`ColliderAabb`].
+//!   Finds all entities with a [`ColliderAabb`] that is intersecting the given [`ColliderAabb`].
 //! - [`shape_intersections`](SpatialQuery::shape_intersections): Finds all entities with a [collider](Collider)
-//! that is intersecting the given shape.
+//!   that is intersecting the given shape.
 //!
 //! See the documentation of the components and methods for more information.
 //!

--- a/src/spatial_query/pipeline.rs
+++ b/src/spatial_query/pipeline.rs
@@ -157,7 +157,7 @@ impl SpatialQueryPipeline {
     /// - `direction`: What direction the ray is cast in.
     /// - `max_time_of_impact`: The maximum distance that the ray can travel.
     /// - `solid`: If true and the ray origin is inside of a collider, the hit point will be the ray origin itself.
-    /// Otherwise, the collider will be treated as hollow, and the hit point will be at the collider's boundary.
+    ///   Otherwise, the collider will be treated as hollow, and the hit point will be at the collider's boundary.
     /// - `query_filter`: A [`SpatialQueryFilter`] that determines which colliders are taken into account in the query.
     ///
     /// See also: [`SpatialQuery::cast_ray`]
@@ -196,10 +196,10 @@ impl SpatialQueryPipeline {
     /// - `direction`: What direction the ray is cast in.
     /// - `max_time_of_impact`: The maximum distance that the ray can travel.
     /// - `solid`: If true and the ray origin is inside of a collider, the hit point will be the ray origin itself.
-    /// Otherwise, the collider will be treated as hollow, and the hit point will be at the collider's boundary.
+    ///   Otherwise, the collider will be treated as hollow, and the hit point will be at the collider's boundary.
     /// - `query_filter`: A [`SpatialQueryFilter`] that determines which colliders are taken into account in the query.
     /// - `predicate`: A function with which the colliders are filtered. Given the Entity it should return false, if the
-    /// entity should be ignored.
+    ///   entity should be ignored.
     ///
     /// See also: [`SpatialQuery::cast_ray`]
     pub fn cast_ray_predicate(
@@ -241,7 +241,7 @@ impl SpatialQueryPipeline {
     /// - `max_time_of_impact`: The maximum distance that the ray can travel.
     /// - `max_hits`: The maximum number of hits. Additional hits will be missed.
     /// - `solid`: If true and the ray origin is inside of a collider, the hit point will be the ray origin itself.
-    /// Otherwise, the collider will be treated as hollow, and the hit point will be at the collider's boundary.
+    ///   Otherwise, the collider will be treated as hollow, and the hit point will be at the collider's boundary.
     /// - `query_filter`: A [`SpatialQueryFilter`] that determines which colliders are taken into account in the query.
     ///
     /// See also: [`SpatialQuery::ray_hits`]
@@ -280,7 +280,7 @@ impl SpatialQueryPipeline {
     /// - `direction`: What direction the ray is cast in.
     /// - `max_time_of_impact`: The maximum distance that the ray can travel.
     /// - `solid`: If true and the ray origin is inside of a collider, the hit point will be the ray origin itself.
-    /// Otherwise, the collider will be treated as hollow, and the hit point will be at the collider's boundary.
+    ///   Otherwise, the collider will be treated as hollow, and the hit point will be at the collider's boundary.
     /// - `query_filter`: A [`SpatialQueryFilter`] that determines which colliders are taken into account in the query.
     /// - `callback`: A callback function called for each hit.
     ///
@@ -339,8 +339,8 @@ impl SpatialQueryPipeline {
     /// - `direction`: What direction the shape is cast in.
     /// - `max_time_of_impact`: The maximum distance that the shape can travel.
     /// - `ignore_origin_penetration`: If true and the shape is already penetrating a collider at the
-    /// shape origin, the hit will be ignored and only the next hit will be computed. Otherwise, the initial
-    /// hit will be returned.
+    ///   shape origin, the hit will be ignored and only the next hit will be computed. Otherwise, the initial
+    ///   hit will be returned.
     /// - `query_filter`: A [`SpatialQueryFilter`] that determines which colliders are taken into account in the query.
     ///
     /// See also: [`SpatialQuery::cast_shape`]
@@ -405,8 +405,8 @@ impl SpatialQueryPipeline {
     /// - `max_time_of_impact`: The maximum distance that the shape can travel.
     /// - `max_hits`: The maximum number of hits. Additional hits will be missed.
     /// - `ignore_origin_penetration`: If true and the shape is already penetrating a collider at the
-    /// shape origin, the hit will be ignored and only the next hit will be computed. Otherwise, the initial
-    /// hit will be returned.
+    ///   shape origin, the hit will be ignored and only the next hit will be computed. Otherwise, the initial
+    ///   hit will be returned.
     /// - `query_filter`: A [`SpatialQueryFilter`] that determines which colliders are taken into account in the query.
     /// - `callback`: A callback function called for each hit.
     ///
@@ -452,8 +452,8 @@ impl SpatialQueryPipeline {
     /// - `direction`: What direction the shape is cast in.
     /// - `max_time_of_impact`: The maximum distance that the shape can travel.
     /// - `ignore_origin_penetration`: If true and the shape is already penetrating a collider at the
-    /// shape origin, the hit will be ignored and only the next hit will be computed. Otherwise, the initial
-    /// hit will be returned.
+    ///   shape origin, the hit will be ignored and only the next hit will be computed. Otherwise, the initial
+    ///   hit will be returned.
     /// - `query_filter`: A [`SpatialQueryFilter`] that determines which colliders are taken into account in the query.
     /// - `callback`: A callback function called for each hit.
     ///
@@ -528,7 +528,7 @@ impl SpatialQueryPipeline {
     ///
     /// - `point`: The point that should be projected.
     /// - `solid`: If true and the point is inside of a collider, the projection will be at the point.
-    /// Otherwise, the collider will be treated as hollow, and the projection will be at the collider's boundary.
+    ///   Otherwise, the collider will be treated as hollow, and the projection will be at the collider's boundary.
     /// - `query_filter`: A [`SpatialQueryFilter`] that determines which colliders are taken into account in the query.
     ///
     /// See also: [`SpatialQuery::project_point`]

--- a/src/spatial_query/system_param.rs
+++ b/src/spatial_query/system_param.rs
@@ -6,17 +6,17 @@ use bevy::{ecs::system::SystemParam, prelude::*};
 /// ## Methods
 ///
 /// - [Raycasting](spatial_query#raycasting): [`cast_ray`](SpatialQuery::cast_ray),
-/// [`ray_hits`](SpatialQuery::ray_hits), [`ray_hits_callback`](SpatialQuery::ray_hits_callback)
+///   [`ray_hits`](SpatialQuery::ray_hits), [`ray_hits_callback`](SpatialQuery::ray_hits_callback)
 /// - [Shapecasting](spatial_query#shapecasting): [`cast_shape`](SpatialQuery::cast_shape),
-/// [`shape_hits`](SpatialQuery::shape_hits), [`shape_hits_callback`](SpatialQuery::shape_hits_callback)
+///   [`shape_hits`](SpatialQuery::shape_hits), [`shape_hits_callback`](SpatialQuery::shape_hits_callback)
 /// - [Point projection](spatial_query#point-projection): [`project_point`](SpatialQuery::project_point)
 /// - [Intersection tests](spatial_query#intersection-tests)
 ///     - Point intersections: [`point_intersections`](SpatialQuery::point_intersections),
-/// [`point_intersections_callback`](SpatialQuery::point_intersections_callback)
+///       [`point_intersections_callback`](SpatialQuery::point_intersections_callback)
 ///     - AABB intersections: [`aabb_intersections_with_aabb`](SpatialQuery::aabb_intersections_with_aabb),
-/// [`aabb_intersections_with_aabb_callback`](SpatialQuery::aabb_intersections_with_aabb_callback)
+///       [`aabb_intersections_with_aabb_callback`](SpatialQuery::aabb_intersections_with_aabb_callback)
 ///     - Shape intersections: [`shape_intersections`](SpatialQuery::shape_intersections)
-/// [`shape_intersections_callback`](SpatialQuery::shape_intersections_callback)
+///       [`shape_intersections_callback`](SpatialQuery::shape_intersections_callback)
 ///
 /// For simple raycasts and shapecasts, consider using the [`RayCaster`] and [`ShapeCaster`] components that
 /// provide a more ECS-based approach and perform casts on every frame.
@@ -95,7 +95,7 @@ impl<'w, 's> SpatialQuery<'w, 's> {
     /// - `direction`: What direction the ray is cast in.
     /// - `max_time_of_impact`: The maximum distance that the ray can travel.
     /// - `solid`: If true and the ray origin is inside of a collider, the hit point will be the ray origin itself.
-    /// Otherwise, the collider will be treated as hollow, and the hit point will be at the collider's boundary.
+    ///   Otherwise, the collider will be treated as hollow, and the hit point will be at the collider's boundary.
     /// - `query_filter`: A [`SpatialQueryFilter`] that determines which colliders are taken into account in the query.
     ///
     /// ## Example
@@ -142,10 +142,10 @@ impl<'w, 's> SpatialQuery<'w, 's> {
     /// - `direction`: What direction the ray is cast in.
     /// - `max_time_of_impact`: The maximum distance that the ray can travel.
     /// - `solid`: If true and the ray origin is inside of a collider, the hit point will be the ray origin itself.
-    /// Otherwise, the collider will be treated as hollow, and the hit point will be at the collider's boundary.
+    ///   Otherwise, the collider will be treated as hollow, and the hit point will be at the collider's boundary.
     /// - `query_filter`: A [`SpatialQueryFilter`] that determines which colliders are taken into account in the query.
     /// - `predicate`: A function with which the colliders are filtered. Given the Entity it should return false, if the
-    /// entity should be ignored.
+    ///   entity should be ignored.
     ///
     /// ## Example
     ///
@@ -208,7 +208,7 @@ impl<'w, 's> SpatialQuery<'w, 's> {
     /// - `max_time_of_impact`: The maximum distance that the ray can travel.
     /// - `max_hits`: The maximum number of hits. Additional hits will be missed.
     /// - `solid`: If true and the ray origin is inside of a collider, the hit point will be the ray origin itself.
-    /// Otherwise, the collider will be treated as hollow, and the hit point will be at the collider's boundary.
+    ///   Otherwise, the collider will be treated as hollow, and the hit point will be at the collider's boundary.
     /// - `query_filter`: A [`SpatialQueryFilter`] that determines which colliders are taken into account in the query.
     ///
     /// ## Example
@@ -268,7 +268,7 @@ impl<'w, 's> SpatialQuery<'w, 's> {
     /// - `direction`: What direction the ray is cast in.
     /// - `max_time_of_impact`: The maximum distance that the ray can travel.
     /// - `solid`: If true and the ray origin is inside of a collider, the hit point will be the ray origin itself.
-    /// Otherwise, the collider will be treated as hollow, and the hit point will be at the collider's boundary.
+    ///   Otherwise, the collider will be treated as hollow, and the hit point will be at the collider's boundary.
     /// - `query_filter`: A [`SpatialQueryFilter`] that determines which colliders are taken into account in the query.
     /// - `callback`: A callback function called for each hit.
     ///
@@ -336,8 +336,8 @@ impl<'w, 's> SpatialQuery<'w, 's> {
     /// - `direction`: What direction the shape is cast in.
     /// - `max_time_of_impact`: The maximum distance that the shape can travel.
     /// - `ignore_origin_penetration`: If true and the shape is already penetrating a collider at the
-    /// shape origin, the hit will be ignored and only the next hit will be computed. Otherwise, the initial
-    /// hit will be returned.
+    ///   shape origin, the hit will be ignored and only the next hit will be computed. Otherwise, the initial
+    ///   hit will be returned.
     /// - `query_filter`: A [`SpatialQueryFilter`] that determines which colliders are taken into account in the query.
     ///
     /// ## Example
@@ -399,8 +399,8 @@ impl<'w, 's> SpatialQuery<'w, 's> {
     /// - `max_time_of_impact`: The maximum distance that the shape can travel.
     /// - `max_hits`: The maximum number of hits. Additional hits will be missed.
     /// - `ignore_origin_penetration`: If true and the shape is already penetrating a collider at the
-    /// shape origin, the hit will be ignored and only the next hit will be computed. Otherwise, the initial
-    /// hit will be returned.
+    ///   shape origin, the hit will be ignored and only the next hit will be computed. Otherwise, the initial
+    ///   hit will be returned.
     /// - `query_filter`: A [`SpatialQueryFilter`] that determines which colliders are taken into account in the query.
     /// - `callback`: A callback function called for each hit.
     ///
@@ -469,8 +469,8 @@ impl<'w, 's> SpatialQuery<'w, 's> {
     /// - `direction`: What direction the shape is cast in.
     /// - `max_time_of_impact`: The maximum distance that the shape can travel.
     /// - `ignore_origin_penetration`: If true and the shape is already penetrating a collider at the
-    /// shape origin, the hit will be ignored and only the next hit will be computed. Otherwise, the initial
-    /// hit will be returned.
+    ///   shape origin, the hit will be ignored and only the next hit will be computed. Otherwise, the initial
+    ///   hit will be returned.
     /// - `query_filter`: A [`SpatialQueryFilter`] that determines which colliders are taken into account in the query.
     /// - `callback`: A callback function called for each hit.
     ///
@@ -539,7 +539,7 @@ impl<'w, 's> SpatialQuery<'w, 's> {
     ///
     /// - `point`: The point that should be projected.
     /// - `solid`: If true and the point is inside of a collider, the projection will be at the point.
-    /// Otherwise, the collider will be treated as hollow, and the projection will be at the collider's boundary.
+    ///   Otherwise, the collider will be treated as hollow, and the projection will be at the collider's boundary.
     /// - `query_filter`: A [`SpatialQueryFilter`] that determines which colliders are taken into account in the query.
     ///
     /// ## Example

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -558,9 +558,9 @@ pub fn propagate_transforms_physics(
 /// # Safety
 ///
 /// - While this function is running, `transform_query` must not have any fetches for `entity`,
-/// nor any of its descendants.
+///   nor any of its descendants.
 /// - The caller must ensure that the hierarchy leading to `entity`
-/// is well-formed and must remain as a tree or a forest. Each entity must have at most one parent.
+///   is well-formed and must remain as a tree or a forest. Each entity must have at most one parent.
 #[allow(clippy::type_complexity)]
 unsafe fn propagate_transforms_physics_recursive(
     parent: &GlobalTransform,


### PR DESCRIPTION
# Objective

Fixes #287 and part of #471.

Scale is currently not propagated correctly for colliders if the rigid body is not the root entity. Additionally, negative scale is prohibited for child colliders: scale is clamped to be greater than zero.

## Solution

Fix scale propagation and allow negative scale.

Note that mirroring is *not* handled properly for child colliders and some shapes yet. That will be fixed later.