### PR TITLE
Add `RigidBodyDisabled`

### DIFF
--- a/crates/avian3d/examples/cubes.rs
+++ b/crates/avian3d/examples/cubes.rs
@@ -10,11 +10,12 @@ fn main() {
             DefaultPlugins,
             ExampleCommonPlugin,
             PhysicsPlugins::default(),
+            PhysicsDebugPlugin::default(),
         ))
         .insert_resource(ClearColor(Color::srgb(0.05, 0.05, 0.1)))
         .insert_resource(Msaa::Sample4)
         .add_systems(Startup, setup)
-        .add_systems(Update, movement)
+        .add_systems(Update, (movement, disable))
         .run();
 }
 
@@ -107,6 +108,24 @@ fn movement(
         if direction != Vector::ZERO {
             linear_velocity.x += direction.x * movement_acceleration.0 * delta_time;
             linear_velocity.z += direction.z * movement_acceleration.0 * delta_time;
+        }
+    }
+}
+
+fn disable(
+    mut commands: Commands,
+    query: Query<(Entity, &RigidBody, Has<RigidBodyDisabled>)>,
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+) {
+    if keyboard_input.just_pressed(KeyCode::Space) {
+        for (entity, rigid_body, is_disabled) in &query {
+            if rigid_body.is_static() {
+                if is_disabled {
+                    commands.entity(entity).remove::<RigidBodyDisabled>();
+                } else {
+                    commands.entity(entity).insert(RigidBodyDisabled);
+                }
+            }
         }
     }
 }

--- a/crates/avian3d/examples/cubes.rs
+++ b/crates/avian3d/examples/cubes.rs
@@ -10,12 +10,11 @@ fn main() {
             DefaultPlugins,
             ExampleCommonPlugin,
             PhysicsPlugins::default(),
-            PhysicsDebugPlugin::default(),
         ))
         .insert_resource(ClearColor(Color::srgb(0.05, 0.05, 0.1)))
         .insert_resource(Msaa::Sample4)
         .add_systems(Startup, setup)
-        .add_systems(Update, (movement, disable))
+        .add_systems(Update, movement)
         .run();
 }
 
@@ -108,24 +107,6 @@ fn movement(
         if direction != Vector::ZERO {
             linear_velocity.x += direction.x * movement_acceleration.0 * delta_time;
             linear_velocity.z += direction.z * movement_acceleration.0 * delta_time;
-        }
-    }
-}
-
-fn disable(
-    mut commands: Commands,
-    query: Query<(Entity, &RigidBody, Has<RigidBodyDisabled>)>,
-    keyboard_input: Res<ButtonInput<KeyCode>>,
-) {
-    if keyboard_input.just_pressed(KeyCode::Space) {
-        for (entity, rigid_body, is_disabled) in &query {
-            if rigid_body.is_static() {
-                if is_disabled {
-                    commands.entity(entity).remove::<RigidBodyDisabled>();
-                } else {
-                    commands.entity(entity).insert(RigidBodyDisabled);
-                }
-            }
         }
     }
 }

--- a/src/collision/narrow_phase.rs
+++ b/src/collision/narrow_phase.rs
@@ -348,6 +348,7 @@ pub struct NarrowPhase<'w, 's, C: AnyCollider> {
             Option<&'static CollisionMargin>,
             Option<&'static SpeculativeMargin>,
         ),
+        Without<RigidBodyDisabled>,
     >,
     /// Contacts found by the narrow phase.
     pub collisions: ResMut<'w, Collisions>,

