### PR TITLE
Use hooks for component initialization

### DIFF
--- a/src/collision/collider/hierarchy.rs
+++ b/src/collision/collider/hierarchy.rs
@@ -58,17 +58,13 @@ impl Plugin for ColliderHierarchyPlugin {
 
         app.configure_sets(
             self.schedule,
-            MarkColliderAncestors
-                .after(PrepareSet::InitColliders)
-                .before(PrepareSet::PropagateTransforms),
+            MarkColliderAncestors.before(PrepareSet::PropagateTransforms),
         );
 
         // Update collider parents.
         app.add_systems(
             self.schedule,
-            update_collider_parents
-                .after(PrepareSet::InitColliders)
-                .before(PrepareSet::Finalize),
+            update_collider_parents.before(PrepareSet::Finalize),
         );
 
         // Run transform propagation if new colliders without rigid bodies have been added.

--- a/src/collision/collider/hierarchy.rs
+++ b/src/collision/collider/hierarchy.rs
@@ -64,7 +64,9 @@ impl Plugin for ColliderHierarchyPlugin {
         // Update collider parents.
         app.add_systems(
             self.schedule,
-            update_collider_parents.before(PrepareSet::Finalize),
+            update_collider_parents
+                .after(PrepareSet::PropagateTransforms)
+                .before(PrepareSet::Finalize),
         );
 
         // Run transform propagation if new colliders without rigid bodies have been added.

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -226,11 +226,11 @@
 //! Finally, making the [physics timestep](Physics) smaller can also help.
 //! However, this comes at the cost of worse performance for the entire simulation.
 
-use crate::{collision::broad_phase::AabbIntersections, prelude::*, prepare::PrepareSet};
+use crate::{collision::broad_phase::AabbIntersections, prelude::*};
 #[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
 use bevy::ecs::query::QueryData;
 use bevy::{
-    ecs::{intern::Interned, schedule::ScheduleLabel},
+    ecs::component::{ComponentHooks, StorageType},
     prelude::*,
 };
 use derive_more::From;
@@ -240,35 +240,11 @@ use parry::query::{
 };
 
 /// A plugin for [Continuous Collision Detection](self).
-pub struct CcdPlugin {
-    schedule: Interned<dyn ScheduleLabel>,
-}
-
-impl CcdPlugin {
-    /// Creates a [`CcdPlugin`] with the schedule that is used for running the [`PhysicsSchedule`].
-    ///
-    /// The default schedule is `PostUpdate`.
-    pub fn new(schedule: impl ScheduleLabel) -> Self {
-        Self {
-            schedule: schedule.intern(),
-        }
-    }
-}
-
-impl Default for CcdPlugin {
-    fn default() -> Self {
-        Self::new(PostUpdate)
-    }
-}
+pub struct CcdPlugin;
 
 impl Plugin for CcdPlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<SweptCcd>().register_type::<SweepMode>();
-
-        app.add_systems(
-            self.schedule,
-            init_ccd_aabb_intersections.in_set(PrepareSet::InitColliders),
-        );
 
         // Get the `PhysicsSchedule`, and panic if it doesn't exist.
         let physics = app
@@ -397,7 +373,7 @@ impl SpeculativeMargin {
 ///     ));
 /// }
 /// ```
-#[derive(Component, Clone, Copy, Debug, PartialEq, Reflect)]
+#[derive(Clone, Copy, Debug, PartialEq, Reflect)]
 #[reflect(Component)]
 pub struct SweptCcd {
     /// The type of sweep used for swept CCD.
@@ -481,6 +457,19 @@ impl SweptCcd {
     }
 }
 
+impl Component for SweptCcd {
+    const STORAGE_TYPE: StorageType = StorageType::Table;
+
+    fn register_component_hooks(hooks: &mut ComponentHooks) {
+        hooks.on_add(|mut world, entity, _| {
+            world
+                .commands()
+                .entity(entity)
+                .insert(AabbIntersections::default());
+        });
+    }
+}
+
 /// The algorithm used for [Swept Continuous Collision Detection](self#swept-ccd).
 ///
 /// If two entities with different sweep modes collide, [`SweepMode::NonLinear`]
@@ -508,12 +497,6 @@ pub enum SweepMode {
     /// consider using [`SweepMode::Linear`].
     #[default]
     NonLinear,
-}
-
-fn init_ccd_aabb_intersections(mut commands: Commands, query: Query<Entity, Added<SweptCcd>>) {
-    for entity in &query {
-        commands.entity(entity).insert(AabbIntersections::default());
-    }
 }
 
 #[cfg(any(feature = "parry-f32", feature = "parry-f64"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -735,9 +735,9 @@ impl PluginGroup for PhysicsPlugins {
             .add(ContactReportingPlugin)
             .add(IntegratorPlugin::default())
             .add(SolverPlugin::new_with_length_unit(self.length_unit))
-            .add(CcdPlugin::new(self.schedule))
+            .add(CcdPlugin)
             .add(SleepingPlugin)
-            .add(SpatialQueryPlugin::new(self.schedule))
+            .add(SpatialQueryPlugin)
             .add(SyncPlugin::new(self.schedule))
     }
 }

--- a/src/spatial_query/mod.rs
+++ b/src/spatial_query/mod.rs
@@ -170,35 +170,13 @@ pub use shape_caster::*;
 #[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
 pub use system_param::*;
 
-use crate::{prelude::*, prepare::PrepareSet};
-use bevy::{
-    ecs::{intern::Interned, schedule::ScheduleLabel},
-    prelude::*,
-};
+use crate::prelude::*;
+use bevy::prelude::*;
 
 /// Initializes the [`SpatialQueryPipeline`] resource and handles component-based [spatial queries](spatial_query)
 /// like [raycasting](spatial_query#raycasting) and [shapecasting](spatial_query#shapecasting) with
 /// [`RayCaster`] and [`ShapeCaster`].
-pub struct SpatialQueryPlugin {
-    schedule: Interned<dyn ScheduleLabel>,
-}
-
-impl SpatialQueryPlugin {
-    /// Creates a [`SpatialQueryPlugin`] with the schedule that is used for running the [`PhysicsSchedule`].
-    ///
-    /// The default schedule is `PostUpdate`.
-    pub fn new(schedule: impl ScheduleLabel) -> Self {
-        Self {
-            schedule: schedule.intern(),
-        }
-    }
-}
-
-impl Default for SpatialQueryPlugin {
-    fn default() -> Self {
-        Self::new(PostUpdate)
-    }
-}
+pub struct SpatialQueryPlugin;
 
 impl Plugin for SpatialQueryPlugin {
     fn build(&self, app: &mut App) {
@@ -207,14 +185,6 @@ impl Plugin for SpatialQueryPlugin {
             any(feature = "parry-f32", feature = "parry-f64")
         ))]
         app.init_resource::<SpatialQueryPipeline>();
-
-        app.add_systems(self.schedule, init_ray_hits.in_set(PrepareSet::PreInit));
-
-        #[cfg(all(
-            feature = "default-collider",
-            any(feature = "parry-f32", feature = "parry-f64")
-        ))]
-        app.add_systems(self.schedule, init_shape_hits.in_set(PrepareSet::PreInit));
 
         let physics_schedule = app
             .get_schedule_mut(PhysicsSchedule)
