### PR TITLE
Migrate from Bevy 0.15 RC to full 0.15

### DIFF
--- a/crates/avian2d/Cargo.toml
+++ b/crates/avian2d/Cargo.toml
@@ -80,7 +80,7 @@ glam = { version = "0.29", features = ["bytemuck"] }
 approx = "0.5"
 bytemuck = "1.19"
 criterion = { version = "0.5", features = ["html_reports"] }
-bevy_mod_debugdump = { git = "https://github.com/andriyDev/bevy_mod_debugdump", branch = "bevy-0.15" }
+bevy_mod_debugdump = { git = "https://github.com/jakobhellermann/bevy_mod_debugdump" }
 
 [[example]]
 name = "dynamic_character_2d"

--- a/crates/avian2d/Cargo.toml
+++ b/crates/avian2d/Cargo.toml
@@ -66,7 +66,7 @@ parry2d = { version = "0.17", optional = true }
 parry2d-f64 = { version = "0.17", optional = true }
 nalgebra = { version = "0.33", features = ["convert-glam029"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
-derive_more = "0.99"
+derive_more = "1"
 indexmap = "2.0.0"
 fxhash = "0.2.1"
 itertools = "0.13"

--- a/crates/avian2d/Cargo.toml
+++ b/crates/avian2d/Cargo.toml
@@ -59,8 +59,8 @@ bench = false
 
 [dependencies]
 avian_derive = { path = "../avian_derive", version = "0.1" }
-bevy = { version = "0.15.0-rc", default-features = false }
-bevy_math = { version = "0.15.0-rc" }
+bevy = { version = "0.15", default-features = false }
+bevy_math = { version = "0.15" }
 libm = { version = "0.2", optional = true }
 parry2d = { version = "0.17", optional = true }
 parry2d-f64 = { version = "0.17", optional = true }
@@ -75,7 +75,7 @@ bitflags = "2.5.0"
 [dev-dependencies]
 examples_common_2d = { path = "../examples_common_2d" }
 benches_common_2d = { path = "../benches_common_2d" }
-bevy_math = { version = "0.15.0-rc", features = ["approx"] }
+bevy_math = { version = "0.15", features = ["approx"] }
 glam = { version = "0.29", features = ["bytemuck"] }
 approx = "0.5"
 bytemuck = "1.19"

--- a/crates/avian2d/examples/dynamic_character_2d/plugin.rs
+++ b/crates/avian2d/examples/dynamic_character_2d/plugin.rs
@@ -150,11 +150,11 @@ fn gamepad_input(
     gamepads: Query<&Gamepad>,
 ) {
     for gamepad in gamepads.iter() {
-        if let Some(x) = gamepad.analog.get(GamepadAxis::LeftStickX) {
+        if let Some(x) = gamepad.get(GamepadAxis::LeftStickX) {
             movement_event_writer.send(MovementAction::Move(x as Scalar));
         }
 
-        if gamepad.digital.just_pressed(GamepadButton::South) {
+        if gamepad.just_pressed(GamepadButton::South) {
             movement_event_writer.send(MovementAction::Jump);
         }
     }

--- a/crates/avian2d/examples/kinematic_character_2d/plugin.rs
+++ b/crates/avian2d/examples/kinematic_character_2d/plugin.rs
@@ -164,11 +164,11 @@ fn gamepad_input(
     gamepads: Query<&Gamepad>,
 ) {
     for gamepad in gamepads.iter() {
-        if let Some(x) = gamepad.analog.get(GamepadAxis::LeftStickX) {
+        if let Some(x) = gamepad.get(GamepadAxis::LeftStickX) {
             movement_event_writer.send(MovementAction::Move(x as Scalar));
         }
 
-        if gamepad.digital.just_pressed(GamepadButton::South) {
+        if gamepad.just_pressed(GamepadButton::South) {
             movement_event_writer.send(MovementAction::Jump);
         }
     }

--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -77,13 +77,14 @@ bitflags = "2.5.0"
 [dev-dependencies]
 bevy = { version = "0.15.0-rc", default-features = false, features = [
     "bevy_gltf",
+    "animation",
 ] }
 examples_common_3d = { path = "../examples_common_3d" }
 benches_common_3d = { path = "../benches_common_3d" }
 bevy_math = { version = "0.15.0-rc", features = ["approx"] }
 approx = "0.5"
 criterion = { version = "0.5", features = ["html_reports"] }
-bevy_mod_debugdump = { git = "https://github.com/andriyDev/bevy_mod_debugdump", branch = "bevy-0.15" }
+bevy_mod_debugdump = { git = "https://github.com/jakobhellermann/bevy_mod_debugdump" }
 
 [[example]]
 name = "dynamic_character_3d"

--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -61,8 +61,8 @@ bench = false
 
 [dependencies]
 avian_derive = { path = "../avian_derive", version = "0.1" }
-bevy = { version = "0.15.0-rc", default-features = false }
-bevy_math = { version = "0.15.0-rc" }
+bevy = { version = "0.15", default-features = false }
+bevy_math = { version = "0.15" }
 libm = { version = "0.2", optional = true }
 parry3d = { version = "0.17", optional = true }
 parry3d-f64 = { version = "0.17", optional = true }
@@ -75,13 +75,13 @@ itertools = "0.13"
 bitflags = "2.5.0"
 
 [dev-dependencies]
-bevy = { version = "0.15.0-rc", default-features = false, features = [
+bevy = { version = "0.15", default-features = false, features = [
     "bevy_gltf",
     "animation",
 ] }
 examples_common_3d = { path = "../examples_common_3d" }
 benches_common_3d = { path = "../benches_common_3d" }
-bevy_math = { version = "0.15.0-rc", features = ["approx"] }
+bevy_math = { version = "0.15", features = ["approx"] }
 approx = "0.5"
 criterion = { version = "0.5", features = ["html_reports"] }
 bevy_mod_debugdump = { git = "https://github.com/jakobhellermann/bevy_mod_debugdump" }

--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -68,7 +68,7 @@ parry3d = { version = "0.17", optional = true }
 parry3d-f64 = { version = "0.17", optional = true }
 nalgebra = { version = "0.33", features = ["convert-glam029"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
-derive_more = "0.99"
+derive_more = "1"
 indexmap = "2.0.0"
 fxhash = "0.2.1"
 itertools = "0.13"

--- a/crates/avian3d/examples/dynamic_character_3d/plugin.rs
+++ b/crates/avian3d/examples/dynamic_character_3d/plugin.rs
@@ -159,15 +159,15 @@ fn gamepad_input(
 ) {
     for gamepad in gamepads.iter() {
         if let (Some(x), Some(y)) = (
-            gamepad.analog.get(GamepadAxis::LeftStickX),
-            gamepad.analog.get(GamepadAxis::LeftStickY),
+            gamepad.get(GamepadAxis::LeftStickX),
+            gamepad.get(GamepadAxis::LeftStickY),
         ) {
             movement_event_writer.send(MovementAction::Move(
                 Vector2::new(x as Scalar, y as Scalar).clamp_length_max(1.0),
             ));
         }
 
-        if gamepad.digital.just_pressed(GamepadButton::South) {
+        if gamepad.just_pressed(GamepadButton::South) {
             movement_event_writer.send(MovementAction::Jump);
         }
     }

--- a/crates/avian3d/examples/kinematic_character_3d/plugin.rs
+++ b/crates/avian3d/examples/kinematic_character_3d/plugin.rs
@@ -174,15 +174,15 @@ fn gamepad_input(
 ) {
     for gamepad in gamepads.iter() {
         if let (Some(x), Some(y)) = (
-            gamepad.analog.get(GamepadAxis::LeftStickX),
-            gamepad.analog.get(GamepadAxis::LeftStickY),
+            gamepad.get(GamepadAxis::LeftStickX),
+            gamepad.get(GamepadAxis::LeftStickY),
         ) {
             movement_event_writer.send(MovementAction::Move(
                 Vector2::new(x as Scalar, y as Scalar).clamp_length_max(1.0),
             ));
         }
 
-        if gamepad.digital.just_pressed(GamepadButton::South) {
+        if gamepad.just_pressed(GamepadButton::South) {
             movement_event_writer.send(MovementAction::Jump);
         }
     }

--- a/crates/benches_common_2d/Cargo.toml
+++ b/crates/benches_common_2d/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = { version = "0.15.0-rc", default-features = false }
+bevy = { version = "0.15", default-features = false }
 avian2d = { path = "../avian2d", default-features = false }
 criterion = "0.5"

--- a/crates/benches_common_3d/Cargo.toml
+++ b/crates/benches_common_3d/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = { version = "0.15.0-rc", default-features = false }
+bevy = { version = "0.15", default-features = false }
 avian3d = { path = "../avian3d", default-features = false }
 criterion = "0.5"

--- a/crates/examples_common_2d/Cargo.toml
+++ b/crates/examples_common_2d/Cargo.toml
@@ -22,6 +22,7 @@ bevy = { version = "0.15.0-rc", default-features = false, features = [
     "ktx2",
     "zstd",
     "bevy_winit",
+    "bevy_window",
     "x11",                # github actions runners don't have libxkbcommon installed, so can't use wayland
 ] }
 avian2d = { path = "../avian2d", default-features = false }

--- a/crates/examples_common_2d/Cargo.toml
+++ b/crates/examples_common_2d/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 use-debug-plugin = []
 
 [dependencies]
-bevy = { version = "0.15.0-rc", default-features = false, features = [
+bevy = { version = "0.15", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_state",
     "bevy_text",

--- a/crates/examples_common_3d/Cargo.toml
+++ b/crates/examples_common_3d/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 use-debug-plugin = []
 
 [dependencies]
-bevy = { version = "0.15.0-rc", default-features = false, features = [
+bevy = { version = "0.15", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_state",
     "bevy_text",

--- a/crates/examples_common_3d/Cargo.toml
+++ b/crates/examples_common_3d/Cargo.toml
@@ -18,12 +18,14 @@ bevy = { version = "0.15.0-rc", default-features = false, features = [
     "bevy_pbr",
     "bevy_gizmos",
     "bevy_gltf",
+    "animation",
     "default_font",
     "tonemapping_luts",
     "ktx2",
     "png",
     "zstd",
     "bevy_winit",
+    "bevy_window",
     "x11",                # github actions runners don't have libxkbcommon installed, so can't use wayland
 ] }
 avian3d = { path = "../avian3d", default-features = false }


### PR DESCRIPTION
# Objective

The full 0.15 release has a few breaking changes from the release candidate.

## Solution

Fix them! Also changed `bevy_mod_debugdump` to use the main branch instead of the 0.15 PR's branch, since it has now been updated.