### PR TITLE
Update to Bevy 0.15 release candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,9 +165,10 @@ cargo run --example cubes --no-default-features --features "3d f64 parry-f64"
 
 ## Supported Bevy versions
 
-| Bevy | Avian |
-| ---- | ----- |
-| 0.14 | 0.1   |
+| Bevy    | Avian |
+| ------- | ----- |
+| 0.15 RC | main  |
+| 0.14    | 0.1   |
 
 <details>
   <summary>Bevy XPBD versions (the predecessor of Avian)</summary>
@@ -179,6 +180,7 @@ cargo run --example cubes --no-default-features --features "3d f64 parry-f64"
   | 0.12 | 0.3       |
   | 0.11 | 0.2       |
   | 0.10 | 0.1       |
+
 </details>
 
 ## Future features

--- a/crates/avian2d/Cargo.toml
+++ b/crates/avian2d/Cargo.toml
@@ -50,13 +50,13 @@ bench = false
 
 [dependencies]
 avian_derive = { path = "../avian_derive", version = "0.1" }
-bevy = { version = "0.14", default-features = false }
-bevy_math = { version = "0.14" }
+bevy = { version = "0.15.0-rc.1", default-features = false }
+bevy_math = { version = "0.15.0-rc.1" }
 libm = { version = "0.2", optional = true }
