### PR TITLE
Fix plugin table

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -530,7 +530,13 @@ use prelude::*;
 /// | [`SleepingPlugin`]                | Manages sleeping and waking for bodies, automatically deactivating them to save computational resources.                                                   |
 /// | [`SpatialQueryPlugin`]            | Handles spatial queries like [raycasting](spatial_query#raycasting) and [shapecasting](spatial_query#shapecasting).                                        |
 /// | [`SyncPlugin`]                    | Keeps [`Position`] and [`Rotation`] in sync with `Transform`.                                                                                              |
+///
+/// Optional additional plugins include:
+///
+/// | Plugin                            | Description                                                                                                                                                |
+/// | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 /// | [`PhysicsDebugPlugin`]            | Renders physics objects and events like [AABBs](ColliderAabb) and [contacts](Collision) for debugging purposes (only with `debug-plugin` feature enabled). |
+/// | [`PhysicsPickingPlugin`]          | Enables a physics picking backend for [`bevy_picking`](bevy::picking) (only with `bevy_picking` feature enabled).                                          |
 ///
 /// Refer to the documentation of the plugins for more information about their responsibilities and implementations.
 ///


### PR DESCRIPTION
# Objective

The plugin table for the docs of `PhysicsPlugins` mentions `PhysicsDebugPlugin` as a plugin that is added by default, but it isn't. `PhysicsPickingPlugin` on the other hand isn't mentioned at all.

## Solution

Add a separate table for additional plugins.