### PR TITLE
Added missing deref and derefMut trait to AngularVelocity in 2D

### DIFF
--- a/src/dynamics/rigid_body/mod.rs
+++ b/src/dynamics/rigid_body/mod.rs
@@ -384,7 +384,7 @@ pub(crate) struct PreSolveLinearVelocity(pub Vector);
 /// }
 /// ```
 #[cfg(feature = "2d")]
-#[derive(Reflect, Clone, Copy, Component, Debug, Default, PartialEq, From)]
+#[derive(Reflect, Clone, Copy, Deref, DerefMut, Component, Debug, Default, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, Component, Default, PartialEq)]


### PR DESCRIPTION
# Objective

`Deref` & `DerefMut` trait is missing for 2D `AngularVelocity`.

## Solution

added the missing deref and derefMut traits.

---

## Changelog

-  added deref and derefMut traits to `AngularVelocity` for avian2d.
