### PR TITLE
Fix effective inverse mass computation for 3D friction

### DIFF
--- a/src/dynamics/solver/contact/tangent_part.rs
+++ b/src/dynamics/solver/contact/tangent_part.rs
@@ -139,7 +139,7 @@ impl ContactTangentPart {
             // This is needed for solving the two tangent directions simultaneously.
             // TODO. Derive and explain the math for this, or consider an alternative approach,
             //       like using the Jacobians to compute the actual effective mass matrix.
-            part.effective_inverse_mass[2] = 2.0 * (i1_rt11.dot(i1_rt21) + i2_rt12.dot(i2_rt22));
+            part.effective_inverse_mass[2] = 2.0 * (rt11.dot(i1_rt21) + rt12.dot(i2_rt22));
         }
 
         part


### PR DESCRIPTION
# Objective

3D friction currently has a bug that causes objects with a small angular inertia to twist and jitter strangely on the ground:

https://github.com/user-attachments/assets/8cc4aa25-808a-4899-b8a4-5079a48c4be1

(reproduction by occuros <3)

## Solution

The problem was caused by an angular inertia term being included *twice* for a part of the effective inverse mass computation for 3D friction. With that fixed, resting contacts are much more stable even with small mass properties:

https://github.com/user-attachments/assets/c2d829b3-bcf5-4c8e-997d-57614e741e1d