### PR TITLE
Run `update_collider_parents` before `update_root_collider_parents` to resolve ordering ambiguity on `ColliderParent`

### DIFF
--- a/src/collision/collider/backend.rs
+++ b/src/collision/collider/backend.rs
@@ -11,6 +11,7 @@ use bevy::{
     ecs::{intern::Interned, schedule::ScheduleLabel, system::SystemId},
     prelude::*,
 };
+use collider::hierarchy::update_collider_parents;
 use mass_properties::{components::RecomputeMassProperties, MassPropertySystems};
 
 /// A plugin for handling generic collider backend logic.
@@ -255,7 +256,9 @@ impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
         // Update collider parents for colliders that are on the same entity as the rigid body.
         app.add_systems(
             self.schedule,
-            update_root_collider_parents::<C>.before(PrepareSet::Finalize),
+            update_root_collider_parents::<C>
+                .before(PrepareSet::Finalize)
+                .before(update_collider_parents),
         );
 
         let physics_schedule = app

--- a/src/collision/collider/hierarchy.rs
+++ b/src/collision/collider/hierarchy.rs
@@ -120,7 +120,7 @@ impl Plugin for ColliderHierarchyPlugin {
 /// The [`ColliderBackendPlugin`] handles collider parents for colliders that are
 /// on the same entity as the rigid body.
 #[allow(clippy::type_complexity)]
-fn update_collider_parents(
+pub fn update_collider_parents(
     mut commands: Commands,
     mut bodies: Query<Entity, (With<RigidBody>, With<AncestorMarker<ColliderMarker>>)>,
     children: Query<&Children>,


### PR DESCRIPTION
…

# Objective
Fixes issue with system ordering where `update_collider_parents` and `update_root_collider_parents` both mutably access `ColliderParent` at the same time.

## Solution

I have ordered `update_root_collider_parents` to run `update_collider_parents` but feel free to modify if there's a better approach.
