### PR TITLE
Optimize `wake_on_collision_ended` when large number of collisions are occurring

### DIFF
--- a/src/dynamics/sleeping/mod.rs
+++ b/src/dynamics/sleeping/mod.rs
@@ -291,7 +291,9 @@ fn wake_on_collision_ended(
                     || moved_bodies.get(p.get()).is_ok_and(|pos| pos.is_changed())
             })
         }) {
-            commands.entity(entity).remove::<Sleeping>();
+            if is_sleeping {
+                commands.entity(entity).remove::<Sleeping>();
+            }
             time_sleeping.0 = 0.0;
         }
     }
@@ -301,12 +303,16 @@ fn wake_on_collision_ended(
         if contacts.during_current_frame || !contacts.during_previous_frame {
             continue;
         }
-        if let Ok((_, mut time_sleeping, _)) = sleeping.get_mut(contacts.entity1) {
-            commands.entity(contacts.entity1).remove::<Sleeping>();
+        if let Ok((_, mut time_sleeping, is_sleeping)) = sleeping.get_mut(contacts.entity1) {
+            if is_sleeping {
+                commands.entity(contacts.entity1).remove::<Sleeping>();
+            }
             time_sleeping.0 = 0.0;
         }
-        if let Ok((_, mut time_sleeping, _)) = sleeping.get_mut(contacts.entity2) {
-            commands.entity(contacts.entity2).remove::<Sleeping>();
+        if let Ok((_, mut time_sleeping, is_sleeping)) = sleeping.get_mut(contacts.entity2) {
+            if is_sleeping {
+                commands.entity(contacts.entity2).remove::<Sleeping>();
+            }
             time_sleeping.0 = 0.0;
         }
     }


### PR DESCRIPTION
# Objective

- With a large number of colliding bodies, I was seeing `wake_on_collision_ended` use almost as much time as `run_substep_schedule` in some cases
- I narrowed the slowness down to evaluation of [this if condition](https://github.com/Jondolf/avian/blob/2f83cc15bd804ad82ecd7e080e337d052d1c3472/src/dynamics/sleeping/mod.rs#L280-L285)
    - Evaluating this once takes around 3μs on my laptop which isn't a huge deal on its own, but when there's 2500 colliders it started to add up to multiple milliseconds

## Solution

- In `wake_on_collision_ended`, skip the body of the first for loop (over `sleeping`) if the following both hold true:
    - The body does not already have a `Sleeping` component
    - TimeSleeping is 0.0

I believe this is ok because the side-effects of that loop is to remove the `Sleeping` component and to reset `TimeSleeping` to zero, which is exactly the condition it now tests for. Therefore, if the entity is already in that state, there's no point in executing the [relatively costly if statement here](https://github.com/Jondolf/avian/blob/2f83cc15bd804ad82ecd7e080e337d052d1c3472/src/dynamics/sleeping/mod.rs#L280-L285) (as mentioned above).

- Since it now also already knows if the `Sleeping` component is present, I gated the `commands.entity(entity).remove::<Sleeping>();` calls so that it only adds that command if the component is present
    - This should save a few lookups on Bevy's end, but isn't strictly necessary for this PR

- It may also be worth gating the `sleeping` query on `Without<SleepingDisabled>` but I wasn't sure how correct that was
    - If we think it's worth it, we could add that too so that bodies with sleeping disabled aren't even considered here

## Results

Large numbers of colliders (here, 2500) showed a near 1000x improvement in execution time of `wake_on_collision_ended`, going from multiple milliseconds to a few microseconds when none of the bodies are sleeping:
<img width="569" alt="2500" src="https://github.com/user-attachments/assets/9785ddfb-0270-474a-bfda-c83a830f011e">

~~Performance regressed for small numbers of colliders (here, 100), however this is regression at the microseconds level (3.5μs to 15.5μs median), so I posit that this is a worthy tradeoff:~~
(removed; I had the traces backwards)


---

## Changelog

- SleepingPlugin's `wake_on_collision_ended` system
    - `sleeping` query now includes `Has<Sleeping>`
    - first loop in system body skips anything that isn't already sleeping or about to sleep
    - don't remove `Sleeping` component if `Has<Sleeping>`resolved to false