### PR TITLE
Prevent panic when despawning entities with NoAuto components

### DIFF
--- a/src/dynamics/rigid_body/mass_properties/components/mod.rs
+++ b/src/dynamics/rigid_body/mass_properties/components/mod.rs
@@ -973,10 +973,9 @@ pub struct NoAutoCenterOfMass;
 
 /// Triggers the recomputation of mass properties for rigid bodies when automatic computation is re-enabled.
 fn on_remove_no_auto_mass_property(mut world: DeferredWorld, entity: Entity, _id: ComponentId) {
-    world
-        .commands()
-        .entity(entity)
-        .insert(RecomputeMassProperties);
+    if let Some(mut entity_commands) = world.commands().get_entity(entity) {
+        entity_commands.try_insert(RecomputeMassProperties);
+    }
 }
 
 /// A marker component that forces the recomputation of [`ComputedMass`], [`ComputedAngularInertia`]


### PR DESCRIPTION
# Objective

- This prevents a panic that can occur if an entity with one of the NoAuto components is despawned.
- Fixes #607 

## Solution

This solution to the problem just uses the non-panicking versions of retrieving an entity from the world and inserting a component in the on_remove_no_auto_mass_property function that runs when the component is removed. 

I think an argument could be made that this silently hides an issue of code trying to operate on an entity that no longer exists or that the on_remove shouldn't fire if it's happening because an entity is being despawned. 