### PR TITLE
Initial diagnostics implementation.

### DIFF
--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -143,6 +143,10 @@ name = "collider_constructors"
 required-features = ["3d", "default-collider", "bevy_scene"]
 
 [[example]]
+name = "diagnostics"
+required-features = ["3d", "default-collider"]
+
+[[example]]
 name = "debugdump_3d"
 required-features = ["3d"]
 

--- a/crates/avian3d/examples/diagnostics.rs
+++ b/crates/avian3d/examples/diagnostics.rs
@@ -1,0 +1,105 @@
+#![allow(clippy::unnecessary_cast)]
+
+use avian3d::{diagnostics::*, math::*, prelude::*};
+use bevy::diagnostic::LogDiagnosticsPlugin;
+use bevy::prelude::*;
+use examples_common_3d::ExampleCommonPlugin;
+
+fn main() {
+    App::new()
+        .add_plugins((
+            DefaultPlugins,
+            LogDiagnosticsPlugin::default(),
+            ExampleCommonPlugin,
+            PhysicsPlugins::default(),
+            PhysicsDiagnosticsPlugin,
+        ))
+        .insert_resource(ClearColor(Color::srgb(0.05, 0.05, 0.1)))
+        .add_systems(Startup, setup)
+        .add_systems(Update, movement)
+        .run();
+}
+
+/// The acceleration used for movement.
+#[derive(Component)]
+struct MovementAcceleration(Scalar);
+
+fn setup(
+    mut commands: Commands,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+    mut meshes: ResMut<Assets<Mesh>>,
+) {
+    let cube_mesh = meshes.add(Cuboid::default());
+
+    // Ground
+    commands.spawn((
+        Mesh3d(cube_mesh.clone()),
+        MeshMaterial3d(materials.add(Color::srgb(0.7, 0.7, 0.8))),
+        Transform::from_xyz(0.0, -2.0, 0.0).with_scale(Vec3::new(100.0, 1.0, 100.0)),
+        RigidBody::Static,
+        Collider::cuboid(1.0, 1.0, 1.0),
+    ));
+
+    let cube_size = 2.0;
+
+    // Spawn cube stacks
+    for x in -2..2 {
+        for y in -2..2 {
+            for z in -2..2 {
+                let position = Vec3::new(x as f32, y as f32 + 3.0, z as f32) * (cube_size + 0.05);
+                commands.spawn((
+                    Mesh3d(cube_mesh.clone()),
+                    MeshMaterial3d(materials.add(Color::srgb(0.2, 0.7, 0.9))),
+                    Transform::from_translation(position).with_scale(Vec3::splat(cube_size as f32)),
+                    RigidBody::Dynamic,
+                    Collider::cuboid(1.0, 1.0, 1.0),
+                    MovementAcceleration(10.0),
+                ));
+            }
+        }
+    }
+
+    // Directional light
+    commands.spawn((
+        DirectionalLight {
+            illuminance: 5000.0,
+            shadows_enabled: true,
+            ..default()
+        },
+        Transform::default().looking_at(Vec3::new(-1.0, -2.5, -1.5), Vec3::Y),
+    ));
+
+    // Camera
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_translation(Vec3::new(0.0, 12.0, 40.0)).looking_at(Vec3::Y * 5.0, Vec3::Y),
+    ));
+}
+
+fn movement(
+    time: Res<Time>,
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+    mut query: Query<(&MovementAcceleration, &mut LinearVelocity)>,
+) {
+    // Precision is adjusted so that the example works with
+    // both the `f32` and `f64` features. Otherwise you don't need this.
+    let delta_time = time.delta_secs_f64().adjust_precision();
+
+    for (movement_acceleration, mut linear_velocity) in &mut query {
+        let up = keyboard_input.any_pressed([KeyCode::KeyW, KeyCode::ArrowUp]);
+        let down = keyboard_input.any_pressed([KeyCode::KeyS, KeyCode::ArrowDown]);
+        let left = keyboard_input.any_pressed([KeyCode::KeyA, KeyCode::ArrowLeft]);
+        let right = keyboard_input.any_pressed([KeyCode::KeyD, KeyCode::ArrowRight]);
+
+        let horizontal = right as i8 - left as i8;
+        let vertical = down as i8 - up as i8;
+        let direction =
+            Vector::new(horizontal as Scalar, 0.0, vertical as Scalar).normalize_or_zero();
+
+        // Move in input direction
+        if direction != Vector::ZERO {
+            linear_velocity.x += direction.x * movement_acceleration.0 * delta_time;
+            linear_velocity.z += direction.z * movement_acceleration.0 * delta_time;
+        }
+    }
+}

