### PR TITLE
Fix rotation multiplication order in `transform_to_position`

### DIFF
--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -268,13 +268,13 @@ pub fn transform_to_position(
         {
             let rot = Rotation::from(transform.rotation.adjust_precision());
             let prev_rot = Rotation::from(previous_transform.rotation.adjust_precision());
-            *rotation = prev_rot * (rot * prev_rot.inverse()) * (*rotation * prev_rot.inverse());
+            *rotation = prev_rot * (prev_rot.inverse() * rot) * (prev_rot.inverse() * *rotation);
         }
         #[cfg(feature = "3d")]
         {
             rotation.0 = (previous_transform.rotation
-                * (transform.rotation * previous_transform.rotation.inverse())
-                * (rotation.f32() * previous_transform.rotation.inverse()))
+                * (previous_transform.rotation.inverse() * transform.rotation)
+                * (previous_transform.rotation.inverse() * rotation.f32()))
             .adjust_precision();
         }
     }


### PR DESCRIPTION
# Objective

Fixes #522.

The order of multiplication for the quaternions in `transform_to_position` seems to be wrong, which can cause desync between `Transform` rotation and `Rotation` when `position_to_transform` in `SyncConfig` is `false`.

## Solution

Flip the order of multiplication where relevant.

There is now no desync:

https://github.com/user-attachments/assets/9b6f8ae0-4cdd-4b54-8490-726d24932a84