### PR TITLE
Add `Default` to `ColliderConstructor` for `avian2d`

### DIFF
--- a/src/collision/collider/constructor.rs
+++ b/src/collision/collider/constructor.rs
@@ -283,10 +283,16 @@ pub struct ColliderConstructorHierarchyConfig {
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[cfg_attr(feature = "collider-from-mesh", derive(Default))]
 #[cfg_attr(feature = "collider-from-mesh", reflect(Default))]
+#[cfg_attr(feature = "2d", derive(Default))]
+#[cfg_attr(feature = "2d", reflect(Default))]
 #[reflect(Debug, Component, PartialEq)]
 #[non_exhaustive]
 #[allow(missing_docs)]
 pub enum ColliderConstructor {
+    /// Constructs a collider with [`Collider::circle`] with radius 1.0 to satisfy the default constructor.
+    #[cfg(feature = "2d")]
+    #[default]
+    UnitCircle,
     /// Constructs a collider with [`Collider::circle`].
     #[cfg(feature = "2d")]
     Circle { radius: Scalar },

--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -1092,6 +1092,8 @@ impl Collider {
     ) -> Option<Self> {
         match collider_constructor {
             #[cfg(feature = "2d")]
+            ColliderConstructor::UnitCircle => Some(Self::circle(1.0)),
+            #[cfg(feature = "2d")]
             ColliderConstructor::Circle { radius } => Some(Self::circle(radius)),
             #[cfg(feature = "3d")]
             ColliderConstructor::Sphere { radius } => Some(Self::sphere(radius)),


### PR DESCRIPTION
# Objective

- Add `Default` to `ColliderConstructor` for `avian2d`

## Solution

- Make a `UnitCircle` option to satisfy `Default`

Need this for `space_editor` support.
