### PR TITLE
Renormalize rotation in 2D integration and clean up `renormalize`

### DIFF
--- a/src/collision/collider/backend.rs
+++ b/src/collision/collider/backend.rs
@@ -600,9 +600,9 @@ fn update_aabb<C: AnyCollider>(
             }
             #[cfg(feature = "3d")]
             {
-                let mut end_rot =
-                    Rotation(Quaternion::from_scaled_axis(ang_vel.0 * delta_secs) * rot.0);
-                end_rot.renormalize();
+                let end_rot =
+                    Rotation(Quaternion::from_scaled_axis(ang_vel.0 * delta_secs) * rot.0)
+                        .fast_renormalize();
                 (
                     pos.0
                         + (lin_vel.0 * delta_secs)

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -646,7 +646,7 @@ fn solve_swept_ccd(
             {
                 let delta_rot = Quaternion::from_scaled_axis(ang_vel1.0 * min_toi);
                 rot1.0 = delta_rot * prev_rot.0 .0;
-                rot1.renormalize();
+                *rot1 = rot1.fast_renormalize();
             }
 
             if let Some(mut collider_translation) = body2.translation {
@@ -663,7 +663,7 @@ fn solve_swept_ccd(
                     let delta_rot = Quaternion::from_scaled_axis(collider_ang_vel * min_toi);
 
                     body2.rot.0 = delta_rot * collider_prev_rot.0 .0;
-                    body2.rot.renormalize();
+                    *body2.rot = body2.rot.fast_renormalize();
                 }
             }
         }

--- a/src/dynamics/integrator/semi_implicit_euler.rs
+++ b/src/dynamics/integrator/semi_implicit_euler.rs
@@ -123,6 +123,7 @@ pub fn integrate_position(
         let delta_rot = Rotation::radians(ang_vel * delta_seconds);
         if delta_rot != Rotation::IDENTITY && delta_rot.is_finite() {
             *rot *= delta_rot;
+            *rot = rot.fast_renormalize();
         }
     }
     #[cfg(feature = "3d")]
@@ -133,7 +134,7 @@ pub fn integrate_position(
         if scaled_axis != AngularVelocity::ZERO.0 && scaled_axis.is_finite() {
             let delta_rot = Quaternion::from_scaled_axis(scaled_axis);
             rot.0 = delta_rot * rot.0;
-            rot.renormalize();
+            *rot = rot.fast_renormalize();
         }
     }
 }

--- a/src/dynamics/solver/xpbd/angular_constraint.rs
+++ b/src/dynamics/solver/xpbd/angular_constraint.rs
@@ -91,13 +91,13 @@ pub trait AngularConstraint: XpbdConstraint<2> {
             //       Maybe the math above can be done in a way that keeps rotations normalized?
             let delta_quat = Self::get_delta_rot(inv_inertia1, impulse);
             body1.rotation.0 = delta_quat * body1.rotation.0;
-            body1.rotation.renormalize();
+            *body1.rotation = body1.rotation.fast_renormalize();
         }
         if body2.rb.is_dynamic() {
             // See comments for `body1` above.
             let delta_quat = Self::get_delta_rot(inv_inertia2, -impulse);
             body2.rotation.0 = delta_quat * body2.rotation.0;
-            body2.rotation.renormalize();
+            *body2.rotation = body2.rotation.fast_renormalize();
         }
 
         impulse
@@ -238,13 +238,13 @@ pub trait AngularConstraint: XpbdConstraint<2> {
             //       Maybe the math above can be done in a way that keeps rotations normalized?
             let delta_quat = Self::get_delta_rot(inv_inertia1, p);
             body1.rotation.0 = delta_quat * body1.rotation.0;
-            body1.rotation.renormalize();
+            *body1.rotation = body1.rotation.fast_renormalize();
         }
         if body2.rb.is_dynamic() {
             // See comments for `body1` above.
             let delta_quat = Self::get_delta_rot(inv_inertia2, -p);
             body2.rotation.0 = delta_quat * body2.rotation.0;
-            body2.rotation.renormalize();
+            *body2.rotation = body2.rotation.fast_renormalize();
         }
 
         p

--- a/src/dynamics/solver/xpbd/positional_constraint.rs
+++ b/src/dynamics/solver/xpbd/positional_constraint.rs
@@ -59,7 +59,7 @@ pub trait PositionConstraint: XpbdConstraint<2> {
                 //       Maybe the math above can be done in a way that keeps rotations normalized?
                 let delta_quat = Self::get_delta_rot(inv_inertia1, r1, impulse);
                 body1.rotation.0 = delta_quat * body1.rotation.0;
-                body1.rotation.renormalize();
+                *body1.rotation = body1.rotation.fast_renormalize();
             }
         }
         if body2.rb.is_dynamic() && body2.dominance() <= body1.dominance() {
@@ -75,7 +75,7 @@ pub trait PositionConstraint: XpbdConstraint<2> {
                 // See comments for `body1` above.
                 let delta_quat = Self::get_delta_rot(inv_inertia2, r2, -impulse);
                 body2.rotation.0 = delta_quat * body2.rotation.0;
-                body2.rotation.renormalize();
+                *body2.rotation = body2.rotation.fast_renormalize();
             }
         }
 

--- a/src/tests/determinism_2d.rs
+++ b/src/tests/determinism_2d.rs
@@ -58,7 +58,7 @@ fn cross_platform_determinism_2d() {
     let hash = compute_hash(app.world(), query);
 
     // Update this value if simulation behavior changes.
-    let expected = 0x47306cfb;
+    let expected = 0x5b90b194;
 
     assert!(
         hash == expected,


### PR DESCRIPTION
# Objective

Currently, only 3D rotation is renormalized after position integration. However, 2D rotation can also become denormalized over time, sometimes causing crashes with `debug_assertions`.

## Solution

Add `fast_renormalize` for 2D `Rotation` and renormalize 2D rotations after position integration.

I also renamed the 3D `Rotation::renormalize` method to `fast_renormalize`, and made it return the value instead of mutating `self`, to match Bevy 0.15.

---

## Migration Guide

The 3D `Rotation::renormalize` method has been renamed to `fast_renormalize`, and it returns the value instead of mutating `self`. This was changed to match Bevy 0.15.