--- a/src/diagnostics/mod.rs
+++ b/src/diagnostics/mod.rs
@@ -1,0 +1,135 @@
+//! Basic diagnostics support.
+
+mod span_recorder;
+
+use crate::{
+    collision::{ColliderMarker, Collisions},
+    dynamics::rigid_body::RigidBody,
+    schedule::{PhysicsSchedule, PhysicsStepSet},
+};
+use bevy::{
+    app::{App, Plugin},
+    diagnostic::{Diagnostic, DiagnosticPath, Diagnostics, RegisterDiagnostic},
+    prelude::{IntoSystemConfigs, PostUpdate, Query, Res, ResMut},
+};
+use span_recorder::{PhysicsSpan, PhysicsSpanRecorder};
+
+/// A plugin that adds various diagnostics for debugging purposes.
+/// It is not enabled by default and must be added manually.
+pub struct PhysicsDiagnosticsPlugin;
+
+impl PhysicsDiagnosticsPlugin {
+    /// Duration of [`PhysicsStepSet::BroadPhase`]
+    pub const BROAD_TIME: DiagnosticPath = DiagnosticPath::const_new("avian/broad_time");
+    /// Duration of [`PhysicsStepSet::NarrowPhase`]
+    pub const NARROW_TIME: DiagnosticPath = DiagnosticPath::const_new("avian/narrow_time");
+    /// Duration of [`PhysicsStepSet::Solver`]
+    pub const SOLVER_TIME: DiagnosticPath = DiagnosticPath::const_new("avian/solver_time");
+    /// Duration of [`PhysicsStepSet::ReportContacts`]
+    pub const REPORT_TIME: DiagnosticPath = DiagnosticPath::const_new("avian/report_time");
+    /// Duration of [`PhysicsStepSet::SpatialQuery`]
+    pub const SPATIAL_TIME: DiagnosticPath = DiagnosticPath::const_new("avian/spatial_time");
+    /// Count of [`RigidBody`]
+    pub const RIGIDS_COUNT: DiagnosticPath = DiagnosticPath::const_new("avian/rigids_count");
+    /// Count of [`ColliderMarker`]
+    pub const COLLIDERS_COUNT: DiagnosticPath = DiagnosticPath::const_new("avian/colliders_count");
+    /// Count of collision pairs
+    pub const CONTACTS_COUNT: DiagnosticPath = DiagnosticPath::const_new("avian/contacts_count");
+}
+
+impl Plugin for PhysicsDiagnosticsPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<PhysicsSpanRecorder>()
+            .register_diagnostic(Diagnostic::new(Self::BROAD_TIME).with_suffix("ms"))
+            .register_diagnostic(Diagnostic::new(Self::NARROW_TIME).with_suffix("ms"))
+            .register_diagnostic(Diagnostic::new(Self::SOLVER_TIME).with_suffix("ms"))
+            .register_diagnostic(Diagnostic::new(Self::SPATIAL_TIME).with_suffix("ms"))
+            .register_diagnostic(Diagnostic::new(Self::REPORT_TIME).with_suffix("ms"))
+            .register_diagnostic(Diagnostic::new(Self::RIGIDS_COUNT))
+            .register_diagnostic(Diagnostic::new(Self::COLLIDERS_COUNT))
+            .register_diagnostic(Diagnostic::new(Self::CONTACTS_COUNT))
+            .add_systems(
+                PhysicsSchedule,
+                diagnostics_frame_start_system.in_set(PhysicsStepSet::DiagnosticsInitialise),
+            )
+            .add_systems(
+                PhysicsSchedule,
+                diagnostics_frame_end_system.in_set(PhysicsStepSet::DiagnosticsFinalise),
+            )
+            .add_systems(PostUpdate, diagnostic_counts_system);
+
+        for (span_type, start_set, end_set) in [
+            (
+                PhysicsSpan::BroadPhase,
+                PhysicsStepSet::PreBroadPhase,
+                PhysicsStepSet::PostBroadPhase,
+            ),
+            (
+                PhysicsSpan::NarrowPhase,
+                PhysicsStepSet::PreNarrowPhase,
+                PhysicsStepSet::PostNarrowPhase,
+            ),
+            (
+                PhysicsSpan::Solver,
+                PhysicsStepSet::PreSolver,
+                PhysicsStepSet::PostSolver,
+            ),
+            (
+                PhysicsSpan::ReportContacts,
+                PhysicsStepSet::PreReportContacts,
+                PhysicsStepSet::PostReportContacts,
+            ),
+            (
+                PhysicsSpan::SpatialQueries,
+                PhysicsStepSet::PreSpatialQuery,
+                PhysicsStepSet::PostSpatialQuery,
+            ),
+        ] {
+            app.add_systems(
+                PhysicsSchedule,
+                start_span_wrapper(span_type).in_set(start_set),
+            )
+            .add_systems(PhysicsSchedule, end_span_wrapper(span_type).in_set(end_set));
+        }
+    }
+}
+
+fn start_span_wrapper(span_type: PhysicsSpan) -> impl FnMut(ResMut<PhysicsSpanRecorder>) {
+    move |mut diagnostic_recorder: ResMut<PhysicsSpanRecorder>| {
+        diagnostic_recorder.start_span(span_type);
+    }
+}
+
+fn end_span_wrapper(span_type: PhysicsSpan) -> impl FnMut(ResMut<PhysicsSpanRecorder>) {
+    move |mut diagnostic_recorder: ResMut<PhysicsSpanRecorder>| {
+        diagnostic_recorder.end_span(span_type);
+    }
+}
+
+fn diagnostics_frame_start_system(mut diagnostic_recorder: ResMut<PhysicsSpanRecorder>) {
+    diagnostic_recorder.reset();
+}
+
+fn diagnostics_frame_end_system(
+    diagnostic_recorder: ResMut<PhysicsSpanRecorder>,
+    mut diagnostics: Diagnostics,
+) {
+    diagnostic_recorder.finalise(&mut diagnostics);
+}
+
+fn diagnostic_counts_system(
+    mut diagnostics: Diagnostics,
+    rigid_bodies_query: Query<&RigidBody>,
+    colliders_query: Query<&ColliderMarker>,
+    collisions: Res<Collisions>,
+) {
+    diagnostics.add_measurement(&PhysicsDiagnosticsPlugin::RIGIDS_COUNT, || {
+        rigid_bodies_query.iter().count() as f64
+    });
+    diagnostics.add_measurement(&PhysicsDiagnosticsPlugin::COLLIDERS_COUNT, || {
+        colliders_query.iter().count() as f64
+    });
+    diagnostics.add_measurement(&PhysicsDiagnosticsPlugin::CONTACTS_COUNT, || {
+        collisions.iter().count() as f64
+    });
+}

