### PR TITLE
Fix angular locked axes in gyroscopic torque computation

### DIFF
--- a/src/dynamics/integrator/semi_implicit_euler.rs
+++ b/src/dynamics/integrator/semi_implicit_euler.rs
@@ -77,7 +77,7 @@ pub fn integrate_velocity(
         // However, the basic semi-implicit approach can blow up, as semi-implicit Euler
         // extrapolates velocity and the gyroscopic torque is quadratic in the angular velocity.
         // Thus, we use implicit Euler, which is much more accurate and stable, although slightly more expensive.
-        let effective_inertia = locked_axes.apply_to_rotation(inv_inertia.inverse().0);
+        let effective_inertia = locked_axes.apply_to_rotation(inv_inertia.0).inverse();
         delta_ang_vel += solve_gyroscopic_torque(
             *ang_vel,
             rotation.0,


### PR DESCRIPTION
# Objective

Fixes #474.

The angular locked axes are applied to the inertia instead of the inverse inertia in gyroscopic torque computations introduced in #420, causing incorrect behavior.

## Solution

Apply the locked axes correctly.