### PR TITLE
Implement `Default` for `ColliderConstructor` for `avian2d`

### DIFF
--- a/crates/avian2d/Cargo.toml
+++ b/crates/avian2d/Cargo.toml
@@ -21,10 +21,10 @@ debug-plugin = ["bevy/bevy_gizmos", "bevy/bevy_render"]
 simd = ["parry2d?/simd-stable", "parry2d-f64?/simd-stable"]
 parallel = ["parry2d?/parallel", "parry2d-f64?/parallel"]
 enhanced-determinism = [
-    "dep:libm",
-    "parry2d?/enhanced-determinism",
-    "parry2d-f64?/enhanced-determinism",
-    "bevy_math/libm",
+  "dep:libm",
+  "parry2d?/enhanced-determinism",
+  "parry2d-f64?/enhanced-determinism",
+  "bevy_math/libm",
 ]
 
 default-collider = ["dep:nalgebra"]
@@ -35,11 +35,11 @@ parry-f64 = ["f64", "dep:parry2d-f64", "default-collider"]
 
 bevy_scene = ["bevy/bevy_scene"]
 serialize = [
-    "dep:serde",
-    "bevy/serialize",
-    "parry2d?/serde-serialize",
-    "parry2d-f64?/serde-serialize",
-    "bitflags/serde",
+  "dep:serde",
+  "bevy/serialize",
+  "parry2d?/serde-serialize",
+  "parry2d-f64?/serde-serialize",
+  "bitflags/serde",
 ]
 
 [lib]
@@ -56,7 +56,7 @@ libm = { version = "0.2", optional = true }
 parry2d = { version = "0.15", optional = true }
 parry2d-f64 = { version = "0.15", optional = true }
 nalgebra = { version = "0.32.6", features = [
-    "convert-glam027",
+  "convert-glam027",
 ], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 derive_more = "0.99"

--- a/local_export.sh
+++ b/local_export.sh
@@ -1,0 +1,15 @@
+#! /bin/bash
+
+currdir=$(pwd)
+
+mkdir -p target/crates/avian2d/
+mkdir -p target/crates/avian3d/
+
+cp -r src target/crates/avian2d/.
+cp -r src target/crates/avian3d/.
+cp -r LICENSE-MIT LICENSE-APACHE README.md crates/avian2d/Cargo.toml target/crates/avian2d/.
+cp -r LICENSE-MIT LICENSE-APACHE README.md crates/avian3d/Cargo.toml target/crates/avian3d/.
+sed 's#\.\./\.\./src#src#g' target/crates/avian2d/Cargo.toml
+sed 's#\.\./\.\./src#src#g' target/crates/avian3d/Cargo.toml > target/crates/avian3d/Cargo.toml
+cp -r crates/avian2d/. target/crates/avian2d/.
+cp -r crates/avian3d/. target/crates/avian3d/.

--- a/src/collision/collider/constructor.rs
+++ b/src/collision/collider/constructor.rs
@@ -283,10 +283,16 @@ pub struct ColliderConstructorHierarchyConfig {
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[cfg_attr(feature = "collider-from-mesh", derive(Default))]
 #[cfg_attr(feature = "collider-from-mesh", reflect(Default))]
+#[cfg_attr(feature = "2d", derive(Default))]
+#[cfg_attr(feature = "2d", reflect(Default))]
 #[reflect(Debug, Component, PartialEq)]
 #[non_exhaustive]
 #[allow(missing_docs)]
 pub enum ColliderConstructor {
+    /// Constructs a collider with [`Collider::circle`] with 1.0 radius to satisfy the default constructor.
+    #[cfg(feature = "2d")]
+    #[default]
+    UnitCircle,
     /// Constructs a collider with [`Collider::circle`].
     #[cfg(feature = "2d")]
     Circle { radius: Scalar },

--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -1092,6 +1092,8 @@ impl Collider {
     ) -> Option<Self> {
         match collider_constructor {
             #[cfg(feature = "2d")]
+            ColliderConstructor::UnitCircle => Some(Self::circle(1.0)),
+            #[cfg(feature = "2d")]
             ColliderConstructor::Circle { radius } => Some(Self::circle(radius)),
             #[cfg(feature = "3d")]
             ColliderConstructor::Sphere { radius } => Some(Self::sphere(radius)),


### PR DESCRIPTION
# Objective

- Fixes the issue in the header.

## Solution

- Make a unit circle option to satisfy the compiler and select it as `default`

Why? Because `space_editor` requires components to implement `Default`, and I think this is just a good thing for 2d to be able to do.