### PR TITLE
Add collide and slide kinematic controller

### DIFF
--- a/crates/avian3d/examples/kinematic_character_cas_3d/plugin.rs
+++ b/crates/avian3d/examples/kinematic_character_cas_3d/plugin.rs
@@ -485,7 +485,7 @@ pub fn snap_to_floor(
             // Get our distance based on travel time
             let distance = cast_result.time_of_impact - SKIN_WIDTH;
             // Move us down
-            transform.translation.y -= distance - SKIN_WIDTH;
+            transform.translation.y -= distance;
         }
     }
 }

--- a/crates/avian3d/examples/kinematic_character_cas_3d/plugin.rs
+++ b/crates/avian3d/examples/kinematic_character_cas_3d/plugin.rs
@@ -397,21 +397,22 @@ fn recursive_collide_and_slide(
         planes.clear();
     }
 
-    // Slope sliding behavior
     let mut should_slope_slide = true; 
+    // We only want to handle this if the controller set a max slope angle
     if let Some(max_slope_angle) = max_slope_angle {
         let angle = cast_result.normal1.angle_between(up_vector);
-        if angle < max_slope_angle.0 {
+        // If the slope isn't very steep and its a floor there's no reason to slide.
+        if angle < max_slope_angle.0 && cast_result.normal1.dot(up_vector) > 0.0 {
             should_slope_slide = false;
         }
     }
 
+    // Eliminate gravity if we're not suppoosed to slide right now.
     let velocity = if !should_slope_slide && velocity.dot(up_vector) < 0.0 {
         velocity - up_vector * velocity.dot(up_vector)
     } else {
         velocity
     };
-
 
     planes.push(cast_result.normal1);
 

--- a/crates/avian3d/examples/kinematic_character_cas_3d/plugin.rs
+++ b/crates/avian3d/examples/kinematic_character_cas_3d/plugin.rs
@@ -22,7 +22,10 @@ impl Plugin for CharacterControllerPlugin {
                 )
                     .chain(),
             )
-            .add_systems(PostProcessCollisions, (snap_to_floor, collide_and_slide).chain());
+            .add_systems(
+                PostProcessCollisions,
+                (snap_to_floor, collide_and_slide).chain(),
+            );
     }
 }
 
@@ -328,7 +331,7 @@ fn collide_and_slide(
             &mut planes,
             Vector::Y,
             grounded,
-            max_slope_angle
+            max_slope_angle,
         );
 
         // Move us to the new position
@@ -397,7 +400,7 @@ fn recursive_collide_and_slide(
         planes.clear();
     }
 
-    let mut should_slope_slide = true; 
+    let mut should_slope_slide = true;
     // We only want to handle this if the controller set a max slope angle
     if let Some(max_slope_angle) = max_slope_angle {
         let angle = cast_result.normal1.angle_between(up_vector);
@@ -453,9 +456,14 @@ fn recursive_collide_and_slide(
         );
 }
 
-
 pub fn snap_to_floor(
-    mut query: Query<(&mut Transform, &Collider, Has<Grounded>, Entity, &CharacterController)>,
+    mut query: Query<(
+        &mut Transform,
+        &Collider,
+        Has<Grounded>,
+        Entity,
+        &CharacterController,
+    )>,
     spatial_query: SpatialQuery,
 ) {
     for (mut transform, collider, grounded, entity, controller) in &mut query {
@@ -477,7 +485,7 @@ pub fn snap_to_floor(
             // Get our distance based on travel time
             let distance = cast_result.time_of_impact - SKIN_WIDTH;
             // Move us down
-            transform.translation.y -= distance;
+            transform.translation.y -= distance - SKIN_WIDTH;
         }
     }
 }


### PR DESCRIPTION
# Objective

- https://github.com/Jondolf/avian/issues/438

## Solution

- Introduce a basic collide and slide implementation for a new Kinematic Character Controller example entitled `kinematic_character_cas_3d`.

---

## Changelog

> **Note**: You can run the new example with `cargo run --example kinematic_character_cas_3d`

### Added
- Introduced a work in progress collide and slide function based on community work in the `Avian Physics` channel of the `Bevy` discord