### PR TITLE
Add `MaxLinearSpeed` and `MaxAngularSpeed`

### DIFF
--- a/src/dynamics/integrator/mod.rs
+++ b/src/dynamics/integrator/mod.rs
@@ -159,6 +159,8 @@ struct VelocityIntegrationQuery {
     global_angular_inertia: &'static GlobalAngularInertia,
     lin_damping: Option<&'static LinearDamping>,
     ang_damping: Option<&'static AngularDamping>,
+    max_linear_speed: Option<&'static MaxLinearSpeed>,
+    max_angular_speed: Option<&'static MaxAngularSpeed>,
     gravity_scale: Option<&'static GravityScale>,
     locked_axes: Option<&'static LockedAxes>,
 }
@@ -225,6 +227,27 @@ fn integrate_velocities(
             gravity,
             delta_secs,
         );
+
+        // Clamp velocities
+        if let Some(max_linear_speed) = body.max_linear_speed {
+            let linear_speed_squared = body.lin_vel.0.length_squared();
+            if linear_speed_squared > max_linear_speed.0.powi(2) {
+                body.lin_vel.0 *= max_linear_speed.0 / linear_speed_squared.sqrt();
+            }
+        }
+        if let Some(max_angular_speed) = body.max_angular_speed {
+            #[cfg(feature = "2d")]
+            if body.ang_vel.0 > max_angular_speed.0 {
+                body.ang_vel.0 = max_angular_speed.copysign(body.ang_vel.0);
+            }
+            #[cfg(feature = "3d")]
+            {
+                let angular_speed_squared = body.ang_vel.0.length_squared();
+                if angular_speed_squared > max_angular_speed.0.powi(2) {
+                    body.ang_vel.0 *= max_angular_speed.0 / angular_speed_squared.sqrt();
+                }
+            }
+        }
     });
 }
 

