### PR TITLE
Fix 3D rotation update in `transform_to_position`

### DIFF
--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -263,10 +263,9 @@ pub fn transform_to_position(
         #[cfg(feature = "3d")]
         {
             rotation.0 = (previous_transform.rotation
-                + (transform.rotation - previous_transform.rotation)
-                + (rotation.f32() - previous_transform.rotation))
-                .normalize()
-                .adjust_precision();
+                * (transform.rotation * previous_transform.rotation.inverse())
+                * (rotation.f32() * previous_transform.rotation.inverse()))
+            .adjust_precision();
         }
     }
 }


### PR DESCRIPTION
# Objective

Fixes #516.

Rotation is currently updated incorrectly in 3D by `transform_to_position`. It uses addition and subtraction instead of multiplication for quaternions. This causes clear desync between `Transform` rotation and `Rotation` when `SyncConfig::position_to_transform` is `false` and the `Transform` is changed:

https://github.com/user-attachments/assets/5b51480e-6f55-4317-9ed1-ec02f9c4d640

## Solution

Fix the rotation update. We can also remove the normalization, because individual quaternion multiplications should remain normalized, assuming the inputs are normalized (and there aren't too many successive rotations).

Now, the desync is fixed:

https://github.com/user-attachments/assets/8922832f-21b4-4ed9-947d-bd4b77786647