### PR TITLE
Add predicate variants to all casts

### DIFF
--- a/src/spatial_query/pipeline.rs
+++ b/src/spatial_query/pipeline.rs
@@ -388,7 +388,7 @@ impl SpatialQueryPipeline {
         direction: Dir,
         max_time_of_impact: Scalar,
         ignore_origin_penetration: bool,
-        query_filter: SpatialQueryFilter,
+        query_filter: &SpatialQueryFilter,
         predicate: &dyn Fn(Entity) -> bool,
     ) -> Option<ShapeHitData> {
         let rotation: Rotation;
@@ -599,7 +599,7 @@ impl SpatialQueryPipeline {
         &self,
         point: Vector,
         solid: bool,
-        query_filter: SpatialQueryFilter,
+        query_filter: &SpatialQueryFilter,
         predicate: &dyn Fn(Entity) -> bool,
     ) -> Option<PointProjection> {
         let point = point.into();


### PR DESCRIPTION
# Objective

-  `cast_ray` already has a sister function called `cast_ray_predicate` that returns the first hit that satisfies a predicate. The other casts do not.

## Solution

- Implement them. Note that I set the internal implementations of the non-predicate versions to use the predicate to reduce code duplication. The predicate does not introduce an extra branch since we already have an `if` for the filter in place, so this should be equivalent in performance.

---

## Changelog

> This section is optional. If this was a trivial fix, or has no externally-visible impact, you can delete this section.

- Added
  - `cast_ray` already has a sister function called `cast_ray_predicate` that returns the first hit that satisfies a predicate. Now, the other cast function have a similar analogue:
	  - Added `cast_ray_predicate` for `cast_ray`
	  - Added `project_point_predicate` for `project_point`