--- a/src/dynamics/integrator/mod.rs
+++ b/src/dynamics/integrator/mod.rs
@@ -165,7 +165,7 @@ struct VelocityIntegrationQuery {
 
 #[allow(clippy::type_complexity)]
 fn integrate_velocities(
-    mut bodies: Query<VelocityIntegrationQuery, Without<Sleeping>>,
+    mut bodies: Query<VelocityIntegrationQuery, RigidBodyActiveFilter>,
     gravity: Res<Gravity>,
     time: Res<Time>,
 ) {
@@ -241,7 +241,7 @@ fn integrate_positions(
             &AngularVelocity,
             Option<&LockedAxes>,
         ),
-        Without<Sleeping>,
+        RigidBodyActiveFilter,
     >,
     time: Res<Time>,
 ) {
@@ -301,7 +301,7 @@ type ImpulseQueryComponents = (
     Option<&'static LockedAxes>,
 );
 
-fn apply_impulses(mut bodies: Query<ImpulseQueryComponents, Without<Sleeping>>) {
+fn apply_impulses(mut bodies: Query<ImpulseQueryComponents, RigidBodyActiveFilter>) {
     for (
         rb,
         impulse,

--- a/src/dynamics/rigid_body/mod.rs
+++ b/src/dynamics/rigid_body/mod.rs
@@ -266,6 +266,24 @@ impl RigidBody {
     }
 }
 
+/// A query filter that selects rigid bodies that are neither disabled nor sleeping.
+pub(crate) type RigidBodyActiveFilter = (Without<RigidBodyDisabled>, Without<Sleeping>);
+
+/// A marker component that indicates that a [rigid body](RigidBody) is disabled
+/// and should not participate in the simulation. Disables velocity, forces, contact response,
+/// and attached joints.
+///
+/// This is useful for temporarily disabling a body without removing it from the world.
+/// To re-enable the body, simply remove the component.
+///
+/// Note that this component does *not* disable collision detection or spatial queries for colliders
+/// attached to the rigid body.
+#[derive(Reflect, Clone, Copy, Component, Debug, Default, PartialEq, Eq, From)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Debug, Component, Default, PartialEq)]
+pub struct RigidBodyDisabled;
+
 /// Indicates that a [rigid body](RigidBody) is not simulated by the physics engine until woken up again.
 /// This is done to improve performance and to help prevent small jitter that is typically present in collisions.
 ///

--- a/src/dynamics/rigid_body/mod.rs
+++ b/src/dynamics/rigid_body/mod.rs
@@ -222,6 +222,7 @@ use derive_more::From;
 /// - [Lock translational and rotational axes](LockedAxes)
 /// - [Dominance]
 /// - [Continuous Collision Detection](dynamics::ccd)
+/// - [Temporarily disabling a rigid body](RigidBodyDisabled)
 /// - [Automatic deactivation with sleeping](Sleeping)
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
@@ -278,6 +279,37 @@ pub(crate) type RigidBodyActiveFilter = (Without<RigidBodyDisabled>, Without<Sle
 ///
 /// Note that this component does *not* disable collision detection or spatial queries for colliders
 /// attached to the rigid body.
+///
+/// # Example
+///
+/// ```
+#[cfg_attr(feature = "2d", doc = "# use avian2d::prelude::*;")]
+#[cfg_attr(feature = "3d", doc = "# use avian3d::prelude::*;")]
+/// # use bevy::prelude::*;
+/// #
+/// #[derive(Component)]
+/// pub struct Character;
+///
+/// /// Disables physics for all rigid body characters, for example during cutscenes.
+/// fn disable_character_physics(
+///     mut commands: Commands,
+///     query: Query<Entity, (With<RigidBody>, With<Character>)>,
+/// ) {
+///     for entity in &query {
+///         commands.entity(entity).insert(RigidBodyDisabled);
+///     }
+/// }
+///
+/// /// Enables physics for all rigid body characters.
+/// fn enable_character_physics(
+///     mut commands: Commands,
+///     query: Query<Entity, (With<RigidBody>, With<Character>)>,
+/// ) {
+///     for entity in &query {
+///         commands.entity(entity).remove::<RigidBodyDisabled>();
+///     }
+/// }
+/// ```
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, PartialEq, Eq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]

--- a/src/dynamics/sleeping/mod.rs
+++ b/src/dynamics/sleeping/mod.rs
@@ -262,12 +262,18 @@ fn wake_all_sleeping_bodies(
 #[allow(clippy::type_complexity)]
 fn wake_on_collision_ended(
     mut commands: Commands,
-    moved_bodies: Query<Ref<Position>, (Changed<Position>, Without<Sleeping>)>,
+    bodies: Query<
+        (Ref<Position>, Has<RigidBodyDisabled>),
+        (
+            Or<(Added<RigidBodyDisabled>, Changed<Position>)>,
+            Without<Sleeping>,
+        ),
+    >,
     colliders: Query<(&ColliderParent, Ref<ColliderTransform>)>,
     collisions: Res<Collisions>,
     mut sleeping: Query<(Entity, &mut TimeSleeping, Has<Sleeping>)>,
 ) {
-    // Wake up bodies when a body they're colliding with moves.
+    // Wake up bodies when a body they're colliding with moves or gets disabled.
     for (entity, mut time_sleeping, is_sleeping) in &mut sleeping {
         // Skip anything that isn't currently sleeping and already has a time_sleeping of zero.
         // We can't gate the sleeping query using With<Sleeping> here because must also reset
@@ -288,7 +294,9 @@ fn wake_on_collision_ended(
         if colliding_entities.any(|other_entity| {
             colliders.get(other_entity).is_ok_and(|(p, transform)| {
                 transform.is_changed()
-                    || moved_bodies.get(p.get()).is_ok_and(|pos| pos.is_changed())
+                    || bodies
+                        .get(p.get())
+                        .is_ok_and(|(pos, is_disabled)| is_disabled || pos.is_changed())
             })
         }) {
             if is_sleeping {

--- a/src/dynamics/solver/mod.rs
+++ b/src/dynamics/solver/mod.rs
@@ -151,7 +151,7 @@ impl Plugin for SolverPlugin {
         // Solve velocities using a position bias.
         substeps.add_systems(
             (
-                |mut bodies: Query<RigidBodyQuery>,
+                |mut bodies: Query<RigidBodyQuery, Without<RigidBodyDisabled>>,
                  mut constraints: ResMut<ContactConstraints>,
                  solver_config: Res<SolverConfig>,
                  length_unit: Res<PhysicsLengthUnit>,
@@ -173,7 +173,7 @@ impl Plugin for SolverPlugin {
         // This reduces overshooting caused by warm starting.
         substeps.add_systems(
             (
-                |mut bodies: Query<RigidBodyQuery>,
+                |mut bodies: Query<RigidBodyQuery, Without<RigidBodyDisabled>>,
                  mut constraints: ResMut<ContactConstraints>,
                  solver_config: Res<SolverConfig>,
                  length_unit: Res<PhysicsLengthUnit>,
@@ -194,12 +194,15 @@ impl Plugin for SolverPlugin {
         // Solve joints with XPBD.
         substeps.add_systems(
             (
-                |mut query: Query<(
-                    &AccumulatedTranslation,
-                    &mut PreSolveAccumulatedTranslation,
-                    &Rotation,
-                    &mut PreSolveRotation,
-                )>| {
+                |mut query: Query<
+                    (
+                        &AccumulatedTranslation,
+                        &mut PreSolveAccumulatedTranslation,
+                        &Rotation,
+                        &mut PreSolveRotation,
+                    ),
+                    Without<RigidBodyDisabled>,
+                >| {
                     for (translation, mut pre_solve_translation, rotation, mut previous_rotation) in
                         &mut query
                     {
@@ -502,7 +505,7 @@ pub struct ContactConstraints(pub Vec<ContactConstraint>);
 ///
 /// See [`SubstepSolverSet::WarmStart`] for more information.
 fn warm_start(
-    mut bodies: Query<RigidBodyQuery>,
+    mut bodies: Query<RigidBodyQuery, Without<RigidBodyDisabled>>,
     mut constraints: ResMut<ContactConstraints>,
     solver_config: Res<SolverConfig>,
 ) {
@@ -544,7 +547,7 @@ fn warm_start(
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
 fn solve_contacts(
-    bodies: &mut Query<RigidBodyQuery>,
+    bodies: &mut Query<RigidBodyQuery, Without<RigidBodyDisabled>>,
     constraints: &mut [ContactConstraint],
     delta_secs: Scalar,
     iterations: usize,
@@ -580,7 +583,7 @@ fn solve_contacts(
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
 fn solve_restitution(
-    mut bodies: Query<RigidBodyQuery>,
+    mut bodies: Query<RigidBodyQuery, Without<RigidBodyDisabled>>,
     mut constraints: ResMut<ContactConstraints>,
     solver_config: Res<SolverConfig>,
     length_unit: Res<PhysicsLengthUnit>,
@@ -681,7 +684,7 @@ pub fn joint_damping<T: Joint>(
             &Mass,
             Option<&Dominance>,
         ),
-        Without<Sleeping>,
+        RigidBodyActiveFilter,
     >,
     joints: Query<&T, Without<RigidBody>>,
     time: Res<Time>,

--- a/src/dynamics/solver/xpbd/mod.rs
+++ b/src/dynamics/solver/xpbd/mod.rs
@@ -350,7 +350,7 @@ pub trait XpbdConstraint<const ENTITY_COUNT: usize>: MapEntities {
 /// ```
 pub fn solve_constraint<C: XpbdConstraint<ENTITY_COUNT> + Component, const ENTITY_COUNT: usize>(
     mut commands: Commands,
-    mut bodies: Query<RigidBodyQuery>,
+    mut bodies: Query<RigidBodyQuery, Without<RigidBodyDisabled>>,
     mut constraints: Query<&mut C, (Without<RigidBody>, Without<JointDisabled>)>,
     time: Res<Time>,
 ) {
@@ -405,7 +405,7 @@ pub(super) fn project_linear_velocity(
             &AccumulatedTranslation,
             &mut LinearVelocity,
         ),
-        Without<Sleeping>,
+        RigidBodyActiveFilter,
     >,
     time: Res<Time>,
 ) {
@@ -438,7 +438,7 @@ pub(super) fn project_angular_velocity(
             &PreSolveRotation,
             &mut AngularVelocity,
         ),
-        Without<Sleeping>,
+        RigidBodyActiveFilter,
     >,
     time: Res<Time>,
 ) {
@@ -470,7 +470,7 @@ pub(super) fn project_angular_velocity(
             &PreSolveRotation,
             &mut AngularVelocity,
         ),
-        Without<Sleeping>,
+        RigidBodyActiveFilter,
     >,
     time: Res<Time>,
 ) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,7 @@
 //! - [Continuous Collision Detection (CCD)](dynamics::ccd)
 //!     - [Speculative collision](dynamics::ccd#speculative-collision)
 //!     - [Swept CCD](dynamics::ccd#swept-ccd)
+//! - [Temporarily disabling a rigid body](RigidBodyDisabled)
 //! - [Automatic deactivation with sleeping](Sleeping)
 //!
 //! See the [`dynamics`] module for more details about rigid body dynamics in Avian.

--- a/src/type_registration.rs
+++ b/src/type_registration.rs
@@ -20,6 +20,7 @@ impl Plugin for PhysicsTypeRegistrationPlugin {
             .register_type::<DeactivationTime>()
             .register_type::<Gravity>()
             .register_type::<RigidBody>()
+            .register_type::<RigidBodyDisabled>()
             .register_type::<Sleeping>()
             .register_type::<SleepingDisabled>()
             .register_type::<TimeSleeping>()


### PR DESCRIPTION
# Objective

Fixes part of #436.

A pretty common user request is to be able to temporarily disable rigid bodies without removing them from the world. This can be done by removing `RigidBody`, but this loses the type of rigid body, makes queries a bit more annoying, and can involve somewhat expensive clean-up.

In the absence of general-purpose component disabling in Bevy, it would be useful to have a `RigidBodyDisabled` marker that can be used to temporarily remove a body from the simulation.

## Solution

Add a `RigidBodyDisabled` marker component. It disables velocity, forces, contact response, and attached joints. It does *not* disable collision detection or spatial queries for attached colliders however; that should be handled with a separate `ColliderDisabled` component in a follow-up.