--- a/src/dynamics/integrator/mod.rs
+++ b/src/dynamics/integrator/mod.rs
@@ -235,7 +235,7 @@ fn integrate_velocities(
         }
         if let Some(max_angular_speed) = body.max_angular_speed {
             #[cfg(feature = "2d")]
-            if body.ang_vel.0 > max_angular_speed.0 {
+            if body.ang_vel.abs() > max_angular_speed.0 {
                 body.ang_vel.0 = max_angular_speed.copysign(body.ang_vel.0);
             }
             #[cfg(feature = "3d")]

--- a/src/dynamics/integrator/mod.rs
+++ b/src/dynamics/integrator/mod.rs
@@ -189,41 +189,41 @@ fn integrate_velocities(
         }
 
         if body.rb.is_dynamic() {
-        let locked_axes = body
-            .locked_axes
-            .map_or(LockedAxes::default(), |locked_axes| *locked_axes);
+            let locked_axes = body
+                .locked_axes
+                .map_or(LockedAxes::default(), |locked_axes| *locked_axes);
 
-        // Apply damping
-        if let Some(lin_damping) = body.lin_damping {
-            if body.lin_vel.0 != Vector::ZERO && lin_damping.0 != 0.0 {
-                body.lin_vel.0 *= 1.0 / (1.0 + delta_secs * lin_damping.0);
+            // Apply damping
+            if let Some(lin_damping) = body.lin_damping {
+                if body.lin_vel.0 != Vector::ZERO && lin_damping.0 != 0.0 {
+                    body.lin_vel.0 *= 1.0 / (1.0 + delta_secs * lin_damping.0);
+                }
             }
-        }
-        if let Some(ang_damping) = body.ang_damping {
-            if body.ang_vel.0 != AngularVelocity::ZERO.0 && ang_damping.0 != 0.0 {
-                body.ang_vel.0 *= 1.0 / (1.0 + delta_secs * ang_damping.0);
+            if let Some(ang_damping) = body.ang_damping {
+                if body.ang_vel.0 != AngularVelocity::ZERO.0 && ang_damping.0 != 0.0 {
+                    body.ang_vel.0 *= 1.0 / (1.0 + delta_secs * ang_damping.0);
+                }
             }
-        }
 
-        let external_force = body.force.force();
-        let external_torque = body.torque.torque() + body.force.torque();
-        let gravity = gravity.0 * body.gravity_scale.map_or(1.0, |scale| scale.0);
+            let external_force = body.force.force();
+            let external_torque = body.torque.torque() + body.force.torque();
+            let gravity = gravity.0 * body.gravity_scale.map_or(1.0, |scale| scale.0);
 
-        semi_implicit_euler::integrate_velocity(
-            &mut body.lin_vel.0,
-            &mut body.ang_vel.0,
-            external_force,
-            external_torque,
-            *body.mass,
-            body.angular_inertia,
-            #[cfg(feature = "3d")]
-            body.global_angular_inertia,
-            #[cfg(feature = "3d")]
-            *body.rot,
-            locked_axes,
-            gravity,
-            delta_secs,
-        );
+            semi_implicit_euler::integrate_velocity(
+                &mut body.lin_vel.0,
+                &mut body.ang_vel.0,
+                external_force,
+                external_torque,
+                *body.mass,
+                body.angular_inertia,
+                #[cfg(feature = "3d")]
+                body.global_angular_inertia,
+                #[cfg(feature = "3d")]
+                *body.rot,
+                locked_axes,
+                gravity,
+                delta_secs,
+            );
         }
 
         // Clamp velocities

--- a/src/dynamics/integrator/mod.rs
+++ b/src/dynamics/integrator/mod.rs
@@ -188,10 +188,7 @@ fn integrate_velocities(
             return;
         }
 
-        if body.rb.is_kinematic() {
-            return;
-        }
-
+        if body.rb.is_dynamic() {
         let locked_axes = body
             .locked_axes
             .map_or(LockedAxes::default(), |locked_axes| *locked_axes);
@@ -227,6 +224,7 @@ fn integrate_velocities(
             gravity,
             delta_secs,
         );
+        }
 
         // Clamp velocities
         if let Some(max_linear_speed) = body.max_linear_speed {

--- a/src/dynamics/rigid_body/mod.rs
+++ b/src/dynamics/rigid_body/mod.rs
@@ -362,6 +362,62 @@ impl LinearVelocity {
     pub const ZERO: LinearVelocity = LinearVelocity(Vector::ZERO);
 }
 
+/// The maximum linear speed of a [rigid body](RigidBody), clamping the [`LinearVelocity`].
+///
+/// This can be useful for limiting how fast bodies can move, and can help control behavior and prevent instability.
+///
+/// # Example
+///
+/// ```
+#[cfg_attr(feature = "2d", doc = "use avian2d::prelude::*;")]
+#[cfg_attr(feature = "3d", doc = "use avian3d::prelude::*;")]
+/// use bevy::prelude::*;
+///
+/// // Spawn a dynamic body with linear velocity clamped to `100.0` units per second.
+/// fn setup(mut commands: Commands) {
+///     commands.spawn((RigidBody::Dynamic, MaxLinearSpeed(100.0)));
+/// }
+/// ```
+#[derive(Reflect, Clone, Copy, Component, Debug, Deref, DerefMut, PartialEq, From)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Debug, Component, Default, PartialEq)]
+pub struct MaxLinearSpeed(pub Scalar);
+
+impl Default for MaxLinearSpeed {
+    fn default() -> Self {
+        Self(Scalar::INFINITY)
+    }
+}
+
+/// The maximum angular speed of a [rigid body](RigidBody), clamping the [`AngularVelocity`].
+///
+/// This can be useful for limiting how fast bodies can rotate, and can help control behavior and prevent instability.
+///
+/// # Example
+///
+/// ```
+#[cfg_attr(feature = "2d", doc = "use avian2d::prelude::*;")]
+#[cfg_attr(feature = "3d", doc = "use avian3d::prelude::*;")]
+/// use bevy::prelude::*;
+///
+/// // Spawn a dynamic body with angular velocity clamped to `20.0` radians per second.
+/// fn setup(mut commands: Commands) {
+///     commands.spawn((RigidBody::Dynamic, MaxAngularSpeed(20.0)));
+/// }
+/// ```
+#[derive(Reflect, Clone, Copy, Component, Debug, Deref, DerefMut, PartialEq, From)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Debug, Component, Default, PartialEq)]
+pub struct MaxAngularSpeed(pub Scalar);
+
+impl Default for MaxAngularSpeed {
+    fn default() -> Self {
+        Self(Scalar::INFINITY)
+    }
+}
+
 /// The linear velocity of a [rigid body](RigidBody) before the velocity solve is performed.
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[reflect(Component)]

--- a/src/dynamics/rigid_body/mod.rs
+++ b/src/dynamics/rigid_body/mod.rs
@@ -382,6 +382,7 @@ impl LinearVelocity {
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, Component, Default, PartialEq)]
+#[doc(alias = "MaxLinearVelocity")]
 pub struct MaxLinearSpeed(pub Scalar);
 
 impl Default for MaxLinearSpeed {
@@ -410,6 +411,7 @@ impl Default for MaxLinearSpeed {
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, Component, Default, PartialEq)]
+#[doc(alias = "MaxAngularVelocity")]
 pub struct MaxAngularSpeed(pub Scalar);
 
 impl Default for MaxAngularSpeed {


### PR DESCRIPTION
# Objective

Closes #410.

Sometimes, it can be useful to limit the maximum speeds of bodies. This can also be useful for preventing explosive behavior when there is instability.

## Solution

Add `MaxLinearSpeed` and `MaxAngularSpeed` components. Global configuration could be added too in the future.