### PR TITLE
Only warn about 'overlapping at spawn' for dynamic bodies

### DIFF
--- a/src/collision/narrow_phase.rs
+++ b/src/collision/narrow_phase.rs
@@ -699,6 +699,11 @@ fn log_overlap_at_spawn(
             continue;
         };
 
+        // only warn if at least one of the bodies is dynamic
+        if !rb1.is_dynamic() && !rb2.is_dynamic() {
+            continue;
+        }
+
         if rb1.is_added() || rb2.is_added() {
             // If the RigidBody entity has a name, use that for debug.
             let debug_id1 = match name1 {


### PR DESCRIPTION
# Objective

When spawning lots of overlapping static colliders (eg: walls) i see a lot of "X and Y are overlapping at spawn, which can result in explosive behavior".

Explosive behaviour is only a concern for dynamic bodies.


## Solution

Only show the warning if at least one of the bodies is dynamic.

---

## Changelog

- "Overlapping at spawn" warning now only applies if at least one of rigid bodies is dynamic
- 