-parry2d = { version = "0.15", optional = true }
-parry2d-f64 = { version = "0.15", optional = true }
-nalgebra = { version = "0.32.6", features = [
-    "convert-glam027",
+parry2d = { git = "https://github.com/Jondolf/parry.git", branch = "update_nalgebra", optional = true }
+parry2d-f64 = { git = "https://github.com/Jondolf/parry.git", branch = "update_nalgebra", optional = true }
+nalgebra = { git = "https://github.com/waywardmonkeys/nalgebra", branch = "support-glam-0.29", features = [
+    "convert-glam029",
 ], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 derive_more = "0.99"
@@ -68,7 +68,7 @@ bitflags = "2.5.0"
 [dev-dependencies]
 examples_common_2d = { path = "../examples_common_2d" }
 benches_common_2d = { path = "../benches_common_2d" }
-bevy_math = { version = "0.14", features = ["approx"] }
+bevy_math = { version = "0.15.0-rc.1", features = ["approx"] }
 approx = "0.5"
 criterion = { version = "0.5", features = ["html_reports"] }
 insta = "1.0"

--- a/crates/avian2d/Cargo.toml
+++ b/crates/avian2d/Cargo.toml
@@ -53,11 +53,9 @@ avian_derive = { path = "../avian_derive", version = "0.1" }
 bevy = { version = "0.15.0-rc.1", default-features = false }
 bevy_math = { version = "0.15.0-rc.1" }
 libm = { version = "0.2", optional = true }
-parry2d = { git = "https://github.com/Jondolf/parry.git", branch = "update_nalgebra", optional = true }
-parry2d-f64 = { git = "https://github.com/Jondolf/parry.git", branch = "update_nalgebra", optional = true }
-nalgebra = { git = "https://github.com/waywardmonkeys/nalgebra", branch = "support-glam-0.29", features = [
-    "convert-glam029",
-], optional = true }
+parry2d = { version = "0.17", optional = true }
+parry2d-f64 = { version = "0.17", optional = true }
+nalgebra = { version = "0.33", features = ["convert-glam029"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 derive_more = "0.99"
 indexmap = "2.0.0"
@@ -72,7 +70,7 @@ bevy_math = { version = "0.15.0-rc.1", features = ["approx"] }
 approx = "0.5"
 criterion = { version = "0.5", features = ["html_reports"] }
 insta = "1.0"
-bevy_mod_debugdump = "0.11"
+bevy_mod_debugdump = { git = "https://github.com/andriyDev/bevy_mod_debugdump", branch = "bevy-0.15" }
 
 [[example]]
 name = "dynamic_character_2d"

--- a/crates/avian2d/Cargo.toml
+++ b/crates/avian2d/Cargo.toml
@@ -50,8 +50,8 @@ bench = false
 
 [dependencies]
 avian_derive = { path = "../avian_derive", version = "0.1" }
-bevy = { version = "0.15.0-rc.1", default-features = false }
-bevy_math = { version = "0.15.0-rc.1" }
+bevy = { version = "0.15.0-rc", default-features = false }
+bevy_math = { version = "0.15.0-rc" }
 libm = { version = "0.2", optional = true }
 parry2d = { version = "0.17", optional = true }
 parry2d-f64 = { version = "0.17", optional = true }
@@ -66,7 +66,7 @@ bitflags = "2.5.0"
 [dev-dependencies]
 examples_common_2d = { path = "../examples_common_2d" }
 benches_common_2d = { path = "../benches_common_2d" }
-bevy_math = { version = "0.15.0-rc.1", features = ["approx"] }
+bevy_math = { version = "0.15.0-rc", features = ["approx"] }
 approx = "0.5"
 criterion = { version = "0.5", features = ["html_reports"] }
 insta = "1.0"

--- a/crates/avian2d/examples/ccd.rs
+++ b/crates/avian2d/examples/ccd.rs
@@ -22,7 +22,7 @@
 //!         2. Non-linear: Considers both translation and rotation. More expensive.
 
 use avian2d::{math::*, prelude::*};
-use bevy::{prelude::*, sprite::MaterialMesh2dBundle};
+use bevy::prelude::*;
 use examples_common_2d::ExampleCommonPlugin;
 
 fn main() {
@@ -41,25 +41,22 @@ fn main() {
 }
 
 #[derive(Component)]
-struct SpeculativeCollisionText;
+struct SpeculativeCollisionEnabledText;
 
 #[derive(Component)]
-struct SweptCcdText;
+struct SweptCcdModeText;
 
 fn setup(mut commands: Commands) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     // Add two kinematic bodies spinning at high speeds.
     commands.spawn((
-        SpriteBundle {
-            sprite: Sprite {
-                color: Color::srgb(0.7, 0.7, 0.8),
-                custom_size: Some(Vec2::new(1.0, 400.0)),
-                ..default()
-            },
-            transform: Transform::from_xyz(-200.0, -200.0, 0.0),
+        Sprite {
+            color: Color::srgb(0.7, 0.7, 0.8),
+            custom_size: Some(Vec2::new(1.0, 400.0)),
             ..default()
         },
+        Transform::from_xyz(-200.0, -200.0, 0.0),
         RigidBody::Kinematic,
         AngularVelocity(25.0),
         Collider::rectangle(1.0, 400.0),
@@ -68,15 +65,12 @@ fn setup(mut commands: Commands) {
         SweptCcd::default(),
     ));
     commands.spawn((
-        SpriteBundle {
-            sprite: Sprite {
-                color: Color::srgb(0.7, 0.7, 0.8),
-                custom_size: Some(Vec2::new(1.0, 400.0)),
-                ..default()
-            },
-            transform: Transform::from_xyz(200.0, -200.0, 0.0),
+        Sprite {
+            color: Color::srgb(0.7, 0.7, 0.8),
+            custom_size: Some(Vec2::new(1.0, 400.0)),
             ..default()
         },
+        Transform::from_xyz(200.0, -200.0, 0.0),
         RigidBody::Kinematic,
         AngularVelocity(-25.0),
         Collider::rectangle(1.0, 400.0),
@@ -86,39 +80,46 @@ fn setup(mut commands: Commands) {
     ));
 
     // Setup help text.
-    let text_style = TextStyle {
+    let font = TextFont {
         font_size: 20.0,
         ..default()
     };
-    commands.spawn((
-        SpeculativeCollisionText,
-        TextBundle::from_sections([
-            TextSection::new("(1) Speculative Collision: ", text_style.clone()),
-            TextSection::new("On", text_style.clone()),
-        ])
-        .with_style(Style {
-            position_type: PositionType::Absolute,
-            top: Val::Px(30.0),
-            left: Val::Px(10.0),
-            ..default()
-        }),
-    ));
-    commands.spawn((
-        SweptCcdText,
-        TextBundle::from_sections([
-            TextSection::new("(2) Swept CCD: ", text_style.clone()),
-            TextSection::new(
-                "Non-linear (considers both translation and rotation)",
-                text_style,
-            ),
-        ])
-        .with_style(Style {
-            position_type: PositionType::Absolute,
-            top: Val::Px(50.0),
-            left: Val::Px(10.0),
-            ..default()
-        }),
-    ));
+    commands
+        .spawn((
+            Text::default(),
+            Node {
+                position_type: PositionType::Absolute,
+                top: Val::Px(30.0),
+                left: Val::Px(10.0),
+                ..default()
+            },
+        ))
+        .with_children(|children| {
+            children.spawn((TextSpan::new("(1) Speculative Collision: "), font.clone()));
+            children.spawn((
+                TextSpan::new("On"),
+                font.clone(),
+                SpeculativeCollisionEnabledText,
+            ));
+        });
+    commands
+        .spawn((
+            Text::default(),
+            Node {
+                position_type: PositionType::Absolute,
+                top: Val::Px(50.0),
+                left: Val::Px(10.0),
+                ..default()
+            },
+        ))
+        .with_children(|children| {
+            children.spawn((TextSpan::new("(2) Swept CCD: "), font.clone()));
+            children.spawn((
+                TextSpan::new("Non-linear (considers both translation and rotation)"),
+                font,
+                SweptCcdModeText,
+            ));
+        });
 }
 
 /// Spawns balls moving at the spinning objects at high speeds.
@@ -131,17 +132,13 @@ fn spawn_balls(
     let circle = Circle::new(2.0);
 
     // Compute the shooting direction.
-    let (sin, cos) =
-        (0.5 * time.elapsed_seconds_f64().adjust_precision().sin() - PI / 2.0).sin_cos();
+    let (sin, cos) = (0.5 * time.elapsed_secs_f64().adjust_precision().sin() - PI / 2.0).sin_cos();
     let direction = Vector::new(cos, sin).rotate(Vector::X);
 
     commands.spawn((
-        MaterialMesh2dBundle {
-            mesh: meshes.add(circle).into(),
-            transform: Transform::from_xyz(0.0, 350.0, 0.0),
-            material: materials.add(Color::srgb(0.2, 0.7, 0.9)),
-            ..default()
-        },
+        Mesh2d(meshes.add(circle)),
+        MeshMaterial2d(materials.add(Color::srgb(0.2, 0.7, 0.9))),
+        Transform::from_xyz(0.0, 350.0, 0.0),
         RigidBody::Dynamic,
         LinearVelocity(2000.0 * direction),
         Friction::ZERO.with_combine_rule(CoefficientCombine::Min),
@@ -150,11 +147,8 @@ fn spawn_balls(
 }
 
 fn update_config(
-    mut speculative_collision_text: Query<
-        &mut Text,
-        (With<SpeculativeCollisionText>, Without<SweptCcdText>),
-    >,
-    mut swept_ccd_text: Query<&mut Text, (Without<SpeculativeCollisionText>, With<SweptCcdText>)>,
+    speculative_collision_text: Single<&mut Text, With<SpeculativeCollisionEnabledText>>,
+    swept_ccd_mode_text: Single<&mut Text, With<SweptCcdModeText>>,
     keys: Res<ButtonInput<KeyCode>>,
     mut narrow_phase_config: ResMut<NarrowPhaseConfig>,
     mut ccd_bodies: Query<&mut SweptCcd>,
@@ -163,36 +157,35 @@ fn update_config(
     // Note: This sets the default speculative margin, but it can be overridden
     //       for individual entities with the `SpeculativeMargin` component.
     if keys.just_pressed(KeyCode::Digit1) {
-        let mut text = speculative_collision_text.single_mut();
+        let mut text = speculative_collision_text;
         if narrow_phase_config.default_speculative_margin == Scalar::MAX {
             narrow_phase_config.default_speculative_margin = 0.0;
-            text.sections[1].value = "Off".to_string();
+            text.0 = "Off".to_string();
         } else {
             narrow_phase_config.default_speculative_margin = Scalar::MAX;
-            text.sections[1].value = "On".to_string();
+            text.0 = "On".to_string();
         }
     }
 
     // Change the sweep mode and whether swept CCD is enabled.
     if keys.just_pressed(KeyCode::Digit2) {
-        let mut text = swept_ccd_text.single_mut();
+        let mut text = swept_ccd_mode_text;
         for mut swept_ccd in &mut ccd_bodies {
             if swept_ccd.mode == SweepMode::NonLinear && swept_ccd.include_dynamic {
                 swept_ccd.mode = SweepMode::Linear;
-                text.sections[1].value = "Linear (considers only translation)".to_string();
+                text.0 = "Linear (considers only translation)".to_string();
             } else if swept_ccd.mode == SweepMode::Linear {
                 // Disable swept CCD for collisions against dynamic bodies.
                 // To disable it completely, you should remove the component.
                 swept_ccd.include_dynamic = false;
 
                 swept_ccd.mode = SweepMode::NonLinear;
-                text.sections[1].value = "Off".to_string();
+                text.0 = "Off".to_string();
             } else {
                 // Enable swept CCD again.
                 swept_ccd.include_dynamic = true;
 
-                text.sections[1].value =
-                    "Non-linear (considers both translation and rotation)".to_string();
+                text.0 = "Non-linear (considers both translation and rotation)".to_string();
             }
         }
     }

--- a/crates/avian2d/examples/ccd.rs
+++ b/crates/avian2d/examples/ccd.rs
@@ -147,8 +147,20 @@ fn spawn_balls(
 }
 
 fn update_config(
-    speculative_collision_text: Single<&mut Text, With<SpeculativeCollisionEnabledText>>,
-    swept_ccd_mode_text: Single<&mut Text, With<SweptCcdModeText>>,
+    speculative_collision_text: Single<
+        &mut TextSpan,
+        (
+            With<SpeculativeCollisionEnabledText>,
+            Without<SweptCcdModeText>,
+        ),
+    >,
+    swept_ccd_mode_text: Single<
+        &mut TextSpan,
+        (
+            With<SweptCcdModeText>,
+            Without<SpeculativeCollisionEnabledText>,
+        ),
+    >,
     keys: Res<ButtonInput<KeyCode>>,
     mut narrow_phase_config: ResMut<NarrowPhaseConfig>,
     mut ccd_bodies: Query<&mut SweptCcd>,

--- a/crates/avian2d/examples/chain_2d.rs
+++ b/crates/avian2d/examples/chain_2d.rs
@@ -1,11 +1,7 @@
 #![allow(clippy::unnecessary_cast)]
 
 use avian2d::{math::*, prelude::*};
-use bevy::{
-    prelude::*,
-    sprite::{MaterialMesh2dBundle, Mesh2dHandle},
-    window::PrimaryWindow,
-};
+use bevy::{prelude::*, window::PrimaryWindow};
 use examples_common_2d::ExampleCommonPlugin;
 
 fn main() {
@@ -31,11 +27,11 @@ fn setup(
     mut materials: ResMut<Assets<ColorMaterial>>,
     mut meshes: ResMut<Assets<Mesh>>,
 ) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let particle_count = 100;
     let particle_radius = 1.2;
-    let particle_mesh: Mesh2dHandle = meshes.add(Circle::new(particle_radius as f32)).into();
+    let particle_mesh = meshes.add(Circle::new(particle_radius as f32));
     let particle_material = materials.add(Color::srgb(0.2, 0.7, 0.9));
 
     // Spawn kinematic particle that can follow the mouse
@@ -43,11 +39,8 @@ fn setup(
         .spawn((
             RigidBody::Kinematic,
             FollowMouse,
-            MaterialMesh2dBundle {
-                mesh: particle_mesh.clone(),
-                material: particle_material.clone(),
-                ..default()
-            },
+            Mesh2d(particle_mesh.clone()),
+            MeshMaterial2d(particle_material.clone()),
         ))
         .id();
 
@@ -57,16 +50,9 @@ fn setup(
             .spawn((
                 RigidBody::Dynamic,
                 MassPropertiesBundle::new_computed(&Collider::circle(particle_radius), 1.0),
-                MaterialMesh2dBundle {
-                    mesh: particle_mesh.clone(),
-                    material: particle_material.clone(),
-                    transform: Transform::from_xyz(
-                        0.0,
-                        -i as f32 * (particle_radius as f32 * 2.0 + 1.0),
-                        0.0,
-                    ),
-                    ..default()
-                },
+                Mesh2d(particle_mesh.clone()),
+                MeshMaterial2d(particle_material.clone()),
+                Transform::from_xyz(0.0, -i as f32 * (particle_radius as f32 * 2.0 + 1.0), 0.0),
             ))
             .id();
 
@@ -93,7 +79,7 @@ fn follow_mouse(
 
         if let Some(cursor_world_pos) = window
             .cursor_position()
-            .and_then(|cursor| camera.viewport_to_world_2d(camera_transform, cursor))
+            .and_then(|cursor| camera.viewport_to_world_2d(camera_transform, cursor).ok())
         {
             follower_position.translation =
                 cursor_world_pos.extend(follower_position.translation.z);

--- a/crates/avian2d/examples/collision_layers.rs
+++ b/crates/avian2d/examples/collision_layers.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::unnecessary_cast)]
 
 use avian2d::{math::*, prelude::*};
-use bevy::{prelude::*, sprite::MaterialMesh2dBundle};
+use bevy::prelude::*;
 use examples_common_2d::ExampleCommonPlugin;
 
 fn main() {
@@ -33,19 +33,16 @@ fn setup(
     mut materials: ResMut<Assets<ColorMaterial>>,
     mut meshes: ResMut<Assets<Mesh>>,
 ) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     // Spawn blue platform that belongs on the blue layer and collides with blue
     commands.spawn((
-        SpriteBundle {
-            sprite: Sprite {
-                color: Color::srgb(0.2, 0.7, 0.9),
-                custom_size: Some(Vec2::new(500.0, 25.0)),
-                ..default()
-            },
-            transform: Transform::from_xyz(0.0, -50.0, 0.0),
+        Sprite {
+            color: Color::srgb(0.2, 0.7, 0.9),
+            custom_size: Some(Vec2::new(500.0, 25.0)),
             ..default()
         },
+        Transform::from_xyz(0.0, -50.0, 0.0),
         RigidBody::Static,
         Collider::rectangle(500.0, 25.0),
         CollisionLayers::new([Layer::Blue], [Layer::Blue]),
@@ -53,15 +50,12 @@ fn setup(
 
     // Spawn red platform that belongs on the red layer and collides with red
     commands.spawn((
-        SpriteBundle {
-            sprite: Sprite {
-                color: Color::srgb(0.9, 0.3, 0.3),
-                custom_size: Some(Vec2::new(500.0, 25.0)),
-                ..default()
-            },
-            transform: Transform::from_xyz(0.0, -200.0, 0.0),
+        Sprite {
+            color: Color::srgb(0.9, 0.3, 0.3),
+            custom_size: Some(Vec2::new(500.0, 25.0)),
             ..default()
         },
+        Transform::from_xyz(0.0, -200.0, 0.0),
         RigidBody::Static,
         Collider::rectangle(500.0, 25.0),
         CollisionLayers::new([Layer::Red], [Layer::Red]),
@@ -75,16 +69,13 @@ fn setup(
     for x in -6..6 {
         for y in 0..4 {
             commands.spawn((
-                MaterialMesh2dBundle {
-                    mesh: marble_mesh.clone().into(),
-                    material: blue_material.clone(),
-                    transform: Transform::from_xyz(
-                        x as f32 * 2.5 * marble_radius,
-                        y as f32 * 2.5 * marble_radius + 200.0,
-                        0.0,
-                    ),
-                    ..default()
-                },
+                Mesh2d(marble_mesh.clone()),
+                MeshMaterial2d(blue_material.clone()),
+                Transform::from_xyz(
+                    x as f32 * 2.5 * marble_radius,
+                    y as f32 * 2.5 * marble_radius + 200.0,
+                    0.0,
+                ),
                 RigidBody::Dynamic,
                 Collider::circle(marble_radius as Scalar),
                 CollisionLayers::new([Layer::Blue], [Layer::Blue]),
@@ -97,16 +88,13 @@ fn setup(
     for x in -6..6 {
         for y in -4..0 {
             commands.spawn((
-                MaterialMesh2dBundle {
-                    mesh: marble_mesh.clone().into(),
-                    material: red_material.clone(),
-                    transform: Transform::from_xyz(
-                        x as f32 * 2.5 * marble_radius,
-                        y as f32 * 2.5 * marble_radius + 200.0,
-                        0.0,
-                    ),
-                    ..default()
-                },
+                Mesh2d(marble_mesh.clone()),
+                MeshMaterial2d(red_material.clone()),
+                Transform::from_xyz(
+                    x as f32 * 2.5 * marble_radius,
+                    y as f32 * 2.5 * marble_radius + 200.0,
+                    0.0,
+                ),
                 RigidBody::Dynamic,
                 Collider::circle(marble_radius as Scalar),
                 CollisionLayers::new([Layer::Red], [Layer::Red]),

--- a/crates/avian2d/examples/custom_collider.rs
+++ b/crates/avian2d/examples/custom_collider.rs
@@ -1,7 +1,7 @@
 //! An example demonstrating how to make a custom collider and use it for collision detection.
 
 use avian2d::{math::*, prelude::*};
-use bevy::{prelude::*, sprite::MaterialMesh2dBundle};
+use bevy::prelude::*;
 use examples_common_2d::ExampleCommonPlugin;
 
 fn main() {
@@ -144,7 +144,7 @@ fn setup(
     mut materials: ResMut<Assets<ColorMaterial>>,
     mut meshes: ResMut<Assets<Mesh>>,
 ) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let center_radius = 200.0;
     let particle_radius = 5.0;
@@ -156,11 +156,8 @@ fn setup(
     // Spawn rotating body at the center.
     commands
         .spawn((
-            MaterialMesh2dBundle {
-                mesh: meshes.add(Circle::new(center_radius)).into(),
-                material: materials.add(Color::srgb(0.7, 0.7, 0.8)).clone(),
-                ..default()
-            },
+            Mesh2d(meshes.add(Circle::new(center_radius))),
+            MeshMaterial2d(materials.add(Color::srgb(0.7, 0.7, 0.8)).clone()),
             RigidBody::Kinematic,
             CircleCollider::new(center_radius.adjust_precision()),
             CenterBody,
@@ -172,12 +169,9 @@ fn setup(
             for i in 0..count {
                 let pos = Quat::from_rotation_z(i as f32 * angle_step) * Vec3::Y * center_radius;
                 c.spawn((
-                    MaterialMesh2dBundle {
-                        mesh: particle_mesh.clone().into(),
-                        material: red.clone(),
-                        transform: Transform::from_translation(pos).with_scale(Vec3::ONE * 5.0),
-                        ..default()
-                    },
+                    Mesh2d(particle_mesh.clone()),
+                    MeshMaterial2d(red.clone()),
+                    Transform::from_translation(pos).with_scale(Vec3::ONE * 5.0),
                     CircleCollider::new(particle_radius.adjust_precision()),
                 ));
             }
@@ -190,16 +184,13 @@ fn setup(
     for x in -x_count / 2..x_count / 2 {
         for y in -y_count / 2..y_count / 2 {
             commands.spawn((
-                MaterialMesh2dBundle {
-                    mesh: particle_mesh.clone().into(),
-                    material: blue.clone(),
-                    transform: Transform::from_xyz(
-                        x as f32 * 3.0 * particle_radius - 350.0,
-                        y as f32 * 3.0 * particle_radius,
-                        0.0,
-                    ),
-                    ..default()
-                },
+                Mesh2d(particle_mesh.clone()),
+                MeshMaterial2d(blue.clone()),
+                Transform::from_xyz(
+                    x as f32 * 3.0 * particle_radius - 350.0,
+                    y as f32 * 3.0 * particle_radius,
+                    0.0,
+                ),
                 RigidBody::Dynamic,
                 CircleCollider::new(particle_radius.adjust_precision()),
                 LinearDamping(0.4),
@@ -213,7 +204,7 @@ fn center_gravity(
     mut particles: Query<(&Transform, &mut LinearVelocity), Without<CenterBody>>,
     time: Res<Time>,
 ) {
-    let delta_seconds = time.delta_seconds_f64().adjust_precision();
+    let delta_seconds = time.delta_secs_f64().adjust_precision();
     for (transform, mut lin_vel) in &mut particles {
         let pos_delta = transform.translation.truncate().adjust_precision();
         let dir = -pos_delta.normalize_or_zero();
@@ -223,7 +214,7 @@ fn center_gravity(
 
 /// Rotates the center body periodically clockwise and counterclockwise.
 fn rotate(mut query: Query<&mut AngularVelocity, With<CenterBody>>, time: Res<Time>) {
-    let sin = 3.0 * time.elapsed_seconds_f64().adjust_precision().sin();
+    let sin = 3.0 * time.elapsed_secs_f64().adjust_precision().sin();
     for mut ang_vel in &mut query {
         ang_vel.0 = sin;
     }

--- a/crates/avian2d/examples/distance_joint_2d.rs
+++ b/crates/avian2d/examples/distance_joint_2d.rs
@@ -17,7 +17,7 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let square_sprite = Sprite {
         color: Color::srgb(0.2, 0.7, 0.9),
@@ -26,22 +26,13 @@ fn setup(mut commands: Commands) {
     };
 
     let anchor = commands
-        .spawn((
-            SpriteBundle {
-                sprite: square_sprite.clone(),
-                ..default()
-            },
-            RigidBody::Kinematic,
-        ))
+        .spawn((square_sprite.clone(), RigidBody::Kinematic))
         .id();
 
     let object = commands
         .spawn((
-            SpriteBundle {
-                sprite: square_sprite,
-                transform: Transform::from_xyz(100.0, 0.0, 0.0),
-                ..default()
-            },
+            square_sprite,
+            Transform::from_xyz(100.0, 0.0, 0.0),
             RigidBody::Dynamic,
             MassPropertiesBundle::new_computed(&Collider::rectangle(50.0, 50.0), 1.0),
         ))

--- a/crates/avian2d/examples/dynamic_character_2d/main.rs
+++ b/crates/avian2d/examples/dynamic_character_2d/main.rs
@@ -16,7 +16,6 @@ use avian2d::{math::*, prelude::*};
 use bevy::{
     prelude::*,
     render::{render_asset::RenderAssetUsages, render_resource::PrimitiveTopology},
-    sprite::MaterialMesh2dBundle,
 };
 use examples_common_2d::ExampleCommonPlugin;
 use plugin::*;
@@ -44,12 +43,9 @@ fn setup(
 ) {
     // Player
     commands.spawn((
-        MaterialMesh2dBundle {
-            mesh: meshes.add(Capsule2d::new(12.5, 20.0)).into(),
-            material: materials.add(Color::srgb(0.2, 0.7, 0.9)),
-            transform: Transform::from_xyz(0.0, -100.0, 0.0),
-            ..default()
-        },
+        Mesh2d(meshes.add(Capsule2d::new(12.5, 20.0))),
+        MeshMaterial2d(materials.add(Color::srgb(0.2, 0.7, 0.9))),
+        Transform::from_xyz(0.0, -100.0, 0.0),
         CharacterControllerBundle::new(Collider::capsule(12.5, 20.0)).with_movement(
             1250.0,
             0.92,
@@ -64,82 +60,64 @@ fn setup(
 
     // A cube to move around
     commands.spawn((
-        SpriteBundle {
-            sprite: Sprite {
-                color: Color::srgb(0.0, 0.4, 0.7),
-                custom_size: Some(Vec2::new(30.0, 30.0)),
-                ..default()
-            },
-            transform: Transform::from_xyz(50.0, -100.0, 0.0),
+        Sprite {
+            color: Color::srgb(0.0, 0.4, 0.7),
+            custom_size: Some(Vec2::new(30.0, 30.0)),
             ..default()
         },
+        Transform::from_xyz(50.0, -100.0, 0.0),
         RigidBody::Dynamic,
         Collider::rectangle(30.0, 30.0),
     ));
 
     // Platforms
     commands.spawn((
-        SpriteBundle {
-            sprite: Sprite {
-                color: Color::srgb(0.7, 0.7, 0.8),
-                custom_size: Some(Vec2::new(1100.0, 50.0)),
-                ..default()
-            },
-            transform: Transform::from_xyz(0.0, -175.0, 0.0),
+        Sprite {
+            color: Color::srgb(0.7, 0.7, 0.8),
+            custom_size: Some(Vec2::new(1100.0, 50.0)),
             ..default()
         },
+        Transform::from_xyz(0.0, -175.0, 0.0),
         RigidBody::Static,
         Collider::rectangle(1100.0, 50.0),
     ));
     commands.spawn((
-        SpriteBundle {
-            sprite: Sprite {
-                color: Color::srgb(0.7, 0.7, 0.8),
-                custom_size: Some(Vec2::new(300.0, 25.0)),
-                ..default()
-            },
-            transform: Transform::from_xyz(175.0, -35.0, 0.0),
+        Sprite {
+            color: Color::srgb(0.7, 0.7, 0.8),
+            custom_size: Some(Vec2::new(300.0, 25.0)),
             ..default()
         },
+        Transform::from_xyz(175.0, -35.0, 0.0),
         RigidBody::Static,
         Collider::rectangle(300.0, 25.0),
     ));
     commands.spawn((
-        SpriteBundle {
-            sprite: Sprite {
-                color: Color::srgb(0.7, 0.7, 0.8),
-                custom_size: Some(Vec2::new(300.0, 25.0)),
-                ..default()
-            },
-            transform: Transform::from_xyz(-175.0, 0.0, 0.0),
+        Sprite {
+            color: Color::srgb(0.7, 0.7, 0.8),
+            custom_size: Some(Vec2::new(300.0, 25.0)),
             ..default()
         },
+        Transform::from_xyz(-175.0, 0.0, 0.0),
         RigidBody::Static,
         Collider::rectangle(300.0, 25.0),
     ));
     commands.spawn((
-        SpriteBundle {
-            sprite: Sprite {
-                color: Color::srgb(0.7, 0.7, 0.8),
-                custom_size: Some(Vec2::new(150.0, 80.0)),
-                ..default()
-            },
-            transform: Transform::from_xyz(475.0, -110.0, 0.0),
+        Sprite {
+            color: Color::srgb(0.7, 0.7, 0.8),
+            custom_size: Some(Vec2::new(150.0, 80.0)),
             ..default()
         },
+        Transform::from_xyz(475.0, -110.0, 0.0),
         RigidBody::Static,
         Collider::rectangle(150.0, 80.0),
     ));
     commands.spawn((
-        SpriteBundle {
-            sprite: Sprite {
-                color: Color::srgb(0.7, 0.7, 0.8),
-                custom_size: Some(Vec2::new(150.0, 80.0)),
-                ..default()
-            },
-            transform: Transform::from_xyz(-475.0, -110.0, 0.0),
+        Sprite {
+            color: Color::srgb(0.7, 0.7, 0.8),
+            custom_size: Some(Vec2::new(150.0, 80.0)),
             ..default()
         },
+        Transform::from_xyz(-475.0, -110.0, 0.0),
         RigidBody::Static,
         Collider::rectangle(150.0, 80.0),
     ));
@@ -163,12 +141,9 @@ fn setup(
     );
 
     commands.spawn((
-        MaterialMesh2dBundle {
-            mesh: meshes.add(ramp_mesh).into(),
-            material: materials.add(Color::srgb(0.4, 0.4, 0.5)),
-            transform: Transform::from_xyz(-275.0, -150.0, 0.0),
-            ..default()
-        },
+        Mesh2d(meshes.add(ramp_mesh)),
+        MeshMaterial2d(materials.add(Color::srgb(0.4, 0.4, 0.5))),
+        Transform::from_xyz(-275.0, -150.0, 0.0),
         RigidBody::Static,
         ramp_collider,
     ));
@@ -190,16 +165,13 @@ fn setup(
     );
 
     commands.spawn((
-        MaterialMesh2dBundle {
-            mesh: meshes.add(ramp_mesh).into(),
-            material: materials.add(Color::srgb(0.4, 0.4, 0.5)),
-            transform: Transform::from_xyz(380.0, -110.0, 0.0),
-            ..default()
-        },
+        Mesh2d(meshes.add(ramp_mesh)),
+        MeshMaterial2d(materials.add(Color::srgb(0.4, 0.4, 0.5))),
+        Transform::from_xyz(380.0, -110.0, 0.0),
         RigidBody::Static,
         ramp_collider,
     ));
 
     // Camera
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 }

--- a/crates/avian2d/examples/dynamic_character_2d/plugin.rs
+++ b/crates/avian2d/examples/dynamic_character_2d/plugin.rs
@@ -147,26 +147,14 @@ fn keyboard_input(
 /// Sends [`MovementAction`] events based on gamepad input.
 fn gamepad_input(
     mut movement_event_writer: EventWriter<MovementAction>,
-    gamepads: Res<Gamepads>,
-    axes: Res<Axis<GamepadAxis>>,
-    buttons: Res<ButtonInput<GamepadButton>>,
+    gamepads: Query<&Gamepad>,
 ) {
     for gamepad in gamepads.iter() {
-        let axis_lx = GamepadAxis {
-            gamepad,
-            axis_type: GamepadAxisType::LeftStickX,
-        };
-
-        if let Some(x) = axes.get(axis_lx) {
+        if let Some(x) = gamepad.get(GamepadAxis::LeftStickX) {
             movement_event_writer.send(MovementAction::Move(x as Scalar));
         }
 
-        let jump_button = GamepadButton {
-            gamepad,
-            button_type: GamepadButtonType::South,
-        };
-
-        if buttons.just_pressed(jump_button) {
+        if gamepad.just_pressed(GamepadButton::South) {
             movement_event_writer.send(MovementAction::Jump);
         }
     }
@@ -185,7 +173,7 @@ fn update_grounded(
         // that isn't too steep.
         let is_grounded = hits.iter().any(|hit| {
             if let Some(angle) = max_slope_angle {
-                (rotation * -hit.normal2).angle_between(Vector::Y).abs() <= angle.0
+                (rotation * -hit.normal2).angle_to(Vector::Y).abs() <= angle.0
             } else {
                 true
             }
@@ -212,7 +200,7 @@ fn movement(
 ) {
     // Precision is adjusted so that the example works with
     // both the `f32` and `f64` features. Otherwise you don't need this.
-    let delta_time = time.delta_seconds_f64().adjust_precision();
+    let delta_time = time.delta_secs_f64().adjust_precision();
 
     for event in movement_event_reader.read() {
         for (movement_acceleration, jump_impulse, mut linear_velocity, is_grounded) in

--- a/crates/avian2d/examples/fixed_joint_2d.rs
+++ b/crates/avian2d/examples/fixed_joint_2d.rs
@@ -17,7 +17,7 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let square_sprite = Sprite {
         color: Color::srgb(0.2, 0.7, 0.9),
@@ -27,10 +27,7 @@ fn setup(mut commands: Commands) {
 
     let anchor = commands
         .spawn((
-            SpriteBundle {
-                sprite: square_sprite.clone(),
-                ..default()
-            },
+            square_sprite.clone(),
             RigidBody::Kinematic,
             AngularVelocity(1.5),
         ))
@@ -38,11 +35,8 @@ fn setup(mut commands: Commands) {
 
     let object = commands
         .spawn((
-            SpriteBundle {
-                sprite: square_sprite,
-                transform: Transform::from_xyz(100.0, 0.0, 0.0),
-                ..default()
-            },
+            square_sprite,
+            Transform::from_xyz(100.0, 0.0, 0.0),
             RigidBody::Dynamic,
             MassPropertiesBundle::new_computed(&Collider::rectangle(50.0, 50.0), 1.0),
         ))

--- a/crates/avian2d/examples/kinematic_character_2d/main.rs
+++ b/crates/avian2d/examples/kinematic_character_2d/main.rs
@@ -26,7 +26,6 @@ use avian2d::{math::*, prelude::*};
 use bevy::{
     prelude::*,
     render::{render_asset::RenderAssetUsages, render_resource::PrimitiveTopology},
-    sprite::MaterialMesh2dBundle,
 };
 use examples_common_2d::ExampleCommonPlugin;
 use plugin::*;
@@ -54,94 +53,73 @@ fn setup(
 ) {
     // Player
     commands.spawn((
-        MaterialMesh2dBundle {
-            mesh: meshes.add(Capsule2d::new(12.5, 20.0)).into(),
-            material: materials.add(Color::srgb(0.2, 0.7, 0.9)),
-            transform: Transform::from_xyz(0.0, -100.0, 0.0),
-            ..default()
-        },
+        Mesh2d(meshes.add(Capsule2d::new(12.5, 20.0))),
+        MeshMaterial2d(materials.add(Color::srgb(0.2, 0.7, 0.9))),
+        Transform::from_xyz(0.0, -100.0, 0.0),
         CharacterControllerBundle::new(Collider::capsule(12.5, 20.0), Vector::NEG_Y * 1500.0)
             .with_movement(1250.0, 0.92, 400.0, (30.0 as Scalar).to_radians()),
     ));
 
     // A cube to move around
     commands.spawn((
-        SpriteBundle {
-            sprite: Sprite {
-                color: Color::srgb(0.0, 0.4, 0.7),
-                custom_size: Some(Vec2::new(30.0, 30.0)),
-                ..default()
-            },
-            transform: Transform::from_xyz(50.0, -100.0, 0.0),
+        Sprite {
+            color: Color::srgb(0.0, 0.4, 0.7),
+            custom_size: Some(Vec2::new(30.0, 30.0)),
             ..default()
         },
+        Transform::from_xyz(50.0, -100.0, 0.0),
         RigidBody::Dynamic,
         Collider::rectangle(30.0, 30.0),
     ));
 
     // Platforms
     commands.spawn((
-        SpriteBundle {
-            sprite: Sprite {
-                color: Color::srgb(0.7, 0.7, 0.8),
-                custom_size: Some(Vec2::new(1100.0, 50.0)),
-                ..default()
-            },
-            transform: Transform::from_xyz(0.0, -175.0, 0.0),
+        Sprite {
+            color: Color::srgb(0.7, 0.7, 0.8),
+            custom_size: Some(Vec2::new(1100.0, 50.0)),
             ..default()
         },
+        Transform::from_xyz(0.0, -175.0, 0.0),
         RigidBody::Static,
         Collider::rectangle(1100.0, 50.0),
     ));
     commands.spawn((
-        SpriteBundle {
-            sprite: Sprite {
-                color: Color::srgb(0.7, 0.7, 0.8),
-                custom_size: Some(Vec2::new(300.0, 25.0)),
-                ..default()
-            },
-            transform: Transform::from_xyz(175.0, -35.0, 0.0),
+        Sprite {
+            color: Color::srgb(0.7, 0.7, 0.8),
+            custom_size: Some(Vec2::new(300.0, 25.0)),
             ..default()
         },
+        Transform::from_xyz(175.0, -35.0, 0.0),
         RigidBody::Static,
         Collider::rectangle(300.0, 25.0),
     ));
     commands.spawn((
-        SpriteBundle {
-            sprite: Sprite {
-                color: Color::srgb(0.7, 0.7, 0.8),
-                custom_size: Some(Vec2::new(300.0, 25.0)),
-                ..default()
-            },
-            transform: Transform::from_xyz(-175.0, 0.0, 0.0),
+        Sprite {
+            color: Color::srgb(0.7, 0.7, 0.8),
+            custom_size: Some(Vec2::new(300.0, 25.0)),
             ..default()
         },
+        Transform::from_xyz(-175.0, 0.0, 0.0),
         RigidBody::Static,
         Collider::rectangle(300.0, 25.0),
     ));
     commands.spawn((
-        SpriteBundle {
-            sprite: Sprite {
-                color: Color::srgb(0.7, 0.7, 0.8),
-                custom_size: Some(Vec2::new(150.0, 80.0)),
-                ..default()
-            },
-            transform: Transform::from_xyz(475.0, -110.0, 0.0),
+        Sprite {
+            color: Color::srgb(0.7, 0.7, 0.8),
+            custom_size: Some(Vec2::new(150.0, 80.0)),
             ..default()
         },
+        Transform::from_xyz(475.0, -110.0, 0.0),
         RigidBody::Static,
         Collider::rectangle(150.0, 80.0),
     ));
     commands.spawn((
-        SpriteBundle {
-            sprite: Sprite {
-                color: Color::srgb(0.7, 0.7, 0.8),
-                custom_size: Some(Vec2::new(150.0, 80.0)),
-                ..default()
-            },
-            transform: Transform::from_xyz(-475.0, -110.0, 0.0),
+        Sprite {
+            color: Color::srgb(0.7, 0.7, 0.8),
+            custom_size: Some(Vec2::new(150.0, 80.0)),
             ..default()
         },
+        Transform::from_xyz(-475.0, -110.0, 0.0),
         RigidBody::Static,
         Collider::rectangle(150.0, 80.0),
     ));
@@ -165,12 +143,9 @@ fn setup(
     );
 
     commands.spawn((
-        MaterialMesh2dBundle {
-            mesh: meshes.add(ramp_mesh).into(),
-            material: materials.add(Color::srgb(0.4, 0.4, 0.5)),
-            transform: Transform::from_xyz(-275.0, -150.0, 0.0),
-            ..default()
-        },
+        Mesh2d(meshes.add(ramp_mesh)),
+        MeshMaterial2d(materials.add(Color::srgb(0.4, 0.4, 0.5))),
+        Transform::from_xyz(-275.0, -150.0, 0.0),
         RigidBody::Static,
         ramp_collider,
     ));
@@ -192,16 +167,13 @@ fn setup(
     );
 
     commands.spawn((
-        MaterialMesh2dBundle {
-            mesh: meshes.add(ramp_mesh).into(),
-            material: materials.add(Color::srgb(0.4, 0.4, 0.5)),
-            transform: Transform::from_xyz(380.0, -110.0, 0.0),
-            ..default()
-        },
+        Mesh2d(meshes.add(ramp_mesh)),
+        MeshMaterial2d(materials.add(Color::srgb(0.4, 0.4, 0.5))),
+        Transform::from_xyz(380.0, -110.0, 0.0),
         RigidBody::Static,
         ramp_collider,
     ));
 
     // Camera
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 }

--- a/crates/avian2d/examples/kinematic_character_2d/plugin.rs
+++ b/crates/avian2d/examples/kinematic_character_2d/plugin.rs
@@ -161,26 +161,14 @@ fn keyboard_input(
 /// Sends [`MovementAction`] events based on gamepad input.
 fn gamepad_input(
     mut movement_event_writer: EventWriter<MovementAction>,
-    gamepads: Res<Gamepads>,
-    axes: Res<Axis<GamepadAxis>>,
-    buttons: Res<ButtonInput<GamepadButton>>,
+    gamepads: Query<&Gamepad>,
 ) {
     for gamepad in gamepads.iter() {
-        let axis_lx = GamepadAxis {
-            gamepad,
-            axis_type: GamepadAxisType::LeftStickX,
-        };
-
-        if let Some(x) = axes.get(axis_lx) {
+        if let Some(x) = gamepad.get(GamepadAxis::LeftStickX) {
             movement_event_writer.send(MovementAction::Move(x as Scalar));
         }
 
-        let jump_button = GamepadButton {
-            gamepad,
-            button_type: GamepadButtonType::South,
-        };
-
-        if buttons.just_pressed(jump_button) {
+        if gamepad.just_pressed(GamepadButton::South) {
             movement_event_writer.send(MovementAction::Jump);
         }
     }
@@ -199,7 +187,7 @@ fn update_grounded(
         // that isn't too steep.
         let is_grounded = hits.iter().any(|hit| {
             if let Some(angle) = max_slope_angle {
-                (rotation * -hit.normal2).angle_between(Vector::Y).abs() <= angle.0
+                (rotation * -hit.normal2).angle_to(Vector::Y).abs() <= angle.0
             } else {
                 true
             }
@@ -226,7 +214,7 @@ fn movement(
 ) {
     // Precision is adjusted so that the example works with
     // both the `f32` and `f64` features. Otherwise you don't need this.
-    let delta_time = time.delta_seconds_f64().adjust_precision();
+    let delta_time = time.delta_secs_f64().adjust_precision();
 
     for event in movement_event_reader.read() {
         for (movement_acceleration, jump_impulse, mut linear_velocity, is_grounded) in
@@ -253,7 +241,7 @@ fn apply_gravity(
 ) {
     // Precision is adjusted so that the example works with
     // both the `f32` and `f64` features. Otherwise you don't need this.
-    let delta_time = time.delta_seconds_f64().adjust_precision();
+    let delta_time = time.delta_secs_f64().adjust_precision();
 
     for (gravity, mut linear_velocity) in &mut controllers {
         linear_velocity.0 += gravity.0 * delta_time;
@@ -356,7 +344,7 @@ fn kinematic_controller_collisions(
             }
 
             // Determine if the slope is climbable or if it's too steep to walk on.
-            let slope_angle = normal.angle_between(Vector::Y);
+            let slope_angle = normal.angle_to(Vector::Y);
             let climbable = max_slope_angle.is_some_and(|angle| slope_angle.abs() <= angle.0);
 
             if deepest_penetration > 0.0 {
@@ -416,8 +404,8 @@ fn kinematic_controller_collisions(
                 }
 
                 // Compute the impulse to apply.
-                let impulse_magnitude = normal_speed
-                    - (deepest_penetration / time.delta_seconds_f64().adjust_precision());
+                let impulse_magnitude =
+                    normal_speed - (deepest_penetration / time.delta_secs_f64().adjust_precision());
                 let mut impulse = impulse_magnitude * normal;
 
                 // Apply the impulse differently depending on the slope angle.

--- a/crates/avian2d/examples/many_shapes.rs
+++ b/crates/avian2d/examples/many_shapes.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::unnecessary_cast)]
 
 use avian2d::{math::*, prelude::*};
-use bevy::{prelude::*, sprite::MaterialMesh2dBundle};
+use bevy::prelude::*;
 use examples_common_2d::ExampleCommonPlugin;
 
 fn main() {
@@ -28,7 +28,7 @@ fn setup(
     mut materials: ResMut<Assets<ColorMaterial>>,
     mut meshes: ResMut<Assets<Mesh>>,
 ) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let square_sprite = Sprite {
         color: Color::srgb(0.7, 0.7, 0.8),
@@ -38,45 +38,29 @@ fn setup(
 
     // Ceiling
     commands.spawn((
-        SpriteBundle {
-            sprite: square_sprite.clone(),
-            transform: Transform::from_xyz(0.0, 50.0 * 6.0, 0.0)
-                .with_scale(Vec3::new(20.0, 1.0, 1.0)),
-            ..default()
-        },
+        square_sprite.clone(),
+        Transform::from_xyz(0.0, 50.0 * 6.0, 0.0).with_scale(Vec3::new(20.0, 1.0, 1.0)),
         RigidBody::Static,
         Collider::rectangle(50.0, 50.0),
     ));
     // Floor
     commands.spawn((
-        SpriteBundle {
-            sprite: square_sprite.clone(),
-            transform: Transform::from_xyz(0.0, -50.0 * 6.0, 0.0)
-                .with_scale(Vec3::new(20.0, 1.0, 1.0)),
-            ..default()
-        },
+        square_sprite.clone(),
+        Transform::from_xyz(0.0, -50.0 * 6.0, 0.0).with_scale(Vec3::new(20.0, 1.0, 1.0)),
         RigidBody::Static,
         Collider::rectangle(50.0, 50.0),
     ));
     // Left wall
     commands.spawn((
-        SpriteBundle {
-            sprite: square_sprite.clone(),
-            transform: Transform::from_xyz(-50.0 * 9.5, 0.0, 0.0)
-                .with_scale(Vec3::new(1.0, 11.0, 1.0)),
-            ..default()
-        },
+        square_sprite.clone(),
+        Transform::from_xyz(-50.0 * 9.5, 0.0, 0.0).with_scale(Vec3::new(1.0, 11.0, 1.0)),
         RigidBody::Static,
         Collider::rectangle(50.0, 50.0),
     ));
     // Right wall
     commands.spawn((
-        SpriteBundle {
-            sprite: square_sprite,
-            transform: Transform::from_xyz(50.0 * 9.5, 0.0, 0.0)
-                .with_scale(Vec3::new(1.0, 11.0, 1.0)),
-            ..default()
-        },
+        square_sprite,
+        Transform::from_xyz(50.0 * 9.5, 0.0, 0.0).with_scale(Vec3::new(1.0, 11.0, 1.0)),
         RigidBody::Static,
         Collider::rectangle(50.0, 50.0),
     ));
@@ -93,22 +77,22 @@ fn setup(
     let shapes = [
         (
             circle.collider(),
-            meshes.add(circle).into(),
+            meshes.add(circle),
             materials.add(Color::srgb(0.29, 0.33, 0.64)),
         ),
         (
             rectangle.collider(),
-            meshes.add(rectangle).into(),
+            meshes.add(rectangle),
             materials.add(Color::srgb(0.47, 0.58, 0.8)),
         ),
         (
             capsule.collider(),
-            meshes.add(capsule).into(),
+            meshes.add(capsule),
             materials.add(Color::srgb(0.63, 0.75, 0.88)),
         ),
         (
             triangle.collider(),
-            meshes.add(triangle).into(),
+            meshes.add(triangle),
             materials.add(Color::srgb(0.77, 0.87, 0.97)),
         ),
     ];
@@ -117,12 +101,9 @@ fn setup(
         for y in -8_i32..8 {
             let (collider, mesh, material) = shapes[(x + y) as usize % 4].clone();
             commands.spawn((
-                MaterialMesh2dBundle {
-                    mesh,
-                    material,
-                    transform: Transform::from_xyz(x as f32 * 25.0, y as f32 * 25.0, 0.0),
-                    ..default()
-                },
+                Mesh2d(mesh),
+                MeshMaterial2d(material),
+                Transform::from_xyz(x as f32 * 25.0, y as f32 * 25.0, 0.0),
                 collider,
                 RigidBody::Dynamic,
                 Friction::new(0.1),
@@ -139,7 +120,7 @@ fn movement(
 ) {
     // Precision is adjusted so that the example works with
     // both the `f32` and `f64` features. Otherwise you don't need this.
-    let delta_time = time.delta_seconds_f64().adjust_precision();
+    let delta_time = time.delta_secs_f64().adjust_precision();
 
     for mut linear_velocity in &mut marbles {
         if keyboard_input.any_pressed([KeyCode::KeyW, KeyCode::ArrowUp]) {

--- a/crates/avian2d/examples/move_marbles.rs
+++ b/crates/avian2d/examples/move_marbles.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::unnecessary_cast)]
 
 use avian2d::{math::*, prelude::*};
-use bevy::{prelude::*, sprite::MaterialMesh2dBundle};
+use bevy::prelude::*;
 use examples_common_2d::ExampleCommonPlugin;
 
 fn main() {
@@ -28,7 +28,7 @@ fn setup(
     mut materials: ResMut<Assets<ColorMaterial>>,
     mut meshes: ResMut<Assets<Mesh>>,
 ) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let square_sprite = Sprite {
         color: Color::srgb(0.7, 0.7, 0.8),
@@ -38,45 +38,29 @@ fn setup(
 
     // Ceiling
     commands.spawn((
-        SpriteBundle {
-            sprite: square_sprite.clone(),
-            transform: Transform::from_xyz(0.0, 50.0 * 6.0, 0.0)
-                .with_scale(Vec3::new(20.0, 1.0, 1.0)),
-            ..default()
-        },
+        square_sprite.clone(),
+        Transform::from_xyz(0.0, 50.0 * 6.0, 0.0).with_scale(Vec3::new(20.0, 1.0, 1.0)),
         RigidBody::Static,
         Collider::rectangle(50.0, 50.0),
     ));
     // Floor
     commands.spawn((
-        SpriteBundle {
-            sprite: square_sprite.clone(),
-            transform: Transform::from_xyz(0.0, -50.0 * 6.0, 0.0)
-                .with_scale(Vec3::new(20.0, 1.0, 1.0)),
-            ..default()
-        },
+        square_sprite.clone(),
+        Transform::from_xyz(0.0, -50.0 * 6.0, 0.0).with_scale(Vec3::new(20.0, 1.0, 1.0)),
         RigidBody::Static,
         Collider::rectangle(50.0, 50.0),
     ));
     // Left wall
     commands.spawn((
-        SpriteBundle {
-            sprite: square_sprite.clone(),
-            transform: Transform::from_xyz(-50.0 * 9.5, 0.0, 0.0)
-                .with_scale(Vec3::new(1.0, 11.0, 1.0)),
-            ..default()
-        },
+        square_sprite.clone(),
+        Transform::from_xyz(-50.0 * 9.5, 0.0, 0.0).with_scale(Vec3::new(1.0, 11.0, 1.0)),
         RigidBody::Static,
         Collider::rectangle(50.0, 50.0),
     ));
     // Right wall
     commands.spawn((
-        SpriteBundle {
-            sprite: square_sprite,
-            transform: Transform::from_xyz(50.0 * 9.5, 0.0, 0.0)
-                .with_scale(Vec3::new(1.0, 11.0, 1.0)),
-            ..default()
-        },
+        square_sprite,
+        Transform::from_xyz(50.0 * 9.5, 0.0, 0.0).with_scale(Vec3::new(1.0, 11.0, 1.0)),
         RigidBody::Static,
         Collider::rectangle(50.0, 50.0),
     ));
@@ -89,16 +73,13 @@ fn setup(
     for x in -16..16 {
         for y in -16..16 {
             commands.spawn((
-                MaterialMesh2dBundle {
-                    mesh: marble_mesh.clone().into(),
-                    material: marble_material.clone(),
-                    transform: Transform::from_xyz(
-                        x as f32 * 2.5 * marble_radius,
-                        y as f32 * 2.5 * marble_radius,
-                        0.0,
-                    ),
-                    ..default()
-                },
+                Mesh2d(marble_mesh.clone()),
+                MeshMaterial2d(marble_material.clone()),
+                Transform::from_xyz(
+                    x as f32 * 2.5 * marble_radius,
+                    y as f32 * 2.5 * marble_radius,
+                    0.0,
+                ),
                 RigidBody::Dynamic,
                 Collider::circle(marble_radius as Scalar),
                 Marble,
@@ -114,7 +95,7 @@ fn movement(
 ) {
     // Precision is adjusted so that the example works with
     // both the `f32` and `f64` features. Otherwise you don't need this.
-    let delta_time = time.delta_seconds_f64().adjust_precision();
+    let delta_time = time.delta_secs_f64().adjust_precision();
 
     for mut linear_velocity in &mut marbles {
         if keyboard_input.any_pressed([KeyCode::KeyW, KeyCode::ArrowUp]) {

--- a/crates/avian2d/examples/one_way_platform_2d.rs
+++ b/crates/avian2d/examples/one_way_platform_2d.rs
@@ -5,7 +5,7 @@
 //! platforms by pressing Space while holding the down arrow.
 
 use avian2d::{math::*, prelude::*};
-use bevy::{prelude::*, sprite::MaterialMesh2dBundle, utils::HashSet};
+use bevy::{prelude::*, utils::HashSet};
 use examples_common_2d::ExampleCommonPlugin;
 
 fn main() {
@@ -53,7 +53,7 @@ fn setup(
     mut materials: ResMut<Assets<ColorMaterial>>,
     mut meshes: ResMut<Assets<Mesh>>,
 ) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     // For borders
     let square_sprite = Sprite {
@@ -64,45 +64,29 @@ fn setup(
 
     // Ceiling
     commands.spawn((
-        SpriteBundle {
-            sprite: square_sprite.clone(),
-            transform: Transform::from_xyz(0.0, 50.0 * 6.0, 0.0)
-                .with_scale(Vec3::new(20.0, 1.0, 1.0)),
-            ..default()
-        },
+        square_sprite.clone(),
+        Transform::from_xyz(0.0, 50.0 * 6.0, 0.0).with_scale(Vec3::new(20.0, 1.0, 1.0)),
         RigidBody::Static,
         Collider::rectangle(50.0, 50.0),
     ));
     // Floor
     commands.spawn((
-        SpriteBundle {
-            sprite: square_sprite.clone(),
-            transform: Transform::from_xyz(0.0, -50.0 * 6.0, 0.0)
-                .with_scale(Vec3::new(20.0, 1.0, 1.0)),
-            ..default()
-        },
+        square_sprite.clone(),
+        Transform::from_xyz(0.0, -50.0 * 6.0, 0.0).with_scale(Vec3::new(20.0, 1.0, 1.0)),
         RigidBody::Static,
         Collider::rectangle(50.0, 50.0),
     ));
     // Left wall
     commands.spawn((
-        SpriteBundle {
-            sprite: square_sprite.clone(),
-            transform: Transform::from_xyz(-50.0 * 9.5, 0.0, 0.0)
-                .with_scale(Vec3::new(1.0, 11.0, 1.0)),
-            ..default()
-        },
+        square_sprite.clone(),
+        Transform::from_xyz(-50.0 * 9.5, 0.0, 0.0).with_scale(Vec3::new(1.0, 11.0, 1.0)),
         RigidBody::Static,
         Collider::rectangle(50.0, 50.0),
     ));
     // Right wall
     commands.spawn((
-        SpriteBundle {
-            sprite: square_sprite,
-            transform: Transform::from_xyz(50.0 * 9.5, 0.0, 0.0)
-                .with_scale(Vec3::new(1.0, 11.0, 1.0)),
-            ..default()
-        },
+        square_sprite,
+        Transform::from_xyz(50.0 * 9.5, 0.0, 0.0).with_scale(Vec3::new(1.0, 11.0, 1.0)),
         RigidBody::Static,
         Collider::rectangle(50.0, 50.0),
     ));
@@ -117,12 +101,9 @@ fn setup(
     // Spawn some one way platforms
     for y in -2..=2 {
         commands.spawn((
-            SpriteBundle {
-                sprite: one_way_sprite.clone(),
-                transform: Transform::from_xyz(0.0, y as f32 * 16.0 * 6.0, 0.0)
-                    .with_scale(Vec3::new(10.0, 0.5, 1.0)),
-                ..default()
-            },
+            one_way_sprite.clone(),
+            Transform::from_xyz(0.0, y as f32 * 16.0 * 6.0, 0.0)
+                .with_scale(Vec3::new(10.0, 0.5, 1.0)),
             RigidBody::Static,
             Collider::rectangle(50.0, 50.0),
             OneWayPlatform::default(),
@@ -131,14 +112,12 @@ fn setup(
 
     // Spawn an actor for the user to control
     let actor_size = Vector::new(20.0, 20.0);
-    let actor_mesh = MaterialMesh2dBundle {
-        mesh: meshes.add(Rectangle::from_size(actor_size.f32())).into(),
-        material: materials.add(Color::srgb(0.2, 0.7, 0.9)),
-        ..default()
-    };
+    let actor_mesh = meshes.add(Rectangle::from_size(actor_size.f32()));
+    let actor_material = materials.add(Color::srgb(0.2, 0.7, 0.9));
 
     commands.spawn((
-        actor_mesh.clone(),
+        Mesh2d(actor_mesh),
+        MeshMaterial2d(actor_material),
         RigidBody::Dynamic,
         LockedAxes::ROTATION_LOCKED,
         Restitution::ZERO.with_combine_rule(CoefficientCombine::Min),

--- a/crates/avian2d/examples/prismatic_joint_2d.rs
+++ b/crates/avian2d/examples/prismatic_joint_2d.rs
@@ -17,7 +17,7 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let square_sprite = Sprite {
         color: Color::srgb(0.2, 0.7, 0.9),
@@ -27,10 +27,7 @@ fn setup(mut commands: Commands) {
 
     let anchor = commands
         .spawn((
-            SpriteBundle {
-                sprite: square_sprite.clone(),
-                ..default()
-            },
+            square_sprite.clone(),
             RigidBody::Kinematic,
             AngularVelocity(1.5),
         ))
@@ -38,11 +35,8 @@ fn setup(mut commands: Commands) {
 
     let object = commands
         .spawn((
-            SpriteBundle {
-                sprite: square_sprite,
-                transform: Transform::from_xyz(100.0, 0.0, 0.0),
-                ..default()
-            },
+            square_sprite,
+            Transform::from_xyz(100.0, 0.0, 0.0),
             RigidBody::Dynamic,
             MassPropertiesBundle::new_computed(&Collider::rectangle(50.0, 50.0), 1.0),
         ))

--- a/crates/avian2d/examples/ray_caster.rs
+++ b/crates/avian2d/examples/ray_caster.rs
@@ -9,7 +9,6 @@ use avian2d::{math::*, prelude::*};
 use bevy::{
     color::palettes::css::{GREEN, ORANGE_RED},
     prelude::*,
-    sprite::MaterialMesh2dBundle,
 };
 use examples_common_2d::*;
 
@@ -31,7 +30,7 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     // Spawn a perimeter of circles that the ray will be cast against
     let radius = 16.0;
@@ -42,16 +41,9 @@ fn setup(
             }
 
             commands.spawn((
-                MaterialMesh2dBundle {
-                    mesh: meshes.add(Circle::new(radius)).into(),
-                    material: materials.add(Color::srgb(0.2, 0.7, 0.9)),
-                    transform: Transform::from_xyz(
-                        x as f32 * radius * 3.0,
-                        y as f32 * radius * 3.0,
-                        0.0,
-                    ),
-                    ..default()
-                },
+                Mesh2d(meshes.add(Circle::new(radius))),
+                MeshMaterial2d(materials.add(Color::srgb(0.2, 0.7, 0.9))),
+                Transform::from_xyz(x as f32 * radius * 3.0, y as f32 * radius * 3.0, 0.0),
                 Collider::circle(radius as Scalar),
             ));
         }

--- a/crates/avian2d/examples/revolute_joint_2d.rs
+++ b/crates/avian2d/examples/revolute_joint_2d.rs
@@ -17,7 +17,7 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let square_sprite = Sprite {
         color: Color::srgb(0.2, 0.7, 0.9),
@@ -27,10 +27,7 @@ fn setup(mut commands: Commands) {
 
     let anchor = commands
         .spawn((
-            SpriteBundle {
-                sprite: square_sprite.clone(),
-                ..default()
-            },
+            square_sprite.clone(),
             RigidBody::Kinematic,
             AngularVelocity(1.5),
         ))
@@ -38,11 +35,8 @@ fn setup(mut commands: Commands) {
 
     let object = commands
         .spawn((
-            SpriteBundle {
-                sprite: square_sprite,
-                transform: Transform::from_xyz(0.0, -100.0, 0.0),
-                ..default()
-            },
+            square_sprite,
+            Transform::from_xyz(0.0, -100.0, 0.0),
             RigidBody::Dynamic,
             MassPropertiesBundle::new_computed(&Collider::rectangle(50.0, 50.0), 1.0),
         ))

--- a/crates/avian2d/examples/sensor.rs
+++ b/crates/avian2d/examples/sensor.rs
@@ -1,5 +1,5 @@
 use avian2d::{math::*, prelude::*};
-use bevy::{prelude::*, sprite::MaterialMesh2dBundle};
+use bevy::prelude::*;
 use examples_common_2d::ExampleCommonPlugin;
 
 fn main() {
@@ -46,12 +46,9 @@ fn setup(
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
     commands.spawn((
-        MaterialMesh2dBundle {
-            mesh: meshes.add(Capsule2d::new(12.5, 20.0)).into(),
-            material: materials.add(Color::srgb(0.2, 0.7, 0.9)),
-            transform: Transform::from_xyz(0.0, -100.0, 1.0),
-            ..default()
-        },
+        Mesh2d(meshes.add(Capsule2d::new(12.5, 20.0))),
+        MeshMaterial2d(materials.add(Color::srgb(0.2, 0.7, 0.9))),
+        Transform::from_xyz(0.0, -100.0, 1.0),
         Character,
         RigidBody::Dynamic,
         Collider::capsule(12.5, 20.0),
@@ -59,15 +56,12 @@ fn setup(
     ));
 
     commands.spawn((
-        SpriteBundle {
-            transform: Transform::from_xyz(0.0, 150.0, 0.0),
-            sprite: Sprite {
-                color: Color::WHITE,
-                custom_size: Some(Vec2::new(100.0, 100.0)),
-                ..default()
-            },
+        Sprite {
+            color: Color::WHITE,
+            custom_size: Some(Vec2::new(100.0, 100.0)),
             ..default()
         },
+        Transform::from_xyz(0.0, 150.0, 0.0),
         PressurePlate,
         Sensor,
         RigidBody::Static,
@@ -76,24 +70,22 @@ fn setup(
     ));
 
     commands.spawn((
-        TextBundle::from_section(
-            "Velocity: ",
-            TextStyle {
-                font_size: 16.0,
-                ..default()
-            },
-        )
-        .with_style(Style {
+        Text::new("Velocity: "),
+        TextFont {
+            font_size: 16.0,
+            ..default()
+        },
+        Node {
             position_type: PositionType::Absolute,
             bottom: Val::Px(5.0),
             left: Val::Px(5.0),
             ..default()
-        }),
+        },
         CharacterVelocityText,
         Name::new("Character Velocity Text"),
     ));
 
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 }
 
 #[derive(Event, Debug, Reflect)]
@@ -158,7 +150,7 @@ fn movement(
     mut movement_event_reader: EventReader<MovementAction>,
     mut controllers: Query<(&mut LinearVelocity, &mut Position), With<Character>>,
 ) {
-    let delta_time = time.delta_seconds_f64().adjust_precision();
+    let delta_time = time.delta_secs_f64().adjust_precision();
     for event in movement_event_reader.read() {
         for (mut linear_velocity, mut position) in &mut controllers {
             match event {
@@ -230,7 +222,7 @@ fn update_velocity_text(
         character_query.get_single(),
         pressure_plate_query.get_single(),
     ) {
-        text_query.single_mut().sections[0].value = format!(
+        text_query.single_mut().0 = format!(
             "Velocity: {:.4}, {:.4}\nCharacter sleeping:{}\nPressure plate sleeping: {}",
             velocity.x, velocity.y, character_sleeping, pressure_plate_sleeping
         );

--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -62,11 +62,9 @@ avian_derive = { path = "../avian_derive", version = "0.1" }
 bevy = { version = "0.15.0-rc.1", default-features = false }
 bevy_math = { version = "0.15.0-rc.1" }
 libm = { version = "0.2", optional = true }
-parry3d = { git = "https://github.com/Jondolf/parry.git", branch = "update_nalgebra", optional = true }
-parry3d-f64 = { git = "https://github.com/Jondolf/parry.git", branch = "update_nalgebra", optional = true }
-nalgebra = { git = "https://github.com/waywardmonkeys/nalgebra", branch = "support-glam-0.29", features = [
-    "convert-glam029",
-], optional = true }
+parry3d = { version = "0.17", optional = true }
+parry3d-f64 = { version = "0.17", optional = true }
+nalgebra = { version = "0.33", features = ["convert-glam029"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 derive_more = "0.99"
 indexmap = "2.0.0"
@@ -84,7 +82,7 @@ bevy_math = { version = "0.15.0-rc.1", features = ["approx"] }
 approx = "0.5"
 criterion = { version = "0.5", features = ["html_reports"] }
 insta = "1.0"
-bevy_mod_debugdump = "0.11"
+bevy_mod_debugdump = { git = "https://github.com/andriyDev/bevy_mod_debugdump", branch = "bevy-0.15" }
 
 [[example]]
 name = "dynamic_character_3d"

--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -59,13 +59,13 @@ bench = false
 
 [dependencies]
 avian_derive = { path = "../avian_derive", version = "0.1" }
-bevy = { version = "0.14", default-features = false }
-bevy_math = { version = "0.14" }
+bevy = { version = "0.15.0-rc.1", default-features = false }
+bevy_math = { version = "0.15.0-rc.1" }
 libm = { version = "0.2", optional = true }
-parry3d = { version = "0.15", optional = true }
-parry3d-f64 = { version = "0.15", optional = true }
-nalgebra = { version = "0.32.6", features = [
-    "convert-glam027",
+parry3d = { git = "https://github.com/Jondolf/parry.git", branch = "update_nalgebra", optional = true }
+parry3d-f64 = { git = "https://github.com/Jondolf/parry.git", branch = "update_nalgebra", optional = true }
+nalgebra = { git = "https://github.com/waywardmonkeys/nalgebra", branch = "support-glam-0.29", features = [
+    "convert-glam029",
 ], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 derive_more = "0.99"
@@ -75,10 +75,12 @@ itertools = "0.13"
 bitflags = "2.5.0"
 
 [dev-dependencies]
-bevy = { version = "0.14", default-features = false, features = ["bevy_gltf"] }
+bevy = { version = "0.15.0-rc.1", default-features = false, features = [
+    "bevy_gltf",
+] }
 examples_common_3d = { path = "../examples_common_3d" }
 benches_common_3d = { path = "../benches_common_3d" }
-bevy_math = { version = "0.14", features = ["approx"] }
+bevy_math = { version = "0.15.0-rc.1", features = ["approx"] }
 approx = "0.5"
 criterion = { version = "0.5", features = ["html_reports"] }
 insta = "1.0"

--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -59,8 +59,8 @@ bench = false
 
 [dependencies]
 avian_derive = { path = "../avian_derive", version = "0.1" }
-bevy = { version = "0.15.0-rc.1", default-features = false }
-bevy_math = { version = "0.15.0-rc.1" }
+bevy = { version = "0.15.0-rc", default-features = false }
+bevy_math = { version = "0.15.0-rc" }
 libm = { version = "0.2", optional = true }
 parry3d = { version = "0.17", optional = true }
 parry3d-f64 = { version = "0.17", optional = true }
@@ -73,12 +73,12 @@ itertools = "0.13"
 bitflags = "2.5.0"
 
 [dev-dependencies]
-bevy = { version = "0.15.0-rc.1", default-features = false, features = [
+bevy = { version = "0.15.0-rc", default-features = false, features = [
     "bevy_gltf",
 ] }
 examples_common_3d = { path = "../examples_common_3d" }
 benches_common_3d = { path = "../benches_common_3d" }
-bevy_math = { version = "0.15.0-rc.1", features = ["approx"] }
+bevy_math = { version = "0.15.0-rc", features = ["approx"] }
 approx = "0.5"
 criterion = { version = "0.5", features = ["html_reports"] }
 insta = "1.0"

--- a/crates/avian3d/examples/cast_ray_predicate.rs
+++ b/crates/avian3d/examples/cast_ray_predicate.rs
@@ -12,7 +12,6 @@ fn main() {
             PhysicsPlugins::default(),
         ))
         .insert_resource(ClearColor(Color::srgb(0.05, 0.05, 0.1)))
-        .insert_resource(Msaa::Sample4)
         .add_systems(Startup, setup)
         .add_systems(Update, (movement, reset_colors, raycast).chain())
         .run();
@@ -41,12 +40,9 @@ fn setup(
 
     // Ground
     commands.spawn((
-        PbrBundle {
-            mesh: cube_mesh.clone(),
-            material: materials.add(Color::srgb(0.7, 0.7, 0.8)),
-            transform: Transform::from_xyz(0.0, -2.0, 0.0).with_scale(Vec3::new(100.0, 1.0, 100.0)),
-            ..default()
-        },
+        Mesh3d(cube_mesh.clone()),
+        MeshMaterial3d(materials.add(Color::srgb(0.7, 0.7, 0.8))),
+        Transform::from_xyz(0.0, -2.0, 0.0).with_scale(Vec3::new(100.0, 1.0, 100.0)),
         RigidBody::Static,
         Collider::cuboid(1.0, 1.0, 1.0),
     ));
@@ -64,13 +60,9 @@ fn setup(
                     CUBE_COLOR.into()
                 };
                 commands.spawn((
-                    PbrBundle {
-                        mesh: cube_mesh.clone(),
-                        material: materials.add(material.clone()),
-                        transform: Transform::from_translation(position)
-                            .with_scale(Vec3::splat(cube_size as f32)),
-                        ..default()
-                    },
+                    Mesh3d(cube_mesh.clone()),
+                    MeshMaterial3d(materials.add(material.clone())),
+                    Transform::from_translation(position).with_scale(Vec3::splat(cube_size as f32)),
                     RigidBody::Dynamic,
                     Collider::cuboid(1.0, 1.0, 1.0),
                     MovementAcceleration(10.0),
@@ -82,34 +74,28 @@ fn setup(
 
     // raycast indicator
     commands.spawn((
-        PbrBundle {
-            mesh: cube_mesh.clone(),
-            material: materials.add(Color::srgb(1.0, 0.0, 0.0)),
-            transform: Transform::from_xyz(-500.0, 2.0, 0.0)
-                .with_scale(Vec3::new(1000.0, 0.1, 0.1)),
-            ..default()
-        },
+        Mesh3d(cube_mesh.clone()),
+        MeshMaterial3d(materials.add(Color::srgb(1.0, 0.0, 0.0))),
+        Transform::from_xyz(-500.0, 2.0, 0.0).with_scale(Vec3::new(1000.0, 0.1, 0.1)),
         RayIndicator,
         NotShadowReceiver,
     ));
 
     // Directional light
-    commands.spawn(DirectionalLightBundle {
-        directional_light: DirectionalLight {
+    commands.spawn((
+        DirectionalLight {
             illuminance: 5000.0,
             shadows_enabled: true,
             ..default()
         },
-        transform: Transform::default().looking_at(Vec3::new(-1.0, -2.5, -1.5), Vec3::Y),
-        ..default()
-    });
+        Transform::default().looking_at(Vec3::new(-1.0, -2.5, -1.5), Vec3::Y),
+    ));
 
     // Camera
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_translation(Vec3::new(0.0, 12.0, 40.0))
-            .looking_at(Vec3::Y * 5.0, Vec3::Y),
-        ..default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_translation(Vec3::new(0.0, 12.0, 40.0)).looking_at(Vec3::Y * 5.0, Vec3::Y),
+    ));
 }
 
 fn movement(
@@ -119,7 +105,7 @@ fn movement(
 ) {
     // Precision is adjusted so that the example works with
     // both the `f32` and `f64` features. Otherwise you don't need this.
-    let delta_time = time.delta_seconds_f64().adjust_precision();
+    let delta_time = time.delta_secs_f64().adjust_precision();
 
     for (movement_acceleration, mut linear_velocity) in &mut query {
         let up = keyboard_input.any_pressed([KeyCode::KeyW, KeyCode::ArrowUp]);
@@ -142,7 +128,7 @@ fn movement(
 
 fn reset_colors(
     mut materials: ResMut<Assets<StandardMaterial>>,
-    cubes: Query<(&Handle<StandardMaterial>, &OutOfGlass)>,
+    cubes: Query<(&MeshMaterial3d<StandardMaterial>, &OutOfGlass)>,
 ) {
     for (material_handle, out_of_glass) in cubes.iter() {
         if let Some(material) = materials.get_mut(material_handle) {
@@ -158,7 +144,7 @@ fn reset_colors(
 fn raycast(
     query: SpatialQuery,
     mut materials: ResMut<Assets<StandardMaterial>>,
-    cubes: Query<(&Handle<StandardMaterial>, &OutOfGlass)>,
+    cubes: Query<(&MeshMaterial3d<StandardMaterial>, &OutOfGlass)>,
     mut indicator_transform: Query<&mut Transform, With<RayIndicator>>,
 ) {
     let origin = Vector::new(-200.0, 2.0, 0.0);

--- a/crates/avian3d/examples/collider_constructors.rs
+++ b/crates/avian3d/examples/collider_constructors.rs
@@ -24,24 +24,18 @@ fn setup(
 ) {
     // Spawn ground and generate a collider for the mesh using ColliderConstructor
     commands.spawn((
-        PbrBundle {
-            mesh: meshes.add(Plane3d::default().mesh().size(8.0, 8.0)),
-            material: materials.add(Color::srgb(0.3, 0.5, 0.3)),
-            ..default()
-        },
+        Mesh3d(meshes.add(Plane3d::default().mesh().size(8.0, 8.0))),
+        MeshMaterial3d(materials.add(Color::srgb(0.3, 0.5, 0.3))),
         ColliderConstructor::TrimeshFromMesh,
         RigidBody::Static,
     ));
 
     // Spawn Ferris the crab and generate colliders for the scene using ColliderConstructorHierarchy
     commands.spawn((
-        SceneBundle {
-            // The model was made by RayMarch, licenced under CC0-1.0, and can be found here:
-            // https://github.com/RayMarch/ferris3d
-            scene: assets.load("ferris.glb#Scene0"),
-            transform: Transform::from_xyz(0.0, 1.0, 0.0).with_scale(Vec3::splat(2.0)),
-            ..default()
-        },
+        // The model was made by RayMarch, licenced under CC0-1.0, and can be found here:
+        // https://github.com/RayMarch/ferris3d
+        SceneRoot(assets.load("ferris.glb#Scene0")),
+        Transform::from_xyz(0.0, 1.0, 0.0).with_scale(Vec3::splat(2.0)),
         // Create colliders using convex decomposition.
         // This takes longer than creating a trimesh or convex hull collider,
         // but is more performant for collision detection.
@@ -53,19 +47,18 @@ fn setup(
     ));
 
     // Light
-    commands.spawn(PointLightBundle {
-        point_light: PointLight {
+    commands.spawn((
+        PointLight {
             intensity: 1_000_000.0,
             shadows_enabled: true,
             ..default()
         },
-        transform: Transform::from_xyz(2.0, 8.0, 2.0),
-        ..default()
-    });
+        Transform::from_xyz(2.0, 8.0, 2.0),
+    ));
 
     // Camera
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(-5.0, 3.5, 5.5).looking_at(Vec3::ZERO, Vec3::Y),
-        ..default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(-5.0, 3.5, 5.5).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
 }

--- a/crates/avian3d/examples/cubes.rs
+++ b/crates/avian3d/examples/cubes.rs
@@ -12,7 +12,6 @@ fn main() {
             PhysicsPlugins::default(),
         ))
         .insert_resource(ClearColor(Color::srgb(0.05, 0.05, 0.1)))
-        .insert_resource(Msaa::Sample4)
         .add_systems(Startup, setup)
         .add_systems(Update, movement)
         .run();
@@ -31,12 +30,9 @@ fn setup(
 
     // Ground
     commands.spawn((
-        PbrBundle {
-            mesh: cube_mesh.clone(),
-            material: materials.add(Color::srgb(0.7, 0.7, 0.8)),
-            transform: Transform::from_xyz(0.0, -2.0, 0.0).with_scale(Vec3::new(100.0, 1.0, 100.0)),
-            ..default()
-        },
+        Mesh3d(cube_mesh.clone()),
+        MeshMaterial3d(materials.add(Color::srgb(0.7, 0.7, 0.8))),
+        Transform::from_xyz(0.0, -2.0, 0.0).with_scale(Vec3::new(100.0, 1.0, 100.0)),
         RigidBody::Static,
         Collider::cuboid(1.0, 1.0, 1.0),
     ));
@@ -49,13 +45,9 @@ fn setup(
             for z in -2..2 {
                 let position = Vec3::new(x as f32, y as f32 + 3.0, z as f32) * (cube_size + 0.05);
                 commands.spawn((
-                    PbrBundle {
-                        mesh: cube_mesh.clone(),
-                        material: materials.add(Color::srgb(0.2, 0.7, 0.9)),
-                        transform: Transform::from_translation(position)
-                            .with_scale(Vec3::splat(cube_size as f32)),
-                        ..default()
-                    },
+                    Mesh3d(cube_mesh.clone()),
+                    MeshMaterial3d(materials.add(Color::srgb(0.2, 0.7, 0.9))),
+                    Transform::from_translation(position).with_scale(Vec3::splat(cube_size as f32)),
                     RigidBody::Dynamic,
                     Collider::cuboid(1.0, 1.0, 1.0),
                     MovementAcceleration(10.0),
@@ -65,22 +57,20 @@ fn setup(
     }
 
     // Directional light
-    commands.spawn(DirectionalLightBundle {
-        directional_light: DirectionalLight {
+    commands.spawn((
+        DirectionalLight {
             illuminance: 5000.0,
             shadows_enabled: true,
             ..default()
         },
-        transform: Transform::default().looking_at(Vec3::new(-1.0, -2.5, -1.5), Vec3::Y),
-        ..default()
-    });
+        Transform::default().looking_at(Vec3::new(-1.0, -2.5, -1.5), Vec3::Y),
+    ));
 
     // Camera
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_translation(Vec3::new(0.0, 12.0, 40.0))
-            .looking_at(Vec3::Y * 5.0, Vec3::Y),
-        ..default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_translation(Vec3::new(0.0, 12.0, 40.0)).looking_at(Vec3::Y * 5.0, Vec3::Y),
+    ));
 }
 
 fn movement(
@@ -90,7 +80,7 @@ fn movement(
 ) {
     // Precision is adjusted so that the example works with
     // both the `f32` and `f64` features. Otherwise you don't need this.
-    let delta_time = time.delta_seconds_f64().adjust_precision();
+    let delta_time = time.delta_secs_f64().adjust_precision();
 
     for (movement_acceleration, mut linear_velocity) in &mut query {
         let up = keyboard_input.any_pressed([KeyCode::KeyW, KeyCode::ArrowUp]);

--- a/crates/avian3d/examples/custom_broad_phase.rs
+++ b/crates/avian3d/examples/custom_broad_phase.rs
@@ -26,41 +26,34 @@ fn setup(
 ) {
     // Plane
     commands.spawn((
-        PbrBundle {
-            mesh: meshes.add(Plane3d::default().mesh().size(8.0, 8.0)),
-            material: materials.add(Color::srgb(0.3, 0.5, 0.3)),
-            ..default()
-        },
+        Mesh3d(meshes.add(Plane3d::default().mesh().size(8.0, 8.0))),
+        MeshMaterial3d(materials.add(Color::srgb(0.3, 0.5, 0.3))),
         RigidBody::Static,
         Collider::cuboid(8.0, 0.002, 8.0),
     ));
     // Cube
     commands.spawn((
-        PbrBundle {
-            mesh: meshes.add(Cuboid::default()),
-            material: materials.add(Color::srgb(0.8, 0.7, 0.6)),
-            transform: Transform::from_xyz(0.0, 4.0, 0.0),
-            ..default()
-        },
+        Mesh3d(meshes.add(Cuboid::default())),
+        MeshMaterial3d(materials.add(Color::srgb(0.8, 0.7, 0.6))),
+        Transform::from_xyz(0.0, 4.0, 0.0),
         RigidBody::Dynamic,
         AngularVelocity(Vector::new(2.5, 3.4, 1.6)),
         Collider::cuboid(1.0, 1.0, 1.0),
     ));
     // Light
-    commands.spawn(PointLightBundle {
-        point_light: PointLight {
+    commands.spawn((
+        PointLight {
             intensity: 2_000_000.0,
             shadows_enabled: true,
             ..default()
         },
-        transform: Transform::from_xyz(4.0, 8.0, 4.0),
-        ..default()
-    });
+        Transform::from_xyz(4.0, 8.0, 4.0),
+    ));
     // Camera
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(-4.0, 6.5, 8.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(-4.0, 6.5, 8.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
 }
 
 // Collects pairs of potentially colliding entities into the BroadCollisionPairs resource provided by the physics engine.

--- a/crates/avian3d/examples/custom_constraint.rs
+++ b/crates/avian3d/examples/custom_constraint.rs
@@ -108,22 +108,16 @@ fn setup(
     // Spawn a static cube and a dynamic cube that is outside of the rest length
     let static_cube = commands
         .spawn((
-            PbrBundle {
-                mesh: cube_mesh.clone(),
-                material: cube_material.clone(),
-                ..default()
-            },
+            Mesh3d(cube_mesh.clone()),
+            MeshMaterial3d(cube_material.clone()),
             RigidBody::Static,
         ))
         .id();
     let dynamic_cube = commands
         .spawn((
-            PbrBundle {
-                mesh: cube_mesh,
-                material: cube_material,
-                transform: Transform::from_xyz(3.0, 3.5, 0.0),
-                ..default()
-            },
+            Mesh3d(cube_mesh),
+            MeshMaterial3d(cube_material),
+            Transform::from_xyz(3.0, 3.5, 0.0),
             RigidBody::Dynamic,
             MassPropertiesBundle::new_computed(&Collider::cuboid(1.0, 1.0, 1.0), 1.0),
         ))
@@ -140,19 +134,18 @@ fn setup(
     });
 
     // Light
-    commands.spawn(PointLightBundle {
-        point_light: PointLight {
+    commands.spawn((
+        PointLight {
             intensity: 2_000_000.0,
             shadows_enabled: true,
             ..default()
         },
-        transform: Transform::from_xyz(4.0, 8.0, 4.0),
-        ..default()
-    });
+        Transform::from_xyz(4.0, 8.0, 4.0),
+    ));
 
     // Camera
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(0.0, 0.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(0.0, 0.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
 }

--- a/crates/avian3d/examples/distance_joint_3d.rs
+++ b/crates/avian3d/examples/distance_joint_3d.rs
@@ -25,23 +25,17 @@ fn setup(
     // Spawn a static cube and a dynamic cube that is connected to it by a distance joint.
     let static_cube = commands
         .spawn((
-            PbrBundle {
-                mesh: cube_mesh.clone(),
-                material: cube_material.clone(),
-                ..default()
-            },
+            Mesh3d(cube_mesh.clone()),
+            MeshMaterial3d(cube_material.clone()),
             RigidBody::Static,
             Collider::cuboid(1., 1., 1.),
         ))
         .id();
     let dynamic_cube = commands
         .spawn((
-            PbrBundle {
-                mesh: cube_mesh,
-                material: cube_material,
-                transform: Transform::from_xyz(-2.0, -0.5, 0.0),
-                ..default()
-            },
+            Mesh3d(cube_mesh),
+            MeshMaterial3d(cube_material),
+            Transform::from_xyz(-2.0, -0.5, 0.0),
             RigidBody::Dynamic,
             Collider::cuboid(1., 1., 1.),
             MassPropertiesBundle::new_computed(&Collider::cuboid(1.0, 1.0, 1.0), 1.0),
@@ -57,19 +51,18 @@ fn setup(
     );
 
     // Light
-    commands.spawn(PointLightBundle {
-        point_light: PointLight {
+    commands.spawn((
+        PointLight {
             intensity: 2_000_000.0,
             shadows_enabled: true,
             ..default()
         },
-        transform: Transform::from_xyz(4.0, 8.0, 4.0),
-        ..default()
-    });
+        Transform::from_xyz(4.0, 8.0, 4.0),
+    ));
 
     // Camera
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(0.0, 0.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(0.0, 0.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
 }

--- a/crates/avian3d/examples/dynamic_character_3d/main.rs
+++ b/crates/avian3d/examples/dynamic_character_3d/main.rs
@@ -38,12 +38,9 @@ fn setup(
 ) {
     // Player
     commands.spawn((
-        PbrBundle {
-            mesh: meshes.add(Capsule3d::new(0.4, 1.0)),
-            material: materials.add(Color::srgb(0.8, 0.7, 0.6)),
-            transform: Transform::from_xyz(0.0, 1.5, 0.0),
-            ..default()
-        },
+        Mesh3d(meshes.add(Capsule3d::new(0.4, 1.0))),
+        MeshMaterial3d(materials.add(Color::srgb(0.8, 0.7, 0.6))),
+        Transform::from_xyz(0.0, 1.5, 0.0),
         CharacterControllerBundle::new(Collider::capsule(0.4, 1.0)).with_movement(
             30.0,
             0.92,
@@ -59,40 +56,33 @@ fn setup(
     commands.spawn((
         RigidBody::Dynamic,
         Collider::cuboid(1.0, 1.0, 1.0),
-        PbrBundle {
-            mesh: meshes.add(Cuboid::default()),
-            material: materials.add(Color::srgb(0.8, 0.7, 0.6)),
-            transform: Transform::from_xyz(3.0, 2.0, 3.0),
-            ..default()
-        },
+        Mesh3d(meshes.add(Cuboid::default())),
+        MeshMaterial3d(materials.add(Color::srgb(0.8, 0.7, 0.6))),
+        Transform::from_xyz(3.0, 2.0, 3.0),
     ));
 
     // Environment (see the `collider_constructors` example for creating colliders from scenes)
     commands.spawn((
-        SceneBundle {
-            scene: assets.load("character_controller_demo.glb#Scene0"),
-            transform: Transform::from_rotation(Quat::from_rotation_y(-std::f32::consts::PI * 0.5)),
-            ..default()
-        },
+        SceneRoot(assets.load("character_controller_demo.glb#Scene0")),
+        Transform::from_rotation(Quat::from_rotation_y(-std::f32::consts::PI * 0.5)),
         ColliderConstructorHierarchy::new(ColliderConstructor::ConvexHullFromMesh),
         RigidBody::Static,
     ));
 
     // Light
-    commands.spawn(PointLightBundle {
-        point_light: PointLight {
+    commands.spawn((
+        PointLight {
             intensity: 2_000_000.0,
             range: 50.0,
             shadows_enabled: true,
             ..default()
         },
-        transform: Transform::from_xyz(0.0, 15.0, 0.0),
-        ..default()
-    });
+        Transform::from_xyz(0.0, 15.0, 0.0),
+    ));
 
     // Camera
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(-7.0, 9.5, 15.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(-7.0, 9.5, 15.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
 }

--- a/crates/avian3d/examples/dynamic_character_3d/plugin.rs
+++ b/crates/avian3d/examples/dynamic_character_3d/plugin.rs
@@ -155,32 +155,19 @@ fn keyboard_input(
 /// Sends [`MovementAction`] events based on gamepad input.
 fn gamepad_input(
     mut movement_event_writer: EventWriter<MovementAction>,
-    gamepads: Res<Gamepads>,
-    axes: Res<Axis<GamepadAxis>>,
-    buttons: Res<ButtonInput<GamepadButton>>,
+    gamepads: Query<&Gamepad>,
 ) {
     for gamepad in gamepads.iter() {
-        let axis_lx = GamepadAxis {
-            gamepad,
-            axis_type: GamepadAxisType::LeftStickX,
-        };
-        let axis_ly = GamepadAxis {
-            gamepad,
-            axis_type: GamepadAxisType::LeftStickY,
-        };
-
-        if let (Some(x), Some(y)) = (axes.get(axis_lx), axes.get(axis_ly)) {
+        if let (Some(x), Some(y)) = (
+            gamepad.get(GamepadAxis::LeftStickX),
+            gamepad.get(GamepadAxis::LeftStickY),
+        ) {
             movement_event_writer.send(MovementAction::Move(
                 Vector2::new(x as Scalar, y as Scalar).clamp_length_max(1.0),
             ));
         }
 
-        let jump_button = GamepadButton {
-            gamepad,
-            button_type: GamepadButtonType::South,
-        };
-
-        if buttons.just_pressed(jump_button) {
+        if gamepad.just_pressed(GamepadButton::South) {
             movement_event_writer.send(MovementAction::Jump);
         }
     }
@@ -226,7 +213,7 @@ fn movement(
 ) {
     // Precision is adjusted so that the example works with
     // both the `f32` and `f64` features. Otherwise you don't need this.
-    let delta_time = time.delta_seconds_f64().adjust_precision();
+    let delta_time = time.delta_secs_f64().adjust_precision();
 
     for event in movement_event_reader.read() {
         for (movement_acceleration, jump_impulse, mut linear_velocity, is_grounded) in

--- a/crates/avian3d/examples/fixed_joint_3d.rs
+++ b/crates/avian3d/examples/fixed_joint_3d.rs
@@ -10,7 +10,6 @@ fn main() {
             PhysicsPlugins::default(),
         ))
         .insert_resource(ClearColor(Color::srgb(0.05, 0.05, 0.1)))
-        .insert_resource(Msaa::Sample4)
         .insert_resource(SubstepCount(50))
         .add_systems(Startup, setup)
         .run();
@@ -27,11 +26,8 @@ fn setup(
     // Kinematic rotating "anchor" object
     let anchor = commands
         .spawn((
-            PbrBundle {
-                mesh: cube_mesh.clone(),
-                material: cube_material.clone(),
-                ..default()
-            },
+            Mesh3d(cube_mesh.clone()),
+            MeshMaterial3d(cube_material.clone()),
             RigidBody::Kinematic,
             AngularVelocity(Vector::Z * 1.5),
         ))
@@ -40,12 +36,9 @@ fn setup(
     // Dynamic object rotating around anchor
     let object = commands
         .spawn((
-            PbrBundle {
-                mesh: cube_mesh,
-                material: cube_material,
-                transform: Transform::from_xyz(1.5, 0.0, 0.0),
-                ..default()
-            },
+            Mesh3d(cube_mesh),
+            MeshMaterial3d(cube_material),
+            Transform::from_xyz(1.5, 0.0, 0.0),
             RigidBody::Dynamic,
             MassPropertiesBundle::new_computed(&Collider::cuboid(1.0, 1.0, 1.0), 1.0),
         ))
@@ -55,19 +48,18 @@ fn setup(
     commands.spawn(FixedJoint::new(anchor, object).with_local_anchor_1(Vector::X * 1.5));
 
     // Directional light
-    commands.spawn(DirectionalLightBundle {
-        directional_light: DirectionalLight {
+    commands.spawn((
+        DirectionalLight {
             illuminance: 2000.0,
             shadows_enabled: true,
             ..default()
         },
-        transform: Transform::default().looking_at(Vec3::new(-1.0, -2.5, -1.5), Vec3::Y),
-        ..default()
-    });
+        Transform::default().looking_at(Vec3::new(-1.0, -2.5, -1.5), Vec3::Y),
+    ));
 
     // Camera
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_translation(Vec3::Z * 10.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_translation(Vec3::Z * 10.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
 }

--- a/crates/avian3d/examples/kinematic_character_3d/main.rs
+++ b/crates/avian3d/examples/kinematic_character_3d/main.rs
@@ -48,12 +48,9 @@ fn setup(
 ) {
     // Player
     commands.spawn((
-        PbrBundle {
-            mesh: meshes.add(Capsule3d::new(0.4, 1.0)),
-            material: materials.add(Color::srgb(0.8, 0.7, 0.6)),
-            transform: Transform::from_xyz(0.0, 1.5, 0.0),
-            ..default()
-        },
+        Mesh3d(meshes.add(Capsule3d::new(0.4, 1.0))),
+        MeshMaterial3d(materials.add(Color::srgb(0.8, 0.7, 0.6))),
+        Transform::from_xyz(0.0, 1.5, 0.0),
         CharacterControllerBundle::new(Collider::capsule(0.4, 1.0), Vector::NEG_Y * 9.81 * 2.0)
             .with_movement(30.0, 0.92, 7.0, (30.0 as Scalar).to_radians()),
     ));
@@ -62,40 +59,33 @@ fn setup(
     commands.spawn((
         RigidBody::Dynamic,
         Collider::cuboid(1.0, 1.0, 1.0),
-        PbrBundle {
-            mesh: meshes.add(Cuboid::default()),
-            material: materials.add(Color::srgb(0.8, 0.7, 0.6)),
-            transform: Transform::from_xyz(3.0, 2.0, 3.0),
-            ..default()
-        },
+        Mesh3d(meshes.add(Cuboid::default())),
+        MeshMaterial3d(materials.add(Color::srgb(0.8, 0.7, 0.6))),
+        Transform::from_xyz(3.0, 2.0, 3.0),
     ));
 
     // Environment (see the `collider_constructors` example for creating colliders from scenes)
     commands.spawn((
-        SceneBundle {
-            scene: assets.load("character_controller_demo.glb#Scene0"),
-            transform: Transform::from_rotation(Quat::from_rotation_y(-std::f32::consts::PI * 0.5)),
-            ..default()
-        },
+        SceneRoot(assets.load("character_controller_demo.glb#Scene0")),
+        Transform::from_rotation(Quat::from_rotation_y(-std::f32::consts::PI * 0.5)),
         ColliderConstructorHierarchy::new(ColliderConstructor::ConvexHullFromMesh),
         RigidBody::Static,
     ));
 
     // Light
-    commands.spawn(PointLightBundle {
-        point_light: PointLight {
+    commands.spawn((
+        PointLight {
             intensity: 2_000_000.0,
             range: 50.0,
             shadows_enabled: true,
             ..default()
         },
-        transform: Transform::from_xyz(0.0, 15.0, 0.0),
-        ..default()
-    });
+        Transform::from_xyz(0.0, 15.0, 0.0),
+    ));
 
     // Camera
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(-7.0, 9.5, 15.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(-7.0, 9.5, 15.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
 }

--- a/crates/avian3d/examples/kinematic_character_3d/plugin.rs
+++ b/crates/avian3d/examples/kinematic_character_3d/plugin.rs
@@ -44,6 +44,7 @@ pub struct CharacterController;
 #[derive(Component)]
 #[component(storage = "SparseSet")]
 pub struct Grounded;
+
 /// The acceleration used for character movement.
 #[derive(Component)]
 pub struct MovementAcceleration(Scalar);
@@ -169,32 +170,19 @@ fn keyboard_input(
 /// Sends [`MovementAction`] events based on gamepad input.
 fn gamepad_input(
     mut movement_event_writer: EventWriter<MovementAction>,
-    gamepads: Res<Gamepads>,
-    axes: Res<Axis<GamepadAxis>>,
-    buttons: Res<ButtonInput<GamepadButton>>,
+    gamepads: Query<&Gamepad>,
 ) {
     for gamepad in gamepads.iter() {
-        let axis_lx = GamepadAxis {
-            gamepad,
-            axis_type: GamepadAxisType::LeftStickX,
-        };
-        let axis_ly = GamepadAxis {
-            gamepad,
-            axis_type: GamepadAxisType::LeftStickY,
-        };
-
-        if let (Some(x), Some(y)) = (axes.get(axis_lx), axes.get(axis_ly)) {
+        if let (Some(x), Some(y)) = (
+            gamepad.get(GamepadAxis::LeftStickX),
+            gamepad.get(GamepadAxis::LeftStickY),
+        ) {
             movement_event_writer.send(MovementAction::Move(
                 Vector2::new(x as Scalar, y as Scalar).clamp_length_max(1.0),
             ));
         }
 
-        let jump_button = GamepadButton {
-            gamepad,
-            button_type: GamepadButtonType::South,
-        };
-
-        if buttons.just_pressed(jump_button) {
+        if gamepad.just_pressed(GamepadButton::South) {
             movement_event_writer.send(MovementAction::Jump);
         }
     }
@@ -240,7 +228,7 @@ fn movement(
 ) {
     // Precision is adjusted so that the example works with
     // both the `f32` and `f64` features. Otherwise you don't need this.
-    let delta_time = time.delta_seconds_f64().adjust_precision();
+    let delta_time = time.delta_secs_f64().adjust_precision();
 
     for event in movement_event_reader.read() {
         for (movement_acceleration, jump_impulse, mut linear_velocity, is_grounded) in
@@ -268,7 +256,7 @@ fn apply_gravity(
 ) {
     // Precision is adjusted so that the example works with
     // both the `f32` and `f64` features. Otherwise you don't need this.
-    let delta_time = time.delta_seconds_f64().adjust_precision();
+    let delta_time = time.delta_secs_f64().adjust_precision();
 
     for (gravity, mut linear_velocity) in &mut controllers {
         linear_velocity.0 += gravity.0 * delta_time;
@@ -431,8 +419,8 @@ fn kinematic_controller_collisions(
                 }
 
                 // Compute the impulse to apply.
-                let impulse_magnitude = normal_speed
-                    - (deepest_penetration / time.delta_seconds_f64().adjust_precision());
+                let impulse_magnitude =
+                    normal_speed - (deepest_penetration / time.delta_secs_f64().adjust_precision());
                 let mut impulse = impulse_magnitude * normal;
 
                 // Apply the impulse differently depending on the slope angle.

--- a/crates/avian3d/examples/prismatic_joint_3d.rs
+++ b/crates/avian3d/examples/prismatic_joint_3d.rs
@@ -10,7 +10,6 @@ fn main() {
             PhysicsPlugins::default(),
         ))
         .insert_resource(ClearColor(Color::srgb(0.05, 0.05, 0.1)))
-        .insert_resource(Msaa::Sample4)
         .insert_resource(SubstepCount(50))
         .add_systems(Startup, setup)
         .run();
@@ -27,11 +26,8 @@ fn setup(
     // Kinematic rotating "anchor" object
     let anchor = commands
         .spawn((
-            PbrBundle {
-                mesh: cube_mesh.clone(),
-                material: cube_material.clone(),
-                ..default()
-            },
+            Mesh3d(cube_mesh.clone()),
+            MeshMaterial3d(cube_material.clone()),
             RigidBody::Kinematic,
             AngularVelocity(Vector::Z * 1.5),
         ))
@@ -40,12 +36,9 @@ fn setup(
     // Dynamic object rotating around anchor
     let object = commands
         .spawn((
-            PbrBundle {
-                mesh: cube_mesh,
-                material: cube_material,
-                transform: Transform::from_xyz(1.5, 0.0, 0.0),
-                ..default()
-            },
+            Mesh3d(cube_mesh),
+            MeshMaterial3d(cube_material),
+            Transform::from_xyz(1.5, 0.0, 0.0),
             RigidBody::Dynamic,
             MassPropertiesBundle::new_computed(&Collider::cuboid(1.0, 1.0, 1.0), 1.0),
         ))
@@ -60,19 +53,18 @@ fn setup(
     );
 
     // Directional light
-    commands.spawn(DirectionalLightBundle {
-        directional_light: DirectionalLight {
+    commands.spawn((
+        DirectionalLight {
             illuminance: 2000.0,
             shadows_enabled: true,
             ..default()
         },
-        transform: Transform::default().looking_at(Vec3::new(-1.0, -2.5, -1.5), Vec3::Y),
-        ..default()
-    });
+        Transform::default().looking_at(Vec3::new(-1.0, -2.5, -1.5), Vec3::Y),
+    ));
 
     // Camera
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_translation(Vec3::Z * 10.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_translation(Vec3::Z * 10.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
 }

--- a/crates/avian3d/examples/revolute_joint_3d.rs
+++ b/crates/avian3d/examples/revolute_joint_3d.rs
@@ -10,7 +10,6 @@ fn main() {
             PhysicsPlugins::default(),
         ))
         .insert_resource(ClearColor(Color::srgb(0.05, 0.05, 0.1)))
-        .insert_resource(Msaa::Sample4)
         .insert_resource(SubstepCount(50))
         .add_systems(Startup, setup)
         .run();
@@ -27,11 +26,8 @@ fn setup(
     // Kinematic rotating "anchor" object
     let anchor = commands
         .spawn((
-            PbrBundle {
-                mesh: cube_mesh.clone(),
-                material: cube_material.clone(),
-                ..default()
-            },
+            Mesh3d(cube_mesh.clone()),
+            MeshMaterial3d(cube_material.clone()),
             RigidBody::Kinematic,
             AngularVelocity(Vector::Z * 1.5),
         ))
@@ -40,12 +36,9 @@ fn setup(
     // Dynamic object rotating around anchor
     let object = commands
         .spawn((
-            PbrBundle {
-                mesh: cube_mesh,
-                material: cube_material,
-                transform: Transform::from_xyz(0.0, -2.0, 0.0),
-                ..default()
-            },
+            Mesh3d(cube_mesh),
+            MeshMaterial3d(cube_material),
+            Transform::from_xyz(0.0, -2.0, 0.0),
             RigidBody::Dynamic,
             MassPropertiesBundle::new_computed(&Collider::cuboid(1.0, 1.0, 1.0), 1.0),
         ))
@@ -59,19 +52,18 @@ fn setup(
     );
 
     // Directional light
-    commands.spawn(DirectionalLightBundle {
-        directional_light: DirectionalLight {
+    commands.spawn((
+        DirectionalLight {
             illuminance: 2000.0,
             shadows_enabled: true,
             ..default()
         },
-        transform: Transform::default().looking_at(Vec3::new(-1.0, -2.5, -1.5), Vec3::Y),
-        ..default()
-    });
+        Transform::default().looking_at(Vec3::new(-1.0, -2.5, -1.5), Vec3::Y),
+    ));
 
     // Camera
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_translation(Vec3::Z * 10.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_translation(Vec3::Z * 10.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
 }

--- a/crates/avian3d/examples/trimesh_shapes_3d.rs
+++ b/crates/avian3d/examples/trimesh_shapes_3d.rs
@@ -52,17 +52,14 @@ fn setup(
         commands.spawn((
             RigidBody::Dynamic,
             Collider::trimesh_from_mesh(&shape).unwrap(),
-            PbrBundle {
-                mesh: meshes.add(shape),
-                material: debug_material.clone(),
-                transform: Transform::from_xyz(
-                    -10.0 / 2.0 + i as f32 / (num_shapes - 1) as f32 * 10.0,
-                    2.0,
-                    0.0,
-                )
-                .with_rotation(Quat::from_rotation_x(0.4)),
-                ..default()
-            },
+            Mesh3d(meshes.add(shape)),
+            MeshMaterial3d(debug_material.clone()),
+            Transform::from_xyz(
+                -10.0 / 2.0 + i as f32 / (num_shapes - 1) as f32 * 10.0,
+                2.0,
+                0.0,
+            )
+            .with_rotation(Quat::from_rotation_x(0.4)),
         ));
     }
 
@@ -70,31 +67,27 @@ fn setup(
     commands.spawn((
         RigidBody::Static,
         Collider::cuboid(50.0, 0.1, 50.0),
-        PbrBundle {
-            mesh: meshes.add(Plane3d::default().mesh().size(50.0, 50.0)),
-            material: materials.add(Color::from(SILVER)),
-            transform: Transform::from_xyz(0.0, -1.0, 0.0),
-            ..default()
-        },
+        Mesh3d(meshes.add(Plane3d::default().mesh().size(50.0, 50.0))),
+        MeshMaterial3d(materials.add(Color::from(SILVER))),
+        Transform::from_xyz(0.0, -1.0, 0.0),
     ));
 
     // Light
-    commands.spawn(PointLightBundle {
-        point_light: PointLight {
+    commands.spawn((
+        PointLight {
             intensity: 8_000_000.0,
             range: 100.,
             shadows_enabled: true,
             ..default()
         },
-        transform: Transform::from_xyz(8.0, 16.0, 8.0),
-        ..default()
-    });
+        Transform::from_xyz(8.0, 16.0, 8.0),
+    ));
 
     // Camera
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(0.0, 6., 12.0).looking_at(Vec3::new(0., 1., 0.), Vec3::Y),
-        ..default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(0.0, 6., 12.0).looking_at(Vec3::new(0., 1., 0.), Vec3::Y),
+    ));
 }
 
 /// Creates a colorful test pattern

--- a/crates/benches_common_2d/Cargo.toml
+++ b/crates/benches_common_2d/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = { version = "0.15.0-rc.1", default-features = false }
+bevy = { version = "0.15.0-rc", default-features = false }
 avian2d = { path = "../avian2d", default-features = false }
 criterion = "0.5"

--- a/crates/benches_common_2d/Cargo.toml
+++ b/crates/benches_common_2d/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = { version = "0.14", default-features = false }
+bevy = { version = "0.15.0-rc.1", default-features = false }
 avian2d = { path = "../avian2d", default-features = false }
 criterion = "0.5"

--- a/crates/benches_common_3d/Cargo.toml
+++ b/crates/benches_common_3d/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = { version = "0.14", default-features = false }
+bevy = { version = "0.15.0-rc.1", default-features = false }
 avian3d = { path = "../avian3d", default-features = false }
 criterion = "0.5"

--- a/crates/benches_common_3d/Cargo.toml
+++ b/crates/benches_common_3d/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = { version = "0.15.0-rc.1", default-features = false }
+bevy = { version = "0.15.0-rc", default-features = false }
 avian3d = { path = "../avian3d", default-features = false }
 criterion = "0.5"

--- a/crates/examples_common_2d/Cargo.toml
+++ b/crates/examples_common_2d/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 use-debug-plugin = []
 
 [dependencies]
-bevy = { version = "0.14", default-features = false, features = [
+bevy = { version = "0.15.0-rc.1", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_state",
     "bevy_text",
@@ -22,6 +22,6 @@ bevy = { version = "0.14", default-features = false, features = [
     "ktx2",
     "zstd",
     "bevy_winit",
-    "x11", # github actions runners don't have libxkbcommon installed, so can't use wayland
+    "x11",                # github actions runners don't have libxkbcommon installed, so can't use wayland
 ] }
 avian2d = { path = "../avian2d", default-features = false }

--- a/crates/examples_common_2d/Cargo.toml
+++ b/crates/examples_common_2d/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 use-debug-plugin = []
 
 [dependencies]
-bevy = { version = "0.15.0-rc.1", default-features = false, features = [
+bevy = { version = "0.15.0-rc", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_state",
     "bevy_text",

--- a/crates/examples_common_2d/src/lib.rs
+++ b/crates/examples_common_2d/src/lib.rs
@@ -64,20 +64,18 @@ struct FpsText;
 
 fn setup(mut commands: Commands) {
     commands.spawn((
-        TextBundle::from_section(
-            "FPS: ",
-            TextStyle {
-                font: default(),
-                font_size: 20.0,
-                color: TOMATO.into(),
-            },
-        )
-        .with_style(Style {
+        Text::new("FPS: "),
+        TextFont {
+            font_size: 20.0,
+            ..default()
+        },
+        TextColor::from(TOMATO),
+        Node {
             position_type: PositionType::Absolute,
             top: Val::Px(5.0),
             left: Val::Px(5.0),
             ..default()
-        }),
+        },
         FpsText,
     ));
 }
@@ -87,7 +85,7 @@ fn update_fps_text(diagnostics: Res<DiagnosticsStore>, mut query: Query<&mut Tex
         if let Some(fps) = diagnostics.get(&FrameTimeDiagnosticsPlugin::FPS) {
             if let Some(value) = fps.smoothed() {
                 // Update the value of the second section
-                text.sections[0].value = format!("FPS: {value:.2}");
+                text.0 = format!("FPS: {value:.2}");
             }
         }
     }

--- a/crates/examples_common_3d/Cargo.toml
+++ b/crates/examples_common_3d/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 use-debug-plugin = []
 
 [dependencies]
-bevy = { version = "0.15.0-rc.1", default-features = false, features = [
+bevy = { version = "0.15.0-rc", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_state",
     "bevy_text",

--- a/crates/examples_common_3d/Cargo.toml
+++ b/crates/examples_common_3d/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 use-debug-plugin = []
 
 [dependencies]
-bevy = { version = "0.14", default-features = false, features = [
+bevy = { version = "0.15.0-rc.1", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_state",
     "bevy_text",
@@ -24,6 +24,6 @@ bevy = { version = "0.14", default-features = false, features = [
     "png",
     "zstd",
     "bevy_winit",
-    "x11", # github actions runners don't have libxkbcommon installed, so can't use wayland
+    "x11",                # github actions runners don't have libxkbcommon installed, so can't use wayland
 ] }
 avian3d = { path = "../avian3d", default-features = false }

--- a/crates/examples_common_3d/src/lib.rs
+++ b/crates/examples_common_3d/src/lib.rs
@@ -64,20 +64,18 @@ struct FpsText;
 
 fn setup(mut commands: Commands) {
     commands.spawn((
-        TextBundle::from_section(
-            "FPS: ",
-            TextStyle {
-                font: default(),
-                font_size: 20.0,
-                color: TOMATO.into(),
-            },
-        )
-        .with_style(Style {
+        Text::new("FPS: "),
+        TextFont {
+            font_size: 20.0,
+            ..default()
+        },
+        TextColor::from(TOMATO),
+        Node {
             position_type: PositionType::Absolute,
             top: Val::Px(5.0),
             left: Val::Px(5.0),
             ..default()
-        }),
+        },
         FpsText,
     ));
 }
@@ -87,7 +85,7 @@ fn update_fps_text(diagnostics: Res<DiagnosticsStore>, mut query: Query<&mut Tex
         if let Some(fps) = diagnostics.get(&FrameTimeDiagnosticsPlugin::FPS) {
             if let Some(value) = fps.smoothed() {
                 // Update the value of the second section
-                text.sections[0].value = format!("FPS: {value:.2}");
+                text.0 = format!("FPS: {value:.2}");
             }
         }
     }

--- a/src/collision/collider/backend.rs
+++ b/src/collision/collider/backend.rs
@@ -202,7 +202,7 @@ impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
 
         // When the `Sensor` component is added to a collider, trigger an event.
         // The `MassPropertyPlugin` responds to the event and updates the body's mass properties accordingly.
-        app.observe(
+        app.add_observer(
             |trigger: Trigger<OnAdd, Sensor>,
              mut commands: Commands,
              query: Query<&ColliderMassProperties>| {
@@ -226,7 +226,7 @@ impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
 
         // When the `Sensor` component is removed from a collider, update its mass properties and trigger an event.
         // The `MassPropertyPlugin` responds to the event and updates the body's mass properties accordingly.
-        app.observe(
+        app.add_observer(
             |trigger: Trigger<OnRemove, Sensor>,
              mut commands: Commands,
              mut collider_query: Query<(
@@ -348,7 +348,7 @@ fn update_root_collider_parents<C: AnyCollider>(
 fn init_collider_constructors(
     mut commands: Commands,
     #[cfg(feature = "collider-from-mesh")] meshes: Res<Assets<Mesh>>,
-    #[cfg(feature = "collider-from-mesh")] mesh_handles: Query<&Handle<Mesh>>,
+    #[cfg(feature = "collider-from-mesh")] mesh_handles: Query<&Mesh3d>,
     constructors: Query<(
         Entity,
         Option<&Collider>,
@@ -405,9 +405,9 @@ fn init_collider_constructors(
 fn init_collider_constructor_hierarchies(
     mut commands: Commands,
     #[cfg(feature = "collider-from-mesh")] meshes: Res<Assets<Mesh>>,
-    #[cfg(feature = "collider-from-mesh")] mesh_handles: Query<&Handle<Mesh>>,
+    #[cfg(feature = "collider-from-mesh")] mesh_handles: Query<&Mesh3d>,
     #[cfg(feature = "bevy_scene")] scene_spawner: Res<SceneSpawner>,
-    #[cfg(feature = "bevy_scene")] scenes: Query<&Handle<Scene>>,
+    #[cfg(feature = "bevy_scene")] scenes: Query<&SceneRoot>,
     #[cfg(feature = "bevy_scene")] scene_instances: Query<&SceneInstance>,
     collider_constructors: Query<(Entity, &ColliderConstructorHierarchy)>,
     children: Query<&Children>,
@@ -679,7 +679,7 @@ pub fn update_collider_scale<C: ScalableCollider>(
 
 /// A resource that stores the system ID for the system that reacts to collider removals.
 #[derive(Resource)]
-struct ColliderRemovalSystem(SystemId<(Entity, ColliderParent, ColliderMassProperties)>);
+struct ColliderRemovalSystem(SystemId<In<(Entity, ColliderParent, ColliderMassProperties)>>);
 
 /// Updates the mass properties of bodies and wakes bodies up when an attached collider is removed.
 ///
@@ -784,16 +784,13 @@ mod tests {
             .spawn((
                 RigidBody::Dynamic,
                 mass_properties.clone(),
-                TransformBundle::default(),
+                Transform::default(),
             ))
             .id();
 
         let child = app
             .world_mut()
-            .spawn((
-                collider,
-                TransformBundle::from_transform(Transform::from_xyz(1.0, 0.0, 0.0)),
-            ))
+            .spawn((collider, Transform::from_xyz(1.0, 0.0, 0.0)))
             .set_parent(parent)
             .id();
 

--- a/src/collision/collider/constructor.rs
+++ b/src/collision/collider/constructor.rs
@@ -652,7 +652,16 @@ mod tests {
     fn collider_constructor_hierarchy_inserts_correct_configs_on_scene() {
         use parry::shape::ShapeType;
 
+        #[derive(Resource)]
+        struct SceneReady;
+
         let mut app = create_gltf_test_app();
+
+        app.add_observer(
+            |_trigger: Trigger<bevy::scene::SceneInstanceReady>, mut commands: Commands| {
+                commands.insert_resource(SceneReady);
+            },
+        );
 
         let scene_handle = app
             .world_mut()
@@ -673,11 +682,10 @@ mod tests {
             ))
             .id();
 
-        while app
-            .world()
-            .resource::<Events<bevy::scene::SceneInstanceReady>>()
-            .is_empty()
-        {
+        for _ in 0..1000 {
+            if app.world().contains_resource::<SceneReady>() {
+                break;
+            }
             app.update();
         }
         app.update();

--- a/src/collision/collider/constructor.rs
+++ b/src/collision/collider/constructor.rs
@@ -45,7 +45,7 @@ use bevy::utils::HashMap;
     doc = "    // Spawn the scene and automatically generate triangle mesh colliders"
 )]
 ///     commands.spawn((
-///         SceneBundle { scene: scene.clone(), ..default() },
+///         SceneRoot(scene.clone()),
 #[cfg_attr(
     feature = "2d",
     doc = "        ColliderConstructorHierarchy::new(ColliderConstructor::Circle { radius: 2.0 }),"
@@ -58,7 +58,7 @@ use bevy::utils::HashMap;
 ///
 ///     // Specify configuration for specific meshes by name
 ///     commands.spawn((
-///         SceneBundle { scene: scene.clone(), ..default() },
+///         SceneRoot(scene.clone()),
 #[cfg_attr(
     feature = "2d",
     doc = "        ColliderConstructorHierarchy::new(ColliderConstructor::Circle { radius: 2.0 })
@@ -75,7 +75,7 @@ use bevy::utils::HashMap;
 ///
 ///     // Only generate colliders for specific meshes by name
 ///     commands.spawn((
-///         SceneBundle { scene: scene.clone(), ..default() },
+///         SceneRoot(scene.clone()),
 ///         ColliderConstructorHierarchy::new(None)
 #[cfg_attr(
     feature = "2d",
@@ -89,7 +89,7 @@ use bevy::utils::HashMap;
 ///
 ///     // Generate colliders for everything except specific meshes by name
 ///     commands.spawn((
-///         SceneBundle { scene, ..default() },
+///         SceneRoot(scene),
 #[cfg_attr(
     feature = "2d",
     doc = "        ColliderConstructorHierarchy::new(ColliderConstructor::Circle { radius: 2.0 })
@@ -271,10 +271,7 @@ pub struct ColliderConstructorHierarchyConfig {
     feature = "3d",
     doc = "        ColliderConstructor::ConvexHullFromMesh,"
 )]
-///         PbrBundle {
-///             mesh: meshes.add(Mesh::from(Cuboid::default())),
-///             ..default()
-///         },
+///         Mesh3d(meshes.add(Cuboid::default())),
 ///     ));
 /// }
 /// ```

--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -160,7 +160,6 @@ impl From<FillMode> for parry::transformation::voxelization::FillMode {
 /// Flags used for the preprocessing of a triangle mesh collider.
 #[repr(transparent)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serialize", reflect_value(Serialize, Deserialize))]
 #[derive(Hash, Clone, Copy, PartialEq, Eq, Debug, Reflect)]
 #[reflect(opaque, Hash, PartialEq, Debug)]
 pub struct TrimeshFlags(u8);

--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -16,8 +16,6 @@ mod primitives3d;
 #[cfg(feature = "2d")]
 pub(crate) use primitives2d::{EllipseWrapper, RegularPolygonWrapper};
 
-pub use parry::shape::TriMeshBuilderError;
-
 impl<T: IntoCollider<Collider>> From<T> for Collider {
     fn from(value: T) -> Self {
         value.collider()
@@ -765,12 +763,9 @@ impl Collider {
     ///
     /// The [`CollisionMargin`] component can be used to add thickness to the shape if needed.
     /// For thin shapes like triangle meshes, it can help improve collision stability and performance.
-    pub fn trimesh(
-        vertices: Vec<Vector>,
-        indices: Vec<[u32; 3]>,
-    ) -> Result<Self, TriMeshBuilderError> {
+    pub fn trimesh(vertices: Vec<Vector>, indices: Vec<[u32; 3]>) -> Self {
         let vertices = vertices.into_iter().map(|v| v.into()).collect();
-        SharedShape::trimesh(vertices, indices).map(Into::into)
+        SharedShape::trimesh(vertices, indices).into()
     }
 
     /// Creates a collider with a triangle mesh shape defined by its vertex and index buffers
@@ -784,9 +779,9 @@ impl Collider {
         vertices: Vec<Vector>,
         indices: Vec<[u32; 3]>,
         flags: TrimeshFlags,
-    ) -> Result<Self, TriMeshBuilderError> {
+    ) -> Self {
         let vertices = vertices.into_iter().map(|v| v.into()).collect();
-        SharedShape::trimesh_with_flags(vertices, indices, flags.into()).map(Into::into)
+        SharedShape::trimesh_with_flags(vertices, indices, flags.into()).into()
     }
 
     /// Creates a collider shape with a compound shape obtained from the decomposition of a given polyline
@@ -911,14 +906,13 @@ impl Collider {
     /// ```
     #[cfg(feature = "collider-from-mesh")]
     pub fn trimesh_from_mesh(mesh: &Mesh) -> Option<Self> {
-        extract_mesh_vertices_indices(mesh).and_then(|(vertices, indices)| {
+        extract_mesh_vertices_indices(mesh).map(|(vertices, indices)| {
             SharedShape::trimesh_with_flags(
                 vertices,
                 indices,
                 TrimeshFlags::MERGE_DUPLICATE_VERTICES.into(),
             )
-            .ok()
-            .map(Into::into)
+            .into()
         })
     }
 
@@ -949,10 +943,8 @@ impl Collider {
     /// ```
     #[cfg(feature = "collider-from-mesh")]
     pub fn trimesh_from_mesh_with_config(mesh: &Mesh, flags: TrimeshFlags) -> Option<Self> {
-        extract_mesh_vertices_indices(mesh).and_then(|(vertices, indices)| {
-            SharedShape::trimesh_with_flags(vertices, indices, flags.into())
-                .ok()
-                .map(Into::into)
+        extract_mesh_vertices_indices(mesh).map(|(vertices, indices)| {
+            SharedShape::trimesh_with_flags(vertices, indices, flags.into()).into()
         })
     }
 
@@ -1126,13 +1118,13 @@ impl Collider {
                 Some(Self::polyline(vertices, indices))
             }
             ColliderConstructor::Trimesh { vertices, indices } => {
-                Self::trimesh(vertices, indices).ok()
+                Some(Self::trimesh(vertices, indices))
             }
             ColliderConstructor::TrimeshWithConfig {
                 vertices,
                 indices,
                 flags,
-            } => Self::trimesh_with_config(vertices, indices, flags).ok(),
+            } => Some(Self::trimesh_with_config(vertices, indices, flags)),
             #[cfg(feature = "2d")]
             ColliderConstructor::ConvexDecomposition { vertices, indices } => {
                 Some(Self::convex_decomposition(vertices, indices))

--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -896,10 +896,7 @@ impl Collider {
     ///     let mesh = Mesh::from(Cuboid::default());
     ///     commands.spawn((
     ///         Collider::trimesh_from_mesh(&mesh).unwrap(),
-    ///         PbrBundle {
-    ///             mesh: meshes.add(mesh),
-    ///             ..default()
-    ///         },
+    ///         Mesh3d(meshes.add(mesh)),
     ///     ));
     /// }
     /// ```
@@ -933,10 +930,7 @@ impl Collider {
     ///     let mesh = Mesh::from(Cuboid::default());
     ///     commands.spawn((
     ///         Collider::trimesh_from_mesh_with_config(&mesh, TrimeshFlags::all()).unwrap(),
-    ///         PbrBundle {
-    ///             mesh: meshes.add(mesh),
-    ///             ..default()
-    ///         },
+    ///         Mesh3d(meshes.add(mesh)),
     ///     ));
     /// }
     /// ```
@@ -959,10 +953,7 @@ impl Collider {
     ///     let mesh = Mesh::from(Cuboid::default());
     ///     commands.spawn((
     ///         Collider::convex_hull_from_mesh(&mesh).unwrap(),
-    ///         PbrBundle {
-    ///             mesh: meshes.add(mesh),
-    ///             ..default()
-    ///         },
+    ///         Mesh3d(meshes.add(mesh)),
     ///     ));
     /// }
     /// ```
@@ -984,10 +975,7 @@ impl Collider {
     ///     let mesh = Mesh::from(Cuboid::default());
     ///     commands.spawn((
     ///         Collider::convex_decomposition_from_mesh(&mesh).unwrap(),
-    ///         PbrBundle {
-    ///             mesh: meshes.add(mesh),
-    ///             ..default()
-    ///         },
+    ///         Mesh3d(meshes.add(mesh)),
     ///     ));
     /// }
     /// ```
@@ -1015,10 +1003,7 @@ impl Collider {
     ///     };
     ///     commands.spawn((
     ///         Collider::convex_decomposition_from_mesh_with_config(&mesh, &config).unwrap(),
-    ///         PbrBundle {
-    ///             mesh: meshes.add(mesh),
-    ///             ..default()
-    ///         },
+    ///         Mesh3d(meshes.add(mesh)),
     ///     ));
     /// }
     /// ```

--- a/src/collision/collider/parry/primitives2d.rs
+++ b/src/collision/collider/parry/primitives2d.rs
@@ -50,7 +50,7 @@ impl Shape for EllipseWrapper {
         &self,
         scale: &parry::math::Vector<Scalar>,
         _num_subdivisions: u32,
-    ) -> Option<Box<dyn parry2d::shape::Shape>> {
+    ) -> Option<Box<dyn parry::shape::Shape>> {
         let half_size = Vector::from(*scale) * self.half_size;
         Some(Box::new(EllipseWrapper(Ellipse::new(
             half_size.x,
@@ -324,7 +324,7 @@ impl Shape for RegularPolygonWrapper {
         &self,
         scale: &parry::math::Vector<Scalar>,
         _num_subdivisions: u32,
-    ) -> Option<Box<dyn parry2d::shape::Shape>> {
+    ) -> Option<Box<dyn parry::shape::Shape>> {
         let circumradius = Vector::from(*scale) * self.circumradius();
         Some(Box::new(RegularPolygonWrapper(RegularPolygon::new(
             circumradius.length(),

--- a/src/collision/collider/parry/primitives2d.rs
+++ b/src/collision/collider/parry/primitives2d.rs
@@ -1,6 +1,6 @@
 use crate::{math, AdjustPrecision, Scalar, Vector, FRAC_PI_2, PI, TAU};
 
-use super::{Collider, IntoCollider};
+use super::{AsF32, Collider, IntoCollider};
 use bevy::prelude::Deref;
 use bevy_math::{bounding::Bounded2d, prelude::*};
 use nalgebra::{Point2, UnitVector2, Vector2};
@@ -51,7 +51,7 @@ impl Shape for EllipseWrapper {
         scale: &parry::math::Vector<Scalar>,
         _num_subdivisions: u32,
     ) -> Option<Box<dyn parry::shape::Shape>> {
-        let half_size = Vector::from(*scale) * self.half_size;
+        let half_size = Vector::from(*scale).f32() * self.half_size;
         Some(Box::new(EllipseWrapper(Ellipse::new(
             half_size.x,
             half_size.y,
@@ -325,7 +325,7 @@ impl Shape for RegularPolygonWrapper {
         scale: &parry::math::Vector<Scalar>,
         _num_subdivisions: u32,
     ) -> Option<Box<dyn parry::shape::Shape>> {
-        let circumradius = Vector::from(*scale) * self.circumradius();
+        let circumradius = Vector::from(*scale).f32() * self.circumradius();
         Some(Box::new(RegularPolygonWrapper(RegularPolygon::new(
             circumradius.length(),
             self.sides,

--- a/src/collision/collider/parry/primitives2d.rs
+++ b/src/collision/collider/parry/primitives2d.rs
@@ -1,4 +1,4 @@
-use crate::{AdjustPrecision, AsF32, Scalar, Vector, FRAC_PI_2, PI, TAU};
+use crate::{math, AdjustPrecision, Scalar, Vector, FRAC_PI_2, PI, TAU};
 
 use super::{Collider, IntoCollider};
 use bevy::prelude::Deref;
@@ -42,8 +42,24 @@ impl SupportMap for EllipseWrapper {
 }
 
 impl Shape for EllipseWrapper {
+    fn clone_dyn(&self) -> Box<dyn Shape> {
+        Box::new(*self)
+    }
+
+    fn scale_dyn(
+        &self,
+        scale: &parry::math::Vector<Scalar>,
+        _num_subdivisions: u32,
+    ) -> Option<Box<dyn parry2d::shape::Shape>> {
+        let half_size = Vector::from(*scale) * self.half_size;
+        Some(Box::new(EllipseWrapper(Ellipse::new(
+            half_size.x,
+            half_size.y,
+        ))))
+    }
+
     fn compute_local_aabb(&self) -> parry::bounding_volume::Aabb {
-        let aabb = self.aabb_2d(Vec2::ZERO, 0.0);
+        let aabb = self.aabb_2d(Isometry2d::IDENTITY);
         parry::bounding_volume::Aabb::new(
             aabb.min.adjust_precision().into(),
             aabb.max.adjust_precision().into(),
@@ -51,10 +67,8 @@ impl Shape for EllipseWrapper {
     }
 
     fn compute_aabb(&self, position: &Isometry<Scalar>) -> parry::bounding_volume::Aabb {
-        let aabb = self.aabb_2d(
-            Vector::from(position.translation).f32(),
-            position.rotation.angle() as f32,
-        );
+        let isometry = math::na_iso_to_iso(position);
+        let aabb = self.aabb_2d(isometry);
         parry::bounding_volume::Aabb::new(
             aabb.min.adjust_precision().into(),
             aabb.max.adjust_precision().into(),
@@ -62,7 +76,7 @@ impl Shape for EllipseWrapper {
     }
 
     fn compute_local_bounding_sphere(&self) -> parry::bounding_volume::BoundingSphere {
-        let sphere = self.bounding_circle(Vec2::ZERO, 0.0);
+        let sphere = self.bounding_circle(Isometry2d::IDENTITY);
         parry::bounding_volume::BoundingSphere::new(
             sphere.center.adjust_precision().into(),
             sphere.radius().adjust_precision(),
@@ -73,10 +87,8 @@ impl Shape for EllipseWrapper {
         &self,
         position: &Isometry<Scalar>,
     ) -> parry::bounding_volume::BoundingSphere {
-        let sphere = self.bounding_circle(
-            Vector::from(position.translation).f32(),
-            position.rotation.angle() as f32,
-        );
+        let isometry = math::na_iso_to_iso(position);
+        let sphere = self.bounding_circle(isometry);
         parry::bounding_volume::BoundingSphere::new(
             sphere.center.adjust_precision().into(),
             sphere.radius().adjust_precision(),
@@ -103,7 +115,7 @@ impl Shape for EllipseWrapper {
     }
 
     fn as_typed_shape(&self) -> parry::shape::TypedShape {
-        parry::shape::TypedShape::Custom(1)
+        parry::shape::TypedShape::Custom(self)
     }
 
     fn ccd_thickness(&self) -> Scalar {
@@ -245,9 +257,9 @@ impl SupportMap for RegularPolygonWrapper {
 
         // Counterclockwise
         let angle_from_top = if direction.x < 0.0 {
-            -Vector::from(*direction).angle_between(Vector::Y)
+            -Vector::from(*direction).angle_to(Vector::Y)
         } else {
-            TAU - Vector::from(*direction).angle_between(Vector::Y)
+            TAU - Vector::from(*direction).angle_to(Vector::Y)
         };
 
         // How many rotations of `external_angle` correspond to the vertex closest to the support direction.
@@ -273,9 +285,9 @@ impl PolygonalFeatureMap for RegularPolygonWrapper {
 
         // Counterclockwise
         let angle_from_top = if direction.x < 0.0 {
-            -Vector::from(*direction).angle_between(Vector::Y)
+            -Vector::from(*direction).angle_to(Vector::Y)
         } else {
-            TAU - Vector::from(*direction).angle_between(Vector::Y)
+            TAU - Vector::from(*direction).angle_to(Vector::Y)
         };
 
         // How many rotations of `external_angle` correspond to the vertices.
@@ -304,8 +316,24 @@ impl PolygonalFeatureMap for RegularPolygonWrapper {
 }
 
 impl Shape for RegularPolygonWrapper {
+    fn clone_dyn(&self) -> Box<dyn Shape> {
+        Box::new(*self)
+    }
+
+    fn scale_dyn(
+        &self,
+        scale: &parry::math::Vector<Scalar>,
+        _num_subdivisions: u32,
+    ) -> Option<Box<dyn parry2d::shape::Shape>> {
+        let circumradius = Vector::from(*scale) * self.circumradius();
+        Some(Box::new(RegularPolygonWrapper(RegularPolygon::new(
+            circumradius.length(),
+            self.sides,
+        ))))
+    }
+
     fn compute_local_aabb(&self) -> parry::bounding_volume::Aabb {
-        let aabb = self.aabb_2d(Vec2::ZERO, 0.0);
+        let aabb = self.aabb_2d(Isometry2d::IDENTITY);
         parry::bounding_volume::Aabb::new(
             aabb.min.adjust_precision().into(),
             aabb.max.adjust_precision().into(),
@@ -313,10 +341,8 @@ impl Shape for RegularPolygonWrapper {
     }
 
     fn compute_aabb(&self, position: &Isometry<Scalar>) -> parry::bounding_volume::Aabb {
-        let aabb = self.aabb_2d(
-            Vector::from(position.translation).f32(),
-            position.rotation.angle() as f32,
-        );
+        let isometry = math::na_iso_to_iso(position);
+        let aabb = self.aabb_2d(isometry);
         parry::bounding_volume::Aabb::new(
             aabb.min.adjust_precision().into(),
             aabb.max.adjust_precision().into(),
@@ -324,7 +350,7 @@ impl Shape for RegularPolygonWrapper {
     }
 
     fn compute_local_bounding_sphere(&self) -> parry::bounding_volume::BoundingSphere {
-        let sphere = self.bounding_circle(Vec2::ZERO, 0.0);
+        let sphere = self.bounding_circle(Isometry2d::IDENTITY);
         parry::bounding_volume::BoundingSphere::new(
             sphere.center.adjust_precision().into(),
             sphere.radius().adjust_precision(),
@@ -335,10 +361,8 @@ impl Shape for RegularPolygonWrapper {
         &self,
         position: &Isometry<Scalar>,
     ) -> parry::bounding_volume::BoundingSphere {
-        let sphere = self.bounding_circle(
-            Vector::from(position.translation).f32(),
-            position.rotation.angle() as f32,
-        );
+        let isometry = math::na_iso_to_iso(position);
+        let sphere = self.bounding_circle(isometry);
         parry::bounding_volume::BoundingSphere::new(
             sphere.center.adjust_precision().into(),
             sphere.radius().adjust_precision(),
@@ -369,7 +393,7 @@ impl Shape for RegularPolygonWrapper {
     }
 
     fn as_typed_shape(&self) -> parry::shape::TypedShape {
-        parry::shape::TypedShape::Custom(2)
+        parry::shape::TypedShape::Custom(self)
     }
 
     fn ccd_thickness(&self) -> Scalar {

--- a/src/collision/collider/parry/primitives3d.rs
+++ b/src/collision/collider/parry/primitives3d.rs
@@ -23,7 +23,7 @@ impl IntoCollider<Collider> for Plane3d {
             rotation * Vector::new(half_size, 0.0, half_size),
         ];
 
-        Collider::trimesh(vertices, vec![[0, 1, 2], [1, 2, 0]])
+        Collider::trimesh(vertices, vec![[0, 1, 2], [1, 2, 0]]).unwrap()
     }
 }
 

--- a/src/collision/collider/parry/primitives3d.rs
+++ b/src/collision/collider/parry/primitives3d.rs
@@ -23,7 +23,7 @@ impl IntoCollider<Collider> for Plane3d {
             rotation * Vector::new(half_size, 0.0, half_size),
         ];
 
-        Collider::trimesh(vertices, vec![[0, 1, 2], [1, 2, 0]]).unwrap()
+        Collider::trimesh(vertices, vec![[0, 1, 2], [1, 2, 0]])
     }
 }
 

--- a/src/debug_render/gizmos.rs
+++ b/src/debug_render/gizmos.rs
@@ -174,11 +174,15 @@ impl<'w, 's> PhysicsGizmoExt for Gizmos<'w, 's, PhysicsGizmos> {
         match collider.shape_scaled().as_typed_shape() {
             #[cfg(feature = "2d")]
             TypedShape::Ball(s) => {
-                self.circle(position.extend(0.0).f32(), Dir3::Z, s.radius as f32, color);
+                self.circle_2d(position.f32(), s.radius as f32, color);
             }
             #[cfg(feature = "3d")]
             TypedShape::Ball(s) => {
-                self.sphere(position.f32(), rotation.f32(), s.radius as f32, color);
+                self.sphere(
+                    Isometry3d::new(position.f32(), rotation.f32()),
+                    s.radius as f32,
+                    color,
+                );
             }
             #[cfg(feature = "2d")]
             TypedShape::Cuboid(s) => {
@@ -425,28 +429,23 @@ impl<'w, 's> PhysicsGizmoExt for Gizmos<'w, 's, PhysicsGizmos> {
                     color,
                 );
             }
-            TypedShape::Custom(_id) =>
-            {
+            TypedShape::Custom(_id) => {
                 #[cfg(feature = "2d")]
-                if _id == 1 {
+                {
                     if let Some(ellipse) = collider.shape_scaled().as_shape::<EllipseWrapper>() {
-                        self.primitive_2d(
-                            &ellipse.0,
+                        let isometry = Isometry2d::new(
                             position.f32(),
-                            rotation.as_radians() as f32,
-                            color,
+                            Rot2::from_sin_cos(rotation.sin as f32, rotation.cos as f32),
                         );
-                    }
-                } else if _id == 2 {
-                    if let Some(polygon) =
+                        self.primitive_2d(&ellipse.0, isometry, color);
+                    } else if let Some(polygon) =
                         collider.shape_scaled().as_shape::<RegularPolygonWrapper>()
                     {
-                        self.primitive_2d(
-                            &polygon.0,
+                        let isometry = Isometry2d::new(
                             position.f32(),
-                            rotation.as_radians() as f32,
-                            color,
+                            Rot2::from_sin_cos(rotation.sin as f32, rotation.cos as f32),
                         );
+                        self.primitive_2d(&polygon.0, isometry, color);
                     }
                 }
             }
@@ -487,12 +486,7 @@ impl<'w, 's> PhysicsGizmoExt for Gizmos<'w, 's, PhysicsGizmos> {
             #[cfg(feature = "2d")]
             self.circle_2d(point.f32(), 0.1 * length_unit as f32, point_color);
             #[cfg(feature = "3d")]
-            self.sphere(
-                point.f32(),
-                default(),
-                0.1 * length_unit as f32,
-                point_color,
-            );
+            self.sphere(point.f32(), 0.1 * length_unit as f32, point_color);
 
             // Draw hit normal as arrow
             self.draw_arrow(
@@ -551,12 +545,7 @@ impl<'w, 's> PhysicsGizmoExt for Gizmos<'w, 's, PhysicsGizmos> {
             #[cfg(feature = "2d")]
             self.circle_2d(hit.point1.f32(), 0.1 * length_unit as f32, point_color);
             #[cfg(feature = "3d")]
-            self.sphere(
-                hit.point1.f32(),
-                default(),
-                0.1 * length_unit as f32,
-                point_color,
-            );
+            self.sphere(hit.point1.f32(), 0.1 * length_unit as f32, point_color);
 
             // Draw hit normal as arrow
             self.draw_arrow(

--- a/src/debug_render/mod.rs
+++ b/src/debug_render/mod.rs
@@ -336,8 +336,8 @@ fn debug_render_contacts(
                     }
                     #[cfg(feature = "3d")]
                     {
-                        gizmos.sphere(p1.f32(), default(), 0.1 * length_unit.0 as f32, color);
-                        gizmos.sphere(p2.f32(), default(), 0.1 * length_unit.0 as f32, color);
+                        gizmos.sphere(p1.f32(), 0.1 * length_unit.0 as f32, color);
+                        gizmos.sphere(p2.f32(), 0.1 * length_unit.0 as f32, color);
                     }
                 }
 
@@ -352,7 +352,7 @@ fn debug_render_contacts(
                             ContactGizmoScale::Constant(length) => length,
                             ContactGizmoScale::Scaled(scale) => {
                                 scale * contacts.total_normal_impulse
-                                    / time.delta_seconds_f64().adjust_precision()
+                                    / time.delta_secs_f64().adjust_precision()
                             }
                         };
 

--- a/src/dynamics/rigid_body/mass_properties/mod.rs
+++ b/src/dynamics/rigid_body/mass_properties/mod.rs
@@ -45,7 +45,7 @@ impl Plugin for MassPropertyPlugin {
     fn build(&self, app: &mut App) {
         // Update mass properties of rigid bodies when the mass properties of attached colliders are changed.
         // This includes adding, removing, or modifying colliders.
-        app.observe(
+        app.add_observer(
             |trigger: Trigger<OnChangeColliderMassProperties>,
              collider_parents: Query<(
                 &ColliderParent,

--- a/src/dynamics/solver/mod.rs
+++ b/src/dynamics/solver/mod.rs
@@ -475,8 +475,8 @@ fn update_contact_softness(
     substep_time: Res<Time<Substeps>>,
 ) {
     if solver_config.is_changed() || physics_time.is_changed() || substep_time.is_changed() {
-        let dt = physics_time.delta_seconds_f64() as Scalar;
-        let h = substep_time.delta_seconds_f64() as Scalar;
+        let dt = physics_time.delta_secs_f64() as Scalar;
+        let h = substep_time.delta_secs_f64() as Scalar;
 
         // The contact frequency should at most be half of the time step due to Nyquist's theorem.
         // https://en.wikipedia.org/wiki/Nyquist%E2%80%93Shannon_sampling_theorem

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -227,6 +227,15 @@ impl MatExt for DMat3 {
     }
 }
 
+#[expect(clippy::unnecessary_cast)]
+#[cfg(all(feature = "2d", any(feature = "parry-f32", feature = "parry-f64")))]
+pub(crate) fn na_iso_to_iso(isometry: &parry::math::Isometry<Scalar>) -> Isometry2d {
+    Isometry2d::new(
+        Vector::from(isometry.translation).f32(),
+        Rot2::from_sin_cos(isometry.rotation.im as f32, isometry.rotation.re as f32),
+    )
+}
+
 #[cfg(all(
     feature = "default-collider",
     any(feature = "parry-f32", feature = "parry-f64")

--- a/src/schedule/time.rs
+++ b/src/schedule/time.rs
@@ -279,11 +279,11 @@ impl TimePrecisionAdjusted for Time {
     fn delta_seconds_adjusted(&self) -> Scalar {
         #[cfg(feature = "f32")]
         {
-            self.delta_seconds()
+            self.delta_secs()
         }
         #[cfg(feature = "f64")]
         {
-            self.delta_seconds_f64()
+            self.delta_secs_f64()
         }
     }
 }

--- a/src/sync/ancestor_marker.rs
+++ b/src/sync/ancestor_marker.rs
@@ -44,7 +44,7 @@ impl<C: Component> Plugin for AncestorMarkerPlugin<C> {
     fn build(&self, app: &mut App) {
         // Add `AncestorMarker<C>` for the ancestors of added colliders,
         // until an ancestor that has other `AncestorMarker<C>` entities as children is encountered.
-        app.observe(
+        app.add_observer(
             |trigger: Trigger<OnAdd, C>,
              mut commands: Commands,
              parent_query: Query<&Parent>,
@@ -65,7 +65,7 @@ impl<C: Component> Plugin for AncestorMarkerPlugin<C> {
         // Remove `AncestorMarker<C>` from removed colliders and their ancestors,
         // until an ancestor that has other `AncestorMarker<C>` entities as children is encountered.
         #[allow(clippy::type_complexity)]
-        app.observe(
+        app.add_observer(
             |trigger: Trigger<OnRemove, C>,
             mut commands: Commands,
             child_query: Query<&Children>,
@@ -517,7 +517,7 @@ mod tests {
         // Move all children from BN to CY. The `AncestorMarker<C>` marker should
         // now be removed from BN, and CY should get it back.
         let mut entity_mut = app.world_mut().entity_mut(cy);
-        entity_mut.push_children(&[fy, gy]);
+        entity_mut.add_children(&[fy, gy]);
 
         app.world_mut().run_schedule(FixedPostUpdate);
 
@@ -527,7 +527,7 @@ mod tests {
 
         // Move all children from CY to BN and remove CY. This must not crash.
         let mut entity_mut = app.world_mut().entity_mut(bn);
-        entity_mut.push_children(&[dn, en, fy, gy]);
+        entity_mut.add_children(&[dn, en, fy, gy]);
 
         app.world_mut().run_schedule(FixedPostUpdate);
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -86,7 +86,7 @@ fn setup_cubes_simulation(mut commands: Commands) {
                     (z as Scalar - count_z as Scalar * 0.5) * 2.1 * radius,
                 );
                 commands.spawn((
-                    SpatialBundle::default(),
+                    Transform::default(),
                     RigidBody::Dynamic,
                     Position(pos + Vector::Y * 5.0),
                     Collider::cuboid(radius * 2.0, radius * 2.0, radius * 2.0),
@@ -122,7 +122,7 @@ fn body_with_velocity_moves() {
     app.add_systems(Startup, |mut commands: Commands| {
         // move right at 1 unit per second
         commands.spawn((
-            SpatialBundle::default(),
+            Transform::default(),
             RigidBody::Dynamic,
             LinearVelocity(Vector::X),
             #[cfg(feature = "2d")]


### PR DESCRIPTION
# Objective

The Bevy 0.15 release candidate has been released! Avian should be updated for early adopters, and to make sure we are ready when the full 0.15 release is out.

## Solution

Migrate Avian to the Bevy 0.15 release candidate. This only includes the migration necessary to fix all deprecations and warnings. Avian's internals will be updated to take advantage of required components and other new features in follow-ups.

---

## Migration Guide

`Collider::regular_polygon` and `ColliderConstructor::RegularPolygon` now use a `u32` instead of `usize` for `sides`.