@@ -238,33 +208,6 @@ impl Plugin for SpatialQueryPlugin {
                 .chain()
                 .in_set(PhysicsStepSet::SpatialQuery),
         );
-    }
-}
-
-fn init_ray_hits(mut commands: Commands, rays: Query<(Entity, &RayCaster), Added<RayCaster>>) {
-    for (entity, ray) in &rays {
-        let max_hits = if ray.max_hits == u32::MAX {
-            10
-        } else {
-            ray.max_hits as usize
-        };
-        commands.entity(entity).try_insert(RayHits {
-            vector: Vec::with_capacity(max_hits),
-            count: 0,
-        });
-    }
-}
-
-#[cfg(any(feature = "parry-f32", feature = "parry-f64"))]
-fn init_shape_hits(
-    mut commands: Commands,
-    shape_casters: Query<(Entity, &ShapeCaster), Added<ShapeCaster>>,
-) {
-    for (entity, shape_caster) in &shape_casters {
-        commands.entity(entity).try_insert(ShapeHits {
-            vector: Vec::with_capacity(shape_caster.max_hits.min(100_000) as usize),
-            count: 0,
-        });
     }
 }
 

--- a/src/spatial_query/shape_caster.rs
+++ b/src/spatial_query/shape_caster.rs
@@ -1,6 +1,9 @@
 use crate::prelude::*;
 use bevy::{
-    ecs::entity::{EntityMapper, MapEntities},
+    ecs::{
+        component::{ComponentHooks, StorageType},
+        entity::{EntityMapper, MapEntities},
+    },
     prelude::*,
 };
 use parry::query::{details::TOICompositeShapeShapeBestFirstVisitor, ShapeCastOptions};
@@ -50,7 +53,7 @@ use parry::query::{details::TOICompositeShapeShapeBestFirstVisitor, ShapeCastOpt
 ///     }
 /// }
 /// ```
-#[derive(Component, Clone, Debug, Reflect)]
+#[derive(Clone, Debug, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, Component)]
@@ -339,6 +342,26 @@ impl ShapeCaster {
                 return;
             }
         }
+    }
+}
+
+impl Component for ShapeCaster {
+    const STORAGE_TYPE: StorageType = StorageType::Table;
+
+    fn register_component_hooks(hooks: &mut ComponentHooks) {
+        hooks.on_add(|mut world, entity, _| {
+            let shape_caster = world.get::<ShapeCaster>(entity).unwrap();
+            let max_hits = if shape_caster.max_hits == u32::MAX {
+                10
+            } else {
+                shape_caster.max_hits as usize
+            };
+
+            world.commands().entity(entity).try_insert(ShapeHits {
+                vector: Vec::with_capacity(max_hits),
+                count: 0,
+            });
+        });
     }
 }
 

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -85,7 +85,7 @@ impl Plugin for SyncPlugin {
 
         app.configure_sets(
             self.schedule,
-            MarkRigidBodyAncestors.in_set(PrepareSet::PreInit),
+            MarkRigidBodyAncestors.in_set(PrepareSet::First),
         );
 
         // Initialize `PreviousGlobalTransform` and apply `Transform` changes that happened


### PR DESCRIPTION
# Objective

Fixes #475.

Missing components for rigid bodies, colliders, etc. are currently added at specific points in the physics shedule. This means that the world is momentarily in an invalid state before those systems are run, which can even lead to confusing crashes when using methods like `query.single()` for queries that expect those components to exist.

## Solution

Use component hooks for initializing missing components with minimal delay. This also meaningfully simplifies scheduling.

When Bevy gets required components (Soon™), those could be used instead.

### Performance

Using hooks appears to be as fast if not *faster* than the old initialization systems.

---

## Migration Guide

`PrepareSet::PreInit` has been renamed to `PrepareSet::First`, and `PrepareSet::InitRigidBodies`, `PrepareSet::InitColliders`, and `PrepareSet::InitMassProperties` have been removed. Most missing components are now initialized by component lifecycle hooks.

`CcdPlugin` and `SpatialQueryPipeline` no longer store a schedule and are now unit structs. Instead of `SpatialQueryPlugin::new(my_schedule)` or `SpatialQueryPlugin::default()`, just use `SpatialQueryPlugin`.