### PR TITLE
add some #[must_use] to LockedAxes builder fns

### DIFF
--- a/src/dynamics/rigid_body/locked_axes.rs
+++ b/src/dynamics/rigid_body/locked_axes.rs
@@ -62,12 +62,14 @@ impl LockedAxes {
     }
 
     /// Locks translation along the `X` axis.
+    #[must_use]
     pub const fn lock_translation_x(mut self) -> Self {
         self.0 |= 0b100_000;
         self
     }
 
     /// Locks translation along the `Y` axis.
+    #[must_use]
     pub const fn lock_translation_y(mut self) -> Self {
         self.0 |= 0b010_000;
         self
@@ -75,6 +77,7 @@ impl LockedAxes {
 
     /// Locks translation along the `Z` axis.
     #[cfg(feature = "3d")]
+    #[must_use]
     pub const fn lock_translation_z(mut self) -> Self {
         self.0 |= 0b001_000;
         self
@@ -89,6 +92,7 @@ impl LockedAxes {
 
     /// Locks rotation around the `Y` axis.
     #[cfg(feature = "3d")]
+    #[must_use]
     pub const fn lock_rotation_y(mut self) -> Self {
         self.0 |= 0b000_010;
         self
@@ -96,6 +100,7 @@ impl LockedAxes {
 
     /// Locks rotation around the `Z` axis.
     #[cfg(feature = "3d")]
+    #[must_use]
     pub const fn lock_rotation_z(mut self) -> Self {
         self.0 |= 0b000_001;
         self
@@ -103,18 +108,21 @@ impl LockedAxes {
 
     /// Locks all rotation.
     #[cfg(feature = "2d")]
+    #[must_use]
     pub const fn lock_rotation(mut self) -> Self {
         self.0 |= 0b000_001;
         self
     }
 
     /// Unlocks translation along the `X` axis.
+    #[must_use]
     pub const fn unlock_translation_x(mut self) -> Self {
         self.0 &= !0b100_000;
         self
     }
 
     /// Unlocks translation along the `Y` axis.
+    #[must_use]
     pub const fn unlock_translation_y(mut self) -> Self {
         self.0 &= !0b010_000;
         self
@@ -122,6 +130,7 @@ impl LockedAxes {
 
     /// Unlocks translation along the `Z` axis.
     #[cfg(feature = "3d")]
+    #[must_use]
     pub const fn unlock_translation_z(mut self) -> Self {
         self.0 &= !0b001_000;
         self
@@ -129,6 +138,7 @@ impl LockedAxes {
 
     /// Unlocks rotation around the `X` axis.
     #[cfg(feature = "3d")]
+    #[must_use]
     pub const fn unlock_rotation_x(mut self) -> Self {
         self.0 &= !0b000_100;
         self
@@ -136,6 +146,7 @@ impl LockedAxes {
 
     /// Unlocks rotation around the `Y` axis.
     #[cfg(feature = "3d")]
+    #[must_use]
     pub const fn unlock_rotation_y(mut self) -> Self {
         self.0 &= !0b000_010;
         self
@@ -143,6 +154,7 @@ impl LockedAxes {
 
     /// Unlocks rotation around the `Z` axis.
     #[cfg(feature = "3d")]
+    #[must_use]
     pub const fn unlock_rotation_z(mut self) -> Self {
         self.0 &= !0b000_001;
         self
@@ -150,6 +162,7 @@ impl LockedAxes {
 
     /// Unlocks all rotation.
     #[cfg(feature = "2d")]
+    #[must_use]
     pub const fn unlock_rotation(mut self) -> Self {
         self.0 &= !0b000_001;
         self


### PR DESCRIPTION
# Objective

- Helps avoid my mistake of grabbing `LockedAxes` from a query and calling `unlock_rotation()` without reassigning to the component, failing to notice it returns self

## Solution

- Adds `#[must_use]` to builder-style fns that return Self, yielding this compiler warning:

```
warning: unused return value of `avian2d::prelude::LockedAxes::unlock_rotation` that must be used
  --> crates/avian2d/examples/uncommitted_example_fixed_joint_2d.rs:89:17
   |
89 |                 locked_axes.unlock_rotation();
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_must_use)]` on by default
help: use `let _ = ...` to ignore the resulting value
   |
89 |                 let _ = locked_axes.unlock_rotation();
   |                 +++++++

```

