### PR TITLE
Fix missing `bevy_render/serialize` dependency.

### DIFF
--- a/crates/avian2d/Cargo.toml
+++ b/crates/avian2d/Cargo.toml
@@ -47,6 +47,7 @@ bevy_picking = ["bevy/bevy_picking"]
 serialize = [
     "dep:serde",
     "bevy/serialize",
+    "bevy_heavy/serialize",
     "bevy_transform_interpolation/serialize",
     "parry2d?/serde-serialize",
     "parry2d-f64?/serde-serialize",


### PR DESCRIPTION
Closes #591.

## Changelog

- `avian2d` no longer fails to build when `serialize` is enabled and various bevy features are disabled.