### PR TITLE
Add convenience methods for determining if collisions are starting or stopping

### DIFF
--- a/src/collision/mod.rs
+++ b/src/collision/mod.rs
@@ -330,6 +330,16 @@ impl Contacts {
     pub fn total_tangent_force(&self, delta_time: Scalar) -> Vector2 {
         self.total_tangent_impulse / delta_time
     }
+
+    /// Returns `true` if a collision started during the current frame.
+    pub fn collision_started(&self) -> bool {
+        !self.during_previous_frame && self.during_current_frame
+    }
+
+    /// Returns `true` if a collision stopped during the current frame.
+    pub fn collision_stopped(&self) -> bool {
+        self.during_previous_frame && !self.during_current_frame
+    }
 }
 
 /// A contact manifold between two colliders, containing a set of contact points.


### PR DESCRIPTION
# Objective

It can be tricky to match and handle all of an entity's collision states in a single event loop. I routinely find myself writing code like this:

```
    for Collision(contacts)in events.read() {
        let started = contacts.during_current_frame && !contacts.during_previous_frame;
        let stopped = !contacts.during_current_frame && contacts.during_previous_frame;
        if started {
        } else if stopped {
        }
```

## Solution

Add `Contacts::collision_started` and `Contacts::collision_stopped` to more conveniently check these conditions.

## Changelog

### Added

- Added `Contacts::collision_started` and `Contacts::collision_stopped` for more conveniently checking if a collision just started or stopped.