### PR TITLE
PhysicsLayer import crate based on which crate (2d or 3d) is being used

### DIFF
--- a/crates/avian2d/Cargo.toml
+++ b/crates/avian2d/Cargo.toml
@@ -61,7 +61,7 @@ required-features = ["2d"]
 bench = false
 
 [dependencies]
-avian_derive = { path = "../avian_derive", version = "0.2" }
+avian_derive = { path = "../avian_derive", version = "0.2", features = ["2d"] }
 bevy = { version = "0.15", default-features = false }
 bevy_math = { version = "0.15" }
 bevy_heavy = { version = "0.1" }

--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -63,7 +63,7 @@ required-features = ["3d"]
 bench = false
 
 [dependencies]
-avian_derive = { path = "../avian_derive", version = "0.2" }
+avian_derive = { path = "../avian_derive", version = "0.2", features = ["3d"] }
 bevy = { version = "0.15", default-features = false }
 bevy_math = { version = "0.15" }
 bevy_heavy = { version = "0.1" }

--- a/crates/avian_derive/Cargo.toml
+++ b/crates/avian_derive/Cargo.toml
@@ -8,6 +8,10 @@ description = "Provides derive implementations for Avian Physics"
 repository = "https://github.com/Jondolf/avian"
 readme = "README.md"
 
+[features]
+2d = []
+3d = []
+
 [lib]
 proc-macro = true
 bench = false

--- a/crates/avian_derive/src/lib.rs
+++ b/crates/avian_derive/src/lib.rs
@@ -4,7 +4,7 @@ use proc_macro::TokenStream;
 
 use proc_macro_error::{abort, emit_error, proc_macro_error};
 use quote::quote;
-use syn::{parse_macro_input, spanned::Spanned, Data, DeriveInput};
+use syn::{parse_macro_input, spanned::Spanned, Data, DeriveInput, File};
 
 // Modified macro from the discontinued Heron
 // https://github.com/jcornaz/heron/blob/main/macros/src/lib.rs
@@ -122,11 +122,38 @@ pub fn derive_physics_layer(input: TokenStream) -> TokenStream {
         (1 << variants.len()) - 1
     };
 
+    let use_items = if cfg!(feature = "2d") && !cfg!(feature = "3d") {
+        syn::parse::<File>(
+            quote! {
+                use avian2d::prelude::PhysicsLayer;
+            }
+            .into(),
+        )
+        .unwrap()
+    } else if cfg!(feature = "3d") && !cfg!(feature = "2d") {
+        syn::parse::<File>(
+            quote! {
+                use avian3d::prelude::PhysicsLayer;
+            }
+            .into(),
+        )
+        .unwrap()
+    } else {
+        // Used within this repository.
+        syn::parse::<File>(
+            quote! {
+                #[cfg(feature = "2d")]
+                use avian2d::prelude::PhysicsLayer;
+                #[cfg(feature = "3d")]
+                use avian3d::prelude::PhysicsLayer;
+            }
+            .into(),
+        )
+        .unwrap()
+    };
+
     let expanded = quote! {
-        #[cfg(feature = "2d")]
-        use avian2d::prelude::PhysicsLayer;
-        #[cfg(feature = "3d")]
-        use avian3d::prelude::PhysicsLayer;
+        #use_items
 
         impl PhysicsLayer for #enum_ident {
             fn all_bits() -> u32 {

--- a/crates/benches_common_2d/Cargo.toml
+++ b/crates/benches_common_2d/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 
 [dependencies]
 bevy = { version = "0.15", default-features = false }
-avian2d = { path = "../avian2d", default-features = false }
+avian2d = { path = "../avian2d", default-features = false, features = ["2d"] }
 criterion = "0.5"

--- a/crates/benches_common_3d/Cargo.toml
+++ b/crates/benches_common_3d/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 
 [dependencies]
 bevy = { version = "0.15", default-features = false }
-avian3d = { path = "../avian3d", default-features = false }
+avian3d = { path = "../avian3d", default-features = false, features = ["3d"] }
 criterion = "0.5"

--- a/crates/examples_common_2d/Cargo.toml
+++ b/crates/examples_common_2d/Cargo.toml
@@ -25,4 +25,4 @@ bevy = { version = "0.15", default-features = false, features = [
     "bevy_window",
     "x11",                # github actions runners don't have libxkbcommon installed, so can't use wayland
 ] }
-avian2d = { path = "../avian2d", default-features = false }
+avian2d = { path = "../avian2d", default-features = false, features = ["2d"] }

--- a/crates/examples_common_3d/Cargo.toml
+++ b/crates/examples_common_3d/Cargo.toml
@@ -28,4 +28,4 @@ bevy = { version = "0.15", default-features = false, features = [
     "bevy_window",
     "x11",                # github actions runners don't have libxkbcommon installed, so can't use wayland
 ] }
-avian3d = { path = "../avian3d", default-features = false }
+avian3d = { path = "../avian3d", default-features = false, features = ["3d"] }


### PR DESCRIPTION
# Objective

I've been getting warnings in my project when using the PhysicsLayer derive enum, because it's generating code that is using the feature flags `2d` and `3d`. Since the code is procedurally generated within my game project it is checking for these features in my project rather then picking based on which library is being used (avian2d or avian3d).

## Solution

Add 2 feature flags for `avian_derive` (`2d` and `3d`). Use the feature flag when importing `avian_derive` in `avian2d` and `avian3d`. Move the feature flag check out of the `qoute!` macro so that it is checked within `avian_derive` rather then the consuming project.

---

## Changelog

Adds 2 feature flags to `avian_derive` which should be setup correctly for both `avian2d` and `avian3d`.

## Migration Guide

N/A