--- a/src/diagnostics/span_recorder.rs
+++ b/src/diagnostics/span_recorder.rs
@@ -1,0 +1,90 @@
+use crate::diagnostics::PhysicsDiagnosticsPlugin;
+use bevy::{diagnostic::Diagnostics, log::warn, prelude::Resource};
+use std::{collections::HashMap, time::Instant};
+
+#[derive(Hash, Eq, PartialEq, Debug, Copy, Clone)]
+pub enum PhysicsSpan {
+    BroadPhase,
+    NarrowPhase,
+    Solver,
+    #[allow(dead_code)]
+    SolverStage(SolverStageSpan),
+    ReportContacts,
+    SpatialQueries,
+}
+
+#[allow(dead_code)]
+#[derive(Hash, Eq, PartialEq, Debug, Copy, Clone)]
+pub enum SolverStageSpan {
+    Prepare,
+    WarmStart,
+    IntegrateVelocities,
+    SolveConstraints,
+    IntegratePositions,
+    RelaxVelocities,
+    ApplyRestitution,
+    Finalize,
+    StoreImpulses,
+}
+
+pub struct SpanRecord {
+    started_at: Instant,
+    finished_at: Option<Instant>,
+}
+
+#[derive(Resource, Default)]
+pub struct PhysicsSpanRecorder {
+    spans: HashMap<PhysicsSpan, SpanRecord>,
+}
+
+impl PhysicsSpanRecorder {
+    pub fn reset(&mut self) {
+        self.spans.clear();
+    }
+
+    pub fn finalise(&self, diagnostics: &mut Diagnostics) {
+        for (span_type, span_record) in self.spans.iter() {
+            let Some(finished_at) = span_record.finished_at else {
+                warn!("No end instant for span_type: {:?}", span_type);
+                continue;
+            };
+
+            if let Some(diagnostic_path) = match span_type {
+                PhysicsSpan::BroadPhase => Some(PhysicsDiagnosticsPlugin::BROAD_TIME),
+                PhysicsSpan::NarrowPhase => Some(PhysicsDiagnosticsPlugin::NARROW_TIME),
+                PhysicsSpan::Solver => Some(PhysicsDiagnosticsPlugin::SOLVER_TIME),
+                PhysicsSpan::ReportContacts => Some(PhysicsDiagnosticsPlugin::REPORT_TIME),
+                PhysicsSpan::SpatialQueries => Some(PhysicsDiagnosticsPlugin::SPATIAL_TIME),
+                PhysicsSpan::SolverStage(_) => None,
+            } {
+                diagnostics.add_measurement(&diagnostic_path, || {
+                    finished_at
+                        .duration_since(span_record.started_at)
+                        .as_secs_f64()
+                        * 1000.0
+                });
+            }
+        }
+    }
+
+    pub fn start_span(&mut self, span_type: PhysicsSpan) {
+        self.spans.insert(
+            span_type,
+            SpanRecord {
+                started_at: Instant::now(),
+                finished_at: None,
+            },
+        );
+    }
+
+    pub fn end_span(&mut self, span_type: PhysicsSpan) {
+        match self.spans.get_mut(&span_type) {
+            None => {
+                warn!("No span found for span_type: {:?}", span_type);
+            }
+            Some(record) => {
+                record.finished_at = Some(Instant::now());
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -450,6 +450,7 @@ pub extern crate parry3d_f64 as parry;
 pub mod collision;
 #[cfg(feature = "debug-plugin")]
 pub mod debug_render;
+pub mod diagnostics;
 pub mod dynamics;
 pub mod math;
 #[cfg(feature = "bevy_picking")]

--- a/src/schedule/mod.rs
+++ b/src/schedule/mod.rs
@@ -83,14 +83,26 @@ impl Plugin for PhysicsSchedulePlugin {
 
             schedule.configure_sets(
                 (
+                    PhysicsStepSet::DiagnosticsInitialise,
                     PhysicsStepSet::First,
+                    PhysicsStepSet::PreBroadPhase,
                     PhysicsStepSet::BroadPhase,
+                    PhysicsStepSet::PostBroadPhase,
+                    PhysicsStepSet::PreNarrowPhase,
                     PhysicsStepSet::NarrowPhase,
+                    PhysicsStepSet::PostNarrowPhase,
+                    PhysicsStepSet::PreSolver,
                     PhysicsStepSet::Solver,
+                    PhysicsStepSet::PostSolver,
+                    PhysicsStepSet::PreReportContacts,
                     PhysicsStepSet::ReportContacts,
+                    PhysicsStepSet::PostReportContacts,
                     PhysicsStepSet::Sleeping,
+                    PhysicsStepSet::PreSpatialQuery,
                     PhysicsStepSet::SpatialQuery,
+                    PhysicsStepSet::PostSpatialQuery,
                     PhysicsStepSet::Last,
+                    PhysicsStepSet::DiagnosticsFinalise,
                 )
                     .chain(),
             );
@@ -223,35 +235,59 @@ pub enum PhysicsSet {
 /// 8. Last (empty by default)
 #[derive(SystemSet, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum PhysicsStepSet {
+    /// Diagnostic hook
+    DiagnosticsInitialise,
     /// Runs at the start of the [`PhysicsSchedule`]. Empty by default.
     First,
+    /// Diagnostic hook
+    PreBroadPhase,
     /// Responsible for collecting pairs of potentially colliding entities into [`BroadCollisionPairs`] using
     /// [AABB](ColliderAabb) intersection tests.
     ///
     /// See [`BroadPhasePlugin`].
     BroadPhase,
+    /// Diagnostic hook
+    PostBroadPhase,
+    /// Diagnostic hook
+    PreNarrowPhase,
     /// Responsible for computing contacts between entities and sending collision events.
     ///
     /// See [`NarrowPhasePlugin`].
     NarrowPhase,
+    /// Diagnostic hook
+    PostNarrowPhase,
+    /// Diagnostic hook
+    PreSolver,
     /// Responsible for running the solver and its substepping loop.
     ///
     /// See [`SolverPlugin`] and [`SubstepSchedule`].
     Solver,
+    /// Diagnostic hook
+    PostSolver,
+    /// Diagnostic hook
+    PreReportContacts,
     /// Responsible for sending collision events and updating [`CollidingEntities`].
     ///
     /// See [`ContactReportingPlugin`].
     ReportContacts,
+    /// Diagnostic hook
+    PostReportContacts,
     /// Responsible for controlling when bodies should be deactivated and marked as [`Sleeping`].
     ///
     /// See [`SleepingPlugin`].
     Sleeping,
+    /// Diagnostic hook
+    PreSpatialQuery,
     /// Responsible for spatial queries like [raycasting](`RayCaster`) and shapecasting.
     ///
     /// See [`SpatialQueryPlugin`].
     SpatialQuery,
+    /// Diagnostic hook
+    PostSpatialQuery,
     /// Runs at the end of the [`PhysicsSchedule`]. Empty by default.
     Last,
+    /// Diagnostic hook
+    DiagnosticsFinalise,
 }
 
 /// The number of substeps used in the simulation.


### PR DESCRIPTION
# Objective

Add basic diagnostic measurements as outlined in issue #564.

## Solution

Implements optional high-level timing and count metrics using `bevy_diagnostic` and a new `PhysicsDiagnosticsPlugin`.

Currently supports:

- Broad phase duration
- Narrow phase duration
- Solver duration
- Send collision events duration
- Spatial query updates duration

- Rigid body count
- Collider count
- Contacts count

In progress:

- Solver sub phases durations
- Optional UI for plotting diagnostics
---

## Changelog

### Added

- `diagnostics` module
- `diagnostics::PhysicsDiagnosticsPlugin` plugin
- diagnostics example (currently a clone of the cubes example)

### Changed

- New `PhysicsStepSet` variants added to allow for hooking timing measurements without adding a mess of `before()` / `after()` run conditions

