### PR TITLE
Make sure `Collider::triangle` is oriented CCW

### DIFF
--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -734,8 +734,8 @@ impl Collider {
 
     /// Creates a collider with a triangle shape defined by its points `a`, `b`, and `c`.
     ///
-    /// If the triangle is oriented clockwise, it will be reversed to be counterclockwise.
-    /// This is needed for collision detection.
+    /// If the triangle is oriented clockwise, it will be reversed to be counterclockwise
+    /// by swapping `b` and `c`. This is needed for collision detection.
     ///
     /// If you know that the given points produce a counterclockwise triangle,
     /// consider using [`Collider::triangle_unchecked`] instead.

--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -733,6 +733,23 @@ impl Collider {
     }
 
     /// Creates a collider with a triangle shape defined by its points `a`, `b` and `c`.
+    ///
+    /// If the triangle is oriented clockwise, it will be reversed to be counter-clockwise.
+    /// This is needed for collision detection.
+    #[cfg(feature = "2d")]
+    pub fn triangle(a: Vector, b: Vector, c: Vector) -> Self {
+        let mut triangle = parry::shape::Triangle::new(a.into(), b.into(), c.into());
+
+        // Make sure the triangle is counter-clockwise. This is needed for collision detection.
+        if triangle.orientation(1e-8) == parry::shape::TriangleOrientation::Clockwise {
+            triangle.reverse();
+        }
+
+        SharedShape::new(triangle).into()
+    }
+
+    /// Creates a collider with a triangle shape defined by its points `a`, `b` and `c`.
+    #[cfg(feature = "3d")]
     pub fn triangle(a: Vector, b: Vector, c: Vector) -> Self {
         SharedShape::triangle(a.into(), b.into(), c.into()).into()
     }

--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -732,15 +732,18 @@ impl Collider {
         SharedShape::segment(a.into(), b.into()).into()
     }
 
-    /// Creates a collider with a triangle shape defined by its points `a`, `b` and `c`.
+    /// Creates a collider with a triangle shape defined by its points `a`, `b`, and `c`.
     ///
-    /// If the triangle is oriented clockwise, it will be reversed to be counter-clockwise.
+    /// If the triangle is oriented clockwise, it will be reversed to be counterclockwise.
     /// This is needed for collision detection.
+    ///
+    /// If you know that the given points produce a counterclockwise triangle,
+    /// consider using [`Collider::triangle_unchecked`] instead.
     #[cfg(feature = "2d")]
     pub fn triangle(a: Vector, b: Vector, c: Vector) -> Self {
         let mut triangle = parry::shape::Triangle::new(a.into(), b.into(), c.into());
 
-        // Make sure the triangle is counter-clockwise. This is needed for collision detection.
+        // Make sure the triangle is counterclockwise. This is needed for collision detection.
         if triangle.orientation(1e-8) == parry::shape::TriangleOrientation::Clockwise {
             triangle.reverse();
         }
@@ -748,7 +751,18 @@ impl Collider {
         SharedShape::new(triangle).into()
     }
 
-    /// Creates a collider with a triangle shape defined by its points `a`, `b` and `c`.
+    /// Creates a collider with a triangle shape defined by its points `a`, `b`, and `c`.
+    ///
+    /// The orientation of the triangle is assumed to be counterclockwise.
+    /// This is needed for collision detection.
+    ///
+    /// If you are unsure about the orientation of the triangle, consider using [`Collider::triangle`] instead.
+    #[cfg(feature = "2d")]
+    pub fn triangle_unchecked(a: Vector, b: Vector, c: Vector) -> Self {
+        SharedShape::triangle(a.into(), b.into(), c.into()).into()
+    }
+
+    /// Creates a collider with a triangle shape defined by its points `a`, `b`, and `c`.
     #[cfg(feature = "3d")]
     pub fn triangle(a: Vector, b: Vector, c: Vector) -> Self {
         SharedShape::triangle(a.into(), b.into(), c.into()).into()


### PR DESCRIPTION
# Objective

Fixes #368.

Many users create 2D triangle colliders with clockwise orientation. However, this produces a collider that doesn't work, as Parry seems to require conterclockwise orientation.

## Solution

Check the orientation in `Collider::triangle`, and reverse it if necessary. If the orientation is known to be counterclockwise, `Collider::triangle_unchecked` can be used instead.