### PR TITLE
Fix new Rust 1.83.0 lints

### DIFF
--- a/src/collision/collider/backend.rs
+++ b/src/collision/collider/backend.rs
@@ -57,7 +57,6 @@ use mass_properties::OnChangeColliderMassProperties;
 /// it should now work with the rest of the engine just like normal [`Collider`]s!
 ///
 /// **Note**: [Spatial queries](spatial_query) are not supported for custom colliders yet.
-
 pub struct ColliderBackendPlugin<C: ScalableCollider> {
     schedule: Interned<dyn ScheduleLabel>,
     _phantom: PhantomData<C>,

--- a/src/collision/collider/world_query.rs
+++ b/src/collision/collider/world_query.rs
@@ -25,7 +25,7 @@ pub struct ColliderQuery<C: AnyCollider> {
     pub shape: &'static C,
 }
 
-impl<'w, C: AnyCollider> ColliderQueryItem<'w, C> {
+impl<C: AnyCollider> ColliderQueryItem<'_, C> {
     /// Returns the current position of the body. This is a sum of the [`Position`] and
     /// [`AccumulatedTranslation`] components.
     pub fn current_position(&self) -> Vector {

--- a/src/collision/narrow_phase.rs
+++ b/src/collision/narrow_phase.rs
@@ -385,7 +385,7 @@ pub struct NarrowPhase<'w, 's, C: AnyCollider> {
     contact_tolerance: Local<'s, Scalar>,
 }
 
-impl<'w, 's, C: AnyCollider> NarrowPhase<'w, 's, C> {
+impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
     /// Updates the narrow phase by computing [`Contacts`] based on [`BroadCollisionPairs`]
     /// and adding them to [`Collisions`].
     fn update(&mut self, broad_collision_pairs: &[(Entity, Entity)], delta_secs: Scalar) {

--- a/src/debug_render/gizmos.rs
+++ b/src/debug_render/gizmos.rs
@@ -85,7 +85,7 @@ pub trait PhysicsGizmoExt {
     );
 }
 
-impl<'w, 's> PhysicsGizmoExt for Gizmos<'w, 's, PhysicsGizmos> {
+impl PhysicsGizmoExt for Gizmos<'_, '_, PhysicsGizmos> {
     /// Draws a line from `a` to `b`.
     fn draw_line(&mut self, a: Vector, b: Vector, color: Color) {
         #[cfg(feature = "2d")]

--- a/src/dynamics/rigid_body/mass_properties/world_query.rs
+++ b/src/dynamics/rigid_body/mass_properties/world_query.rs
@@ -17,7 +17,7 @@ pub struct MassPropertiesQuery {
     pub center_of_mass: &'static mut CenterOfMass,
 }
 
-impl<'w> MassPropertiesQueryItem<'w> {
+impl MassPropertiesQueryItem<'_> {
     /// Computes the angular inertia shifted by the given offset, taking into account mass.
     #[cfg(feature = "2d")]
     #[inline]
@@ -49,7 +49,7 @@ impl<'w> MassPropertiesQueryItem<'w> {
     }
 }
 
-impl<'w> AddAssign<ColliderMassProperties> for MassPropertiesQueryItem<'w> {
+impl AddAssign<ColliderMassProperties> for MassPropertiesQueryItem<'_> {
     fn add_assign(&mut self, rhs: ColliderMassProperties) {
         let mass1 = self.mass.value();
         let mass2 = rhs.mass;
@@ -75,7 +75,7 @@ impl<'w> AddAssign<ColliderMassProperties> for MassPropertiesQueryItem<'w> {
     }
 }
 
-impl<'w> SubAssign<ColliderMassProperties> for MassPropertiesQueryItem<'w> {
+impl SubAssign<ColliderMassProperties> for MassPropertiesQueryItem<'_> {
     fn sub_assign(&mut self, rhs: ColliderMassProperties) {
         if self.mass.inverse() + rhs.mass.recip_or_zero() <= 0.0 {
             return;

--- a/src/dynamics/rigid_body/world_query.rs
+++ b/src/dynamics/rigid_body/world_query.rs
@@ -34,7 +34,7 @@ pub struct RigidBodyQuery {
     pub is_sensor: Has<Sensor>,
 }
 
-impl<'w> RigidBodyQueryItem<'w> {
+impl RigidBodyQueryItem<'_> {
     /// Computes the velocity at the given `point` relative to the center of the body.
     pub fn velocity_at_point(&self, point: Vector) -> Vector {
         #[cfg(feature = "2d")]
@@ -114,7 +114,7 @@ impl<'w> RigidBodyQueryItem<'w> {
     }
 }
 
-impl<'w> RigidBodyQueryReadOnlyItem<'w> {
+impl RigidBodyQueryReadOnlyItem<'_> {
     /// Computes the velocity at the given `point` relative to the center of mass.
     pub fn velocity_at_point(&self, point: Vector) -> Vector {
         #[cfg(feature = "2d")]

--- a/src/spatial_query/pipeline.rs
+++ b/src/spatial_query/pipeline.rs
@@ -52,7 +52,7 @@ impl SpatialQueryPipeline {
     pub(crate) fn as_composite_shape<'a>(
         &'a self,
         query_filter: &'a SpatialQueryFilter,
-    ) -> QueryPipelineAsCompositeShape {
+    ) -> QueryPipelineAsCompositeShape<'a> {
         QueryPipelineAsCompositeShape {
             pipeline: self,
             colliders: &self.colliders,
@@ -60,11 +60,11 @@ impl SpatialQueryPipeline {
         }
     }
 
-    pub(crate) fn as_composite_shape_with_predicate<'a>(
+    pub(crate) fn as_composite_shape_with_predicate<'a: 'b, 'b>(
         &'a self,
         query_filter: &'a SpatialQueryFilter,
         predicate: &'a dyn Fn(Entity) -> bool,
-    ) -> QueryPipelineAsCompositeShapeWithPredicate {
+    ) -> QueryPipelineAsCompositeShapeWithPredicate<'a, 'b> {
         QueryPipelineAsCompositeShapeWithPredicate {
             pipeline: self,
             colliders: &self.colliders,
@@ -124,7 +124,7 @@ impl SpatialQueryPipeline {
             &'a HashMap<Entity, (Isometry<Scalar>, Collider, CollisionLayers)>,
         );
 
-        impl<'a> parry::partitioning::QbvhDataGenerator<u32> for DataGenerator<'a> {
+        impl parry::partitioning::QbvhDataGenerator<u32> for DataGenerator<'_> {
             fn size_hint(&self) -> usize {
                 self.0.len()
             }
@@ -812,7 +812,7 @@ pub(crate) struct QueryPipelineAsCompositeShape<'a> {
     query_filter: &'a SpatialQueryFilter,
 }
 
-impl<'a> TypedSimdCompositeShape for QueryPipelineAsCompositeShape<'a> {
+impl TypedSimdCompositeShape for QueryPipelineAsCompositeShape<'_> {
     type PartShape = dyn Shape;
     type PartNormalConstraints = dyn NormalConstraints;
     type PartId = u32;
@@ -858,7 +858,7 @@ pub(crate) struct QueryPipelineAsCompositeShapeWithPredicate<'a, 'b> {
     predicate: &'b dyn Fn(Entity) -> bool,
 }
 
-impl<'a, 'b> TypedSimdCompositeShape for QueryPipelineAsCompositeShapeWithPredicate<'a, 'b> {
+impl TypedSimdCompositeShape for QueryPipelineAsCompositeShapeWithPredicate<'_, '_> {
     type PartShape = dyn Shape;
     type PartNormalConstraints = dyn NormalConstraints;
     type PartId = u32;

--- a/src/spatial_query/system_param.rs
+++ b/src/spatial_query/system_param.rs
@@ -77,7 +77,7 @@ pub struct SpatialQuery<'w, 's> {
     pub query_pipeline: ResMut<'w, SpatialQueryPipeline>,
 }
 
-impl<'w, 's> SpatialQuery<'w, 's> {
+impl SpatialQuery<'_, '_> {
     /// Updates the colliders in the pipeline. This is done automatically once per physics frame in
     /// [`PhysicsStepSet::SpatialQuery`], but if you modify colliders or their positions before that, you can
     /// call this to make sure the data is up to date when performing spatial queries using [`SpatialQuery`].


### PR DESCRIPTION
# Objective

Rust 1.83.0 was just released, and CI is complaining because of new lints, mainly for ellided lifetimes.

## Solution

Fix lints!