### PR TITLE
Make `PhysicsLayer` require a `#[default]` variant

### DIFF
--- a/crates/avian2d/examples/collision_layers.rs
+++ b/crates/avian2d/examples/collision_layers.rs
@@ -20,8 +20,10 @@ fn main() {
 }
 
 // Define the collision layers
-#[derive(PhysicsLayer)]
+#[derive(PhysicsLayer, Default)]
 enum Layer {
+    #[default]
+    Default,
     Blue,
     Red,
 }

--- a/crates/avian_derive/Cargo.toml
+++ b/crates/avian_derive/Cargo.toml
@@ -14,5 +14,6 @@ bench = false
 
 [dependencies]
 proc-macro2 = "1.0.78"
+proc-macro-error = "1.0"
 quote = "1.0"
 syn = "2.0"

--- a/crates/avian_derive/src/lib.rs
+++ b/crates/avian_derive/src/lib.rs
@@ -24,7 +24,7 @@ use syn::{parse_macro_input, spanned::Spanned, Data, DeriveInput};
 /// # Example
 ///
 /// ```ignore
-/// #[derive(PhysicsLayer, Default)]
+/// #[derive(PhysicsLayer, Clone, Copy, Debug, Default)]
 /// enum GameLayer {
 ///     #[default]
 ///     Default, // Layer 0 - the default layer that objects are assigned to

--- a/crates/avian_derive/src/lib.rs
+++ b/crates/avian_derive/src/lib.rs
@@ -87,6 +87,7 @@ pub fn derive_physics_layer(input: TokenStream) -> TokenStream {
         );
     };
 
+    // Move the default variant to the front (this probably isn't the best way to do this)
     let mut variants = variants.iter().collect::<Vec<_>>();
     let default_variant = variants.remove(default_variant_index);
     variants.insert(0, default_variant);

--- a/src/collision/layers.rs
+++ b/src/collision/layers.rs
@@ -35,7 +35,7 @@ where
 #[cfg_attr(feature = "2d", doc = "# use avian2d::prelude::*;")]
 #[cfg_attr(feature = "3d", doc = "# use avian3d::prelude::*;")]
 /// #
-/// #[derive(PhysicsLayer, Default)]
+/// #[derive(PhysicsLayer, Clone, Copy, Debug, Default)]
 /// enum GameLayer {
 ///     #[default]
 ///     Default, // Layer 0 - the default layer that objects are assigned to
@@ -43,6 +43,12 @@ where
 ///     Enemy,   // Layer 2
 ///     Ground,  // Layer 3
 /// }
+///
+/// // The first bit is reserved for the default layer.
+/// assert_eq!(GameLayer::default().to_bits(), 1 << 0);
+///
+/// // The `GameLayer::Ground` layer is the fourth layer, so its bit value is `1 << 3`.
+/// assert_eq!(GameLayer::Ground.to_bits(), 1 << 3);
 ///
 /// // Here, `GameLayer::Enemy` is automatically converted to a `LayerMask` for the comparison.
 /// assert_eq!(LayerMask(0b00100), GameLayer::Enemy);

--- a/src/collision/layers.rs
+++ b/src/collision/layers.rs
@@ -6,14 +6,17 @@ use bevy::prelude::*;
 /// Physics layers are used heavily by [`CollisionLayers`].
 ///
 /// This trait can be derived for enums with `#[derive(PhysicsLayer)]`.
-pub trait PhysicsLayer: Sized {
+pub trait PhysicsLayer: Sized + Default {
     /// Converts the layer to a bitmask.
     fn to_bits(&self) -> u32;
     /// Creates a layer bitmask with all bits set to 1.
     fn all_bits() -> u32;
 }
 
-impl<L: PhysicsLayer> PhysicsLayer for &L {
+impl<'a, L: PhysicsLayer> PhysicsLayer for &'a L
+where
+    &'a L: Default,
+{
     fn to_bits(&self) -> u32 {
         L::to_bits(self)
     }
@@ -26,13 +29,15 @@ impl<L: PhysicsLayer> PhysicsLayer for &L {
 /// A bitmask for layers.
 ///
 /// A [`LayerMask`] can be constructed from bits directly, or from types implementing [`PhysicsLayer`].
+/// The first bit `0b0001` is reserved for the default layer, which all entities belong to by default.
 ///
 /// ```
 #[cfg_attr(feature = "2d", doc = "# use avian2d::prelude::*;")]
 #[cfg_attr(feature = "3d", doc = "# use avian3d::prelude::*;")]
 /// #
-/// #[derive(PhysicsLayer, Clone, Copy, Debug)]
+/// #[derive(PhysicsLayer, Default)]
 /// enum GameLayer {
+///     #[default]
 ///     Default, // Layer 0 - the default layer that objects are assigned to
 ///     Player,  // Layer 1
 ///     Enemy,   // Layer 2
@@ -269,8 +274,9 @@ impl Not for LayerMask {
 #[cfg_attr(feature = "2d", doc = "# use avian2d::prelude::*;")]
 #[cfg_attr(feature = "3d", doc = "# use avian3d::prelude::*;")]
 /// #
-/// #[derive(PhysicsLayer)]
+/// #[derive(PhysicsLayer, Default)]
 /// enum GameLayer {
+///     #[default]
 ///     Default, // Layer 0 - the default layer that objects are assigned to
 ///     Player,  // Layer 1
 ///     Enemy,   // Layer 2
@@ -430,8 +436,9 @@ mod tests {
 
     use crate::prelude::*;
 
-    #[derive(PhysicsLayer)]
+    #[derive(PhysicsLayer, Default)]
     enum GameLayer {
+        #[default]
         Default,
         Player,
         Enemy,


### PR DESCRIPTION
# Objective

#476 changed collision layers to reserve the first bit for a default layer. However, for enums implementing `PhysicsLayer`, the default layer is rather implicit and potentially footgunny.

The default layer should ideally be more explicit.

## Solution

Change `PhysicsLayer` to require `Default` to be implemented. The proc macro orders the variants such that the layer set as the default is always the first bit.

Note that `Default` *must* currently be derived instead of implemented manually, as the macro can only access the default variant if the `#[default]` attribute exists. An error is emitted if `#[default]` does not exist. If someone knows a way to make it work with the manual impl, let me know or consider opening a PR!

I also added documentation for the `PhysicsLayer` macro, and improved error handling.

---

## Migration Guide

Enums that derive `PhysicsLayer` must now also derive `Default` and specify a default layer using the `#[default]` attribute.

Before:

```rust
#[derive(PhysicsLayer)]
enum GameLayer {
    Player,
    Enemy,
    Ground,
}
```

After:

```rust
#[derive(PhysicsLayer, Default)]
enum GameLayer {
    #[default]
    Default, // The name doesn't matter, but Default is used here for clarity
    Player,
    Enemy,
    Ground,
}
```

The default layer always has the bit value `0b0001` regardless of its order relative to the other variants.