### PR TITLE
Fix missing feature flag

### DIFF
--- a/crates/avian2d/Cargo.toml
+++ b/crates/avian2d/Cargo.toml
@@ -39,6 +39,7 @@ serialize = [
     "bevy/serialize",
     "parry2d?/serde-serialize",
     "parry2d-f64?/serde-serialize",
+    "bitflags/serde",
 ]
 
 [lib]

--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -48,6 +48,7 @@ serialize = [
     "bevy/serialize",
     "parry3d?/serde-serialize",
     "parry3d-f64?/serde-serialize",
+    "bitflags/serde",
 ]
 
 [lib]


### PR DESCRIPTION
# Objective

While depending on Avian's `main` branch, running `cargo doc --all-features` fails on my crate when including a serialize feature

## Solution

Fix bitflags not being serializable when serializing. Ideally, the CI should catch this.
