### PR TITLE
Make disabling joints possible.

### DIFF
--- a/src/dynamics/solver/joints/mod.rs
+++ b/src/dynamics/solver/joints/mod.rs
@@ -340,5 +340,8 @@ impl AngleLimit {
 }
 
 /// Disables the joint of the entity it is placed on.
-#[derive(Component, Debug)]
+#[derive(Reflect, Clone, Copy, Component, Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Debug, Component)]
 pub struct DisableJoint;

--- a/src/dynamics/solver/joints/mod.rs
+++ b/src/dynamics/solver/joints/mod.rs
@@ -344,4 +344,4 @@ impl AngleLimit {
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, Component)]
-pub struct DisableJoint;
+pub struct JointDisabled;

--- a/src/dynamics/solver/joints/mod.rs
+++ b/src/dynamics/solver/joints/mod.rs
@@ -338,3 +338,7 @@ impl AngleLimit {
         None
     }
 }
+
+/// Disables the joint of the entity it is placed on.
+#[derive(Component, Debug)]
+pub struct DisableJoint;

--- a/src/dynamics/solver/xpbd/mod.rs
+++ b/src/dynamics/solver/xpbd/mod.rs
@@ -351,7 +351,7 @@ pub trait XpbdConstraint<const ENTITY_COUNT: usize>: MapEntities {
 pub fn solve_constraint<C: XpbdConstraint<ENTITY_COUNT> + Component, const ENTITY_COUNT: usize>(
     mut commands: Commands,
     mut bodies: Query<RigidBodyQuery>,
-    mut constraints: Query<&mut C, (Without<RigidBody>, Without<DisableJoint>)>,
+    mut constraints: Query<&mut C, (Without<RigidBody>, Without<JointDisabled>)>,
     time: Res<Time>,
 ) {
     let delta_secs = time.delta_seconds_adjusted();

--- a/src/dynamics/solver/xpbd/mod.rs
+++ b/src/dynamics/solver/xpbd/mod.rs
@@ -351,7 +351,7 @@ pub trait XpbdConstraint<const ENTITY_COUNT: usize>: MapEntities {
 pub fn solve_constraint<C: XpbdConstraint<ENTITY_COUNT> + Component, const ENTITY_COUNT: usize>(
     mut commands: Commands,
     mut bodies: Query<RigidBodyQuery>,
-    mut constraints: Query<&mut C, Without<RigidBody>>,
+    mut constraints: Query<&mut C, (Without<RigidBody>, Without<DisableJoint>)>,
     time: Res<Time>,
 ) {
     let delta_secs = time.delta_seconds_adjusted();


### PR DESCRIPTION
# Objective

Make disabling joints possible.

## Solution

I added `DisableJoint` and added the `Without<DisableJoint>` filter on the query.

### Naming

In discord Jondolf had used the name `JointDisabled`; however, I thought the verb form `DisableJoint` was my preference. But this is not a strong opinion. If there are other past tense components, then I'm happy to have it either way.

### Other Considerations

I added derives for copy, clone, reflect, and serialize but these were added to follow suit rather than for a good reason of my own. 

## Alternatives

One could set the compliance to a large number. But what large number? And why bother computing when one would prefer disabling?

---

## Changelog

- Joints can be disabled with the `DisableJoint` component.
