### PR TITLE
Fix non-square `Collider::heightfield` row and column count order

### DIFF
--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -868,7 +868,7 @@ impl Collider {
             "Each row in `heights` must have the same amount of points"
         );
 
-        let heights = nalgebra::DMatrix::from_vec(row_count, column_count, data);
+        let heights = nalgebra::DMatrix::from_vec(column_count, row_count, data);
         SharedShape::heightfield(heights, scale.into()).into()
     }
 


### PR DESCRIPTION
# Objective

The row and column counts in `Collider::heightfield` seem to be the wrong way around! This makes heightfields with a different number of rows and columns behave incorrectly in comparison to the documented representation.

The heightfield below should slope up smoothly left to right.

![broken](https://github.com/user-attachments/assets/75c20212-c19c-44fb-9792-38dc7db28383)

## Solution

Fix the order.

![fixed](https://github.com/user-attachments/assets/35e639a2-9a18-45a4-8925-3168cefd4482)