### PR TITLE
Collision Hooks

### DIFF
--- a/crates/avian2d/examples/one_way_platform_2d.rs
+++ b/crates/avian2d/examples/one_way_platform_2d.rs
@@ -19,10 +19,11 @@ fn main() {
         .add_plugins((
             DefaultPlugins,
             ExampleCommonPlugin,
-            // Add physics plugins and specify a units-per-meter scaling factor, 1 meter = 20 pixels.
-            // The unit allows the engine to tune its parameters for the scale of the world, improving stability.
             PhysicsPlugins::default()
+                // Specify a units-per-meter scaling factor, 1 meter = 20 pixels.
+                // The unit allows the engine to tune its parameters for the scale of the world, improving stability.
                 .with_length_unit(20.0)
+                // Add our custom collision hooks.
                 .with_collision_hooks::<PlatformerCollisionHooks>(),
         ))
         .insert_resource(ClearColor(Color::srgb(0.05, 0.05, 0.1)))
@@ -42,18 +43,20 @@ struct MovementSpeed(Scalar);
 struct JumpImpulse(Scalar);
 
 // Enable contact modification for one-way platforms with the `ActiveCollisionHooks` component.
+// Here we use required components, but you could also add it manually.
 #[derive(Clone, Eq, PartialEq, Debug, Default, Component)]
 #[require(ActiveCollisionHooks(|| ActiveCollisionHooks::MODIFY_CONTACTS))]
 pub struct OneWayPlatform(HashSet<Entity>);
 
+/// A component to control how an actor interacts with a one-way platform.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Default, Component, Reflect)]
 pub enum PassThroughOneWayPlatform {
     #[default]
-    /// Passes through a `OneWayPlatform` if the contact normal is in line with the platform's local-space up vector
+    /// Passes through a `OneWayPlatform` if the contact normal is in line with the platform's local-space up vector.
     ByNormal,
-    /// Always passes through a `OneWayPlatform`, temporarily set this to allow an actor to jump down through a platform
+    /// Always passes through a `OneWayPlatform`, temporarily set this to allow an actor to jump down through a platform.
     Always,
-    /// Never passes through a `OneWayPlatform`
+    /// Never passes through a `OneWayPlatform`.
     Never,
 }
 
@@ -180,18 +183,24 @@ fn pass_through_one_way_platform(
     }
 }
 
+// Define a custom `SystemParam` for our collision hooks.
+// It can have read-only access to queries, resources, and other system parameters.
 #[derive(SystemParam)]
 struct PlatformerCollisionHooks<'w, 's> {
     one_way_platforms_query: Query<'w, 's, Read<OneWayPlatform>>,
+    // NOTE: This precludes a `OneWayPlatform` passing through a `OneWayPlatform`.
     other_colliders_query: Query<
         'w,
         's,
         Option<Read<PassThroughOneWayPlatform>>,
-        (With<Collider>, Without<OneWayPlatform>), // NOTE: This precludes OneWayPlatform passing through a OneWayPlatform
+        (With<Collider>, Without<OneWayPlatform>),
     >,
 }
 
+// Implement the `CollisionHooks` trait for our custom system parameter.
 impl CollisionHooks for PlatformerCollisionHooks<'_, '_> {
+    // Below is a description of the logic used for one-way platforms.
+
     /// Allows entities to pass through [`OneWayPlatform`] entities.
     ///
     /// Passing through is achieved by removing the collisions between the [`OneWayPlatform`]
@@ -204,25 +213,13 @@ impl CollisionHooks for PlatformerCollisionHooks<'_, '_> {
     /// it is allowed to continue to do so, even if [`PassThroughOneWayPlatform`] has been
     /// set to disallow passing through.
     ///
-    /// > Note that this is a very simplistic implementation of one-way
-    /// > platforms to demonstrate filtering collisions via [`PostProcessCollisions`].
-    /// > You will probably want something more robust to implement one-way
-    /// > platforms properly, or may elect to use a sensor collider for your entities instead,
-    /// > which means you won't need to filter collisions at all.
-    ///
     /// #### When an entity is known to already be passing through the [`OneWayPlatform`]
     ///
-    /// Any time an entity begins passing through a [`OneWayPlatform`], it is added to the
-    /// [`OneWayPlatform`]'s set of currently active penetrations, and will be allowed to
-    /// continue to pass through the platform until it is no longer penetrating the platform.
+    /// When an entity begins passing through a [`OneWayPlatform`], it is added to the
+    /// [`OneWayPlatform`]'s set of active penetrations, and will be allowed to continue
+    /// to pass through until it is no longer penetrating the platform.
     ///
-    /// The entity is allowed to continue to pass through the platform as long as at least
-    /// one contact is penetrating.
-    ///
-    /// Once all of the contacts are no longer penetrating the [`OneWayPlatform`], or all contacts
-    /// have stopped, the entity is forgotten about and the logic falls through to the next part.
-    ///
-    /// #### When an entity is NOT known to be passing through the [`OneWayPlatform`]
+    /// #### When an entity is *not* known to be passing through the [`OneWayPlatform`]
     ///
     /// Depending on the setting of [`PassThroughOneWayPlatform`], the entity may be allowed to
     /// pass through.
@@ -246,6 +243,10 @@ impl CollisionHooks for PlatformerCollisionHooks<'_, '_> {
     /// through a [`OneWayPlatform`] if it is already penetrating the platform. Once it exits the platform,
     /// it will no longer be allowed to pass through.
     fn modify_contacts(&self, contacts: &mut Contacts, commands: &mut Commands) -> bool {
+        // This is the contact modification hook, called after collision detection,
+        // but before contact constraints are created. Mutable access to the ECS
+        // is not allowed, but we can queue commands to perform deferred changes.
+
         // Differentiate between which normal of the manifold we should use
         enum RelevantNormal {
             Normal1,
@@ -290,7 +291,10 @@ impl CollisionHooks for PlatformerCollisionHooks<'_, '_> {
                 return false;
             } else {
                 // If it's no longer penetrating us, forget it.
-                commands.queue(OneWayPlatformCommand::Remove(platform_entity, other_entity));
+                commands.queue(OneWayPlatformCommand::Remove {
+                    platform_entity,
+                    entity: other_entity,
+                });
             }
         }
 
@@ -300,7 +304,10 @@ impl CollisionHooks for PlatformerCollisionHooks<'_, '_> {
             // Pass-through is set to always, so always ignore this collision
             // and register it as an entity that's currently penetrating.
             Ok(Some(PassThroughOneWayPlatform::Always)) => {
-                commands.queue(OneWayPlatformCommand::Add(platform_entity, other_entity));
+                commands.queue(OneWayPlatformCommand::Add {
+                    platform_entity,
+                    entity: other_entity,
+                });
                 false
             }
             // Default behaviour is "by normal".
@@ -319,7 +326,10 @@ impl CollisionHooks for PlatformerCollisionHooks<'_, '_> {
                 } else {
                     // Otherwise, ignore the collision and register
                     // the other entity as one that's currently penetrating.
-                    commands.queue(OneWayPlatformCommand::Add(platform_entity, other_entity));
+                    commands.queue(OneWayPlatformCommand::Add {
+                        platform_entity,
+                        entity: other_entity,
+                    });
                     false
                 }
             }
@@ -327,22 +337,36 @@ impl CollisionHooks for PlatformerCollisionHooks<'_, '_> {
     }
 }
 
+/// A command to add/remove entities to/from the set of entities
+/// that are currently in contact with a one-way platform.
 enum OneWayPlatformCommand {
-    Add(Entity, Entity),
-    Remove(Entity, Entity),
+    Add {
+        platform_entity: Entity,
+        entity: Entity,
+    },
+    Remove {
+        platform_entity: Entity,
+        entity: Entity,
+    },
 }
 
 impl Command for OneWayPlatformCommand {
     fn apply(self, world: &mut World) {
         match self {
-            OneWayPlatformCommand::Add(platform_entity, entity) => {
+            OneWayPlatformCommand::Add {
+                platform_entity,
+                entity,
+            } => {
                 let Some(mut one_way_platforms) = world.get_mut::<OneWayPlatform>(platform_entity)
                 else {
                     return;
                 };
                 one_way_platforms.0.insert(entity);
             }
-            OneWayPlatformCommand::Remove(platform_entity, entity) => {
+            OneWayPlatformCommand::Remove {
+                platform_entity,
+                entity,
+            } => {
                 let Some(mut one_way_platforms) = world.get_mut::<OneWayPlatform>(platform_entity)
                 else {
                     return;

--- a/crates/avian2d/examples/one_way_platform_2d.rs
+++ b/crates/avian2d/examples/one_way_platform_2d.rs
@@ -244,7 +244,7 @@ impl CollisionHooks for PlatformerCollisionHooks<'_, '_> {
     /// it will no longer be allowed to pass through.
     fn modify_contacts(&self, contacts: &mut Contacts, commands: &mut Commands) -> bool {
         // This is the contact modification hook, called after collision detection,
-        // but before contact constraints are created. Mutable access to the ECS
+        // but before constraints are created for the solver. Mutable access to the ECS
         // is not allowed, but we can queue commands to perform deferred changes.
 
         // Differentiate between which normal of the manifold we should use
@@ -357,21 +357,18 @@ impl Command for OneWayPlatformCommand {
                 platform_entity,
                 entity,
             } => {
-                let Some(mut one_way_platforms) = world.get_mut::<OneWayPlatform>(platform_entity)
-                else {
-                    return;
-                };
-                one_way_platforms.0.insert(entity);
+                if let Some(mut platform) = world.get_mut::<OneWayPlatform>(platform_entity) {
+                    platform.0.insert(entity);
+                }
             }
+
             OneWayPlatformCommand::Remove {
                 platform_entity,
                 entity,
             } => {
-                let Some(mut one_way_platforms) = world.get_mut::<OneWayPlatform>(platform_entity)
-                else {
-                    return;
-                };
-                one_way_platforms.0.remove(&entity);
+                if let Some(mut platform) = world.get_mut::<OneWayPlatform>(platform_entity) {
+                    platform.0.remove(&entity);
+                }
             }
         }
     }

--- a/crates/avian2d/examples/one_way_platform_2d.rs
+++ b/crates/avian2d/examples/one_way_platform_2d.rs
@@ -1,11 +1,17 @@
 //! A 2D platformer example with one-way platforms to demonstrate
-//! filtering collisions with systems in the `PostProcessCollisions` schedule.
+//! contact modification with `CollisionHooks`.
 //!
 //! Move with arrow keys, jump with Space and descend through
 //! platforms by pressing Space while holding the down arrow.
 
+#![allow(clippy::type_complexity)]
+
 use avian2d::{math::*, prelude::*};
-use bevy::{prelude::*, utils::HashSet};
+use bevy::{
+    ecs::system::{lifetimeless::Read, SystemParam},
+    prelude::*,
+    utils::HashSet,
+};
 use examples_common_2d::ExampleCommonPlugin;
 
 fn main() {
@@ -15,13 +21,14 @@ fn main() {
             ExampleCommonPlugin,
             // Add physics plugins and specify a units-per-meter scaling factor, 1 meter = 20 pixels.
             // The unit allows the engine to tune its parameters for the scale of the world, improving stability.
-            PhysicsPlugins::default().with_length_unit(20.0),
+            PhysicsPlugins::default()
+                .with_length_unit(20.0)
+                .with_collision_hooks::<PlatformerCollisionHooks>(),
         ))
         .insert_resource(ClearColor(Color::srgb(0.05, 0.05, 0.1)))
         .insert_resource(Gravity(Vector::NEG_Y * 1000.0))
         .add_systems(Startup, setup)
         .add_systems(Update, (movement, pass_through_one_way_platform))
-        .add_systems(PostProcessCollisions, one_way_platform)
         .run();
 }
 
@@ -34,7 +41,9 @@ struct MovementSpeed(Scalar);
 #[derive(Component)]
 struct JumpImpulse(Scalar);
 
+// Enable contact modification for one-way platforms with the `ActiveCollisionHooks` component.
 #[derive(Clone, Eq, PartialEq, Debug, Default, Component)]
+#[require(ActiveCollisionHooks(|| ActiveCollisionHooks::MODIFY_CONTACTS))]
 pub struct OneWayPlatform(HashSet<Entity>);
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Default, Component, Reflect)]
@@ -171,70 +180,72 @@ fn pass_through_one_way_platform(
     }
 }
 
-/// Allows entities to pass through [`OneWayPlatform`] entities.
-///
-/// Passing through is achieved by removing the collisions between the [`OneWayPlatform`]
-/// and the other entity if the entity should pass through.
-/// If a [`PassThroughOneWayPlatform`] is present on the non-platform entity,
-/// the value of the component dictates the pass-through behaviour.
-///
-/// Entities known to be passing through each [`OneWayPlatform`] are stored in the
-/// [`OneWayPlatform`]. If an entity is known to be passing through a [`OneWayPlatform`],
-/// it is allowed to continue to do so, even if [`PassThroughOneWayPlatform`] has been
-/// set to disallow passing through.
-///
-/// > Note that this is a very simplistic implementation of one-way
-/// > platforms to demonstrate filtering collisions via [`PostProcessCollisions`].
-/// > You will probably want something more robust to implement one-way
-/// > platforms properly, or may elect to use a sensor collider for your entities instead,
-/// > which means you won't need to filter collisions at all.
-///
-/// #### When an entity is known to already be passing through the [`OneWayPlatform`]
-///
-/// Any time an entity begins passing through a [`OneWayPlatform`], it is added to the
-/// [`OneWayPlatform`]'s set of currently active penetrations, and will be allowed to
-/// continue to pass through the platform until it is no longer penetrating the platform.
-///
-/// The entity is allowed to continue to pass through the platform as long as at least
-/// one contact is penetrating.
-///
-/// Once all of the contacts are no longer penetrating the [`OneWayPlatform`], or all contacts
-/// have stopped, the entity is forgotten about and the logic falls through to the next part.
-///
-/// #### When an entity is NOT known to be passing through the [`OneWayPlatform`]
-///
-/// Depending on the setting of [`PassThroughOneWayPlatform`], the entity may be allowed to
-/// pass through.
-///
-/// If no [`PassThroughOneWayPlatform`] is present, [`PassThroughOneWayPlatform::ByNormal`] is used.
-///
-/// [`PassThroughOneWayPlatform`] may be in one of three states:
-/// 1. [`PassThroughOneWayPlatform::ByNormal`]
-///     - This is the default state
-///     - The entity may be allowed to pass through the [`OneWayPlatform`] depending on the contact normal
-///         - If all contact normals are in line with the [`OneWayPlatform`]'s local-space up vector,
-///           the entity is allowed to pass through
-/// 2. [`PassThroughOneWayPlatform::Always`]
-///     - The entity will always pass through the [`OneWayPlatform`], regardless of contact normal
-///     - This is useful for allowing an entity to jump down through a platform
-/// 3. [`PassThroughOneWayPlatform::Never`]
-///     - The entity will never pass through the [`OneWayPlatform`], meaning the platform will act
-///       as normal hard collision for this entity
-///
-/// Even if an entity is changed to [`PassThroughOneWayPlatform::Never`], it will be allowed to pass
-/// through a [`OneWayPlatform`] if it is already penetrating the platform. Once it exits the platform,
-/// it will no longer be allowed to pass through.
-fn one_way_platform(
-    mut one_way_platforms_query: Query<&mut OneWayPlatform>,
+#[derive(SystemParam)]
+struct PlatformerCollisionHooks<'w, 's> {
+    one_way_platforms_query: Query<'w, 's, Read<OneWayPlatform>>,
     other_colliders_query: Query<
-        Option<&PassThroughOneWayPlatform>,
+        'w,
+        's,
+        Option<Read<PassThroughOneWayPlatform>>,
         (With<Collider>, Without<OneWayPlatform>), // NOTE: This precludes OneWayPlatform passing through a OneWayPlatform
     >,
-    mut collisions: ResMut<Collisions>,
-) {
-    // This assumes that Collisions contains empty entries for entities
-    // that were once colliding but no longer are.
-    collisions.retain(|contacts| {
+}
+
+impl CollisionHooks for PlatformerCollisionHooks<'_, '_> {
+    /// Allows entities to pass through [`OneWayPlatform`] entities.
+    ///
+    /// Passing through is achieved by removing the collisions between the [`OneWayPlatform`]
+    /// and the other entity if the entity should pass through.
+    /// If a [`PassThroughOneWayPlatform`] is present on the non-platform entity,
+    /// the value of the component dictates the pass-through behaviour.
+    ///
+    /// Entities known to be passing through each [`OneWayPlatform`] are stored in the
+    /// [`OneWayPlatform`]. If an entity is known to be passing through a [`OneWayPlatform`],
+    /// it is allowed to continue to do so, even if [`PassThroughOneWayPlatform`] has been
+    /// set to disallow passing through.
+    ///
+    /// > Note that this is a very simplistic implementation of one-way
+    /// > platforms to demonstrate filtering collisions via [`PostProcessCollisions`].
+    /// > You will probably want something more robust to implement one-way
+    /// > platforms properly, or may elect to use a sensor collider for your entities instead,
+    /// > which means you won't need to filter collisions at all.
+    ///
+    /// #### When an entity is known to already be passing through the [`OneWayPlatform`]
+    ///
+    /// Any time an entity begins passing through a [`OneWayPlatform`], it is added to the
+    /// [`OneWayPlatform`]'s set of currently active penetrations, and will be allowed to
+    /// continue to pass through the platform until it is no longer penetrating the platform.
+    ///
+    /// The entity is allowed to continue to pass through the platform as long as at least
+    /// one contact is penetrating.
+    ///
+    /// Once all of the contacts are no longer penetrating the [`OneWayPlatform`], or all contacts
+    /// have stopped, the entity is forgotten about and the logic falls through to the next part.
+    ///
+    /// #### When an entity is NOT known to be passing through the [`OneWayPlatform`]
+    ///
+    /// Depending on the setting of [`PassThroughOneWayPlatform`], the entity may be allowed to
+    /// pass through.
+    ///
+    /// If no [`PassThroughOneWayPlatform`] is present, [`PassThroughOneWayPlatform::ByNormal`] is used.
+    ///
+    /// [`PassThroughOneWayPlatform`] may be in one of three states:
+    /// 1. [`PassThroughOneWayPlatform::ByNormal`]
+    ///     - This is the default state
+    ///     - The entity may be allowed to pass through the [`OneWayPlatform`] depending on the contact normal
+    ///         - If all contact normals are in line with the [`OneWayPlatform`]'s local-space up vector,
+    ///           the entity is allowed to pass through
+    /// 2. [`PassThroughOneWayPlatform::Always`]
+    ///     - The entity will always pass through the [`OneWayPlatform`], regardless of contact normal
+    ///     - This is useful for allowing an entity to jump down through a platform
+    /// 3. [`PassThroughOneWayPlatform::Never`]
+    ///     - The entity will never pass through the [`OneWayPlatform`], meaning the platform will act
+    ///       as normal hard collision for this entity
+    ///
+    /// Even if an entity is changed to [`PassThroughOneWayPlatform::Never`], it will be allowed to pass
+    /// through a [`OneWayPlatform`] if it is already penetrating the platform. Once it exits the platform,
+    /// it will no longer be allowed to pass through.
+    fn modify_contacts(&self, contacts: &mut Contacts, commands: &mut Commands) -> bool {
         // Differentiate between which normal of the manifold we should use
         enum RelevantNormal {
             Normal1,
@@ -243,11 +254,22 @@ fn one_way_platform(
 
         // First, figure out which entity is the one-way platform, and which is the other.
         // Choose the appropriate normal for pass-through depending on which is which.
-        let (mut one_way_platform, other_entity, relevant_normal) =
-            if let Ok(one_way_platform) = one_way_platforms_query.get_mut(contacts.entity1) {
-                (one_way_platform, contacts.entity2, RelevantNormal::Normal1)
-            } else if let Ok(one_way_platform) = one_way_platforms_query.get_mut(contacts.entity2) {
-                (one_way_platform, contacts.entity1, RelevantNormal::Normal2)
+        let (platform_entity, one_way_platform, other_entity, relevant_normal) =
+            if let Ok(one_way_platform) = self.one_way_platforms_query.get(contacts.entity1) {
+                (
+                    contacts.entity1,
+                    one_way_platform,
+                    contacts.entity2,
+                    RelevantNormal::Normal1,
+                )
+            } else if let Ok(one_way_platform) = self.one_way_platforms_query.get(contacts.entity2)
+            {
+                (
+                    contacts.entity2,
+                    one_way_platform,
+                    contacts.entity1,
+                    RelevantNormal::Normal2,
+                )
             } else {
                 // Neither is a one-way-platform, so accept the collision:
                 // we're done here.
@@ -268,17 +290,17 @@ fn one_way_platform(
                 return false;
             } else {
                 // If it's no longer penetrating us, forget it.
-                one_way_platform.0.remove(&other_entity);
+                commands.queue(OneWayPlatformCommand::Remove(platform_entity, other_entity));
             }
         }
 
-        match other_colliders_query.get(other_entity) {
+        match self.other_colliders_query.get(other_entity) {
             // Pass-through is set to never, so accept the collision.
             Ok(Some(PassThroughOneWayPlatform::Never)) => true,
             // Pass-through is set to always, so always ignore this collision
             // and register it as an entity that's currently penetrating.
             Ok(Some(PassThroughOneWayPlatform::Always)) => {
-                one_way_platform.0.insert(other_entity);
+                commands.queue(OneWayPlatformCommand::Add(platform_entity, other_entity));
                 false
             }
             // Default behaviour is "by normal".
@@ -297,10 +319,36 @@ fn one_way_platform(
                 } else {
                     // Otherwise, ignore the collision and register
                     // the other entity as one that's currently penetrating.
-                    one_way_platform.0.insert(other_entity);
+                    commands.queue(OneWayPlatformCommand::Add(platform_entity, other_entity));
                     false
                 }
             }
         }
-    });
+    }
+}
+
+enum OneWayPlatformCommand {
+    Add(Entity, Entity),
+    Remove(Entity, Entity),
+}
+
+impl Command for OneWayPlatformCommand {
+    fn apply(self, world: &mut World) {
+        match self {
+            OneWayPlatformCommand::Add(platform_entity, entity) => {
+                let Some(mut one_way_platforms) = world.get_mut::<OneWayPlatform>(platform_entity)
+                else {
+                    return;
+                };
+                one_way_platforms.0.insert(entity);
+            }
+            OneWayPlatformCommand::Remove(platform_entity, entity) => {
+                let Some(mut one_way_platforms) = world.get_mut::<OneWayPlatform>(platform_entity)
+                else {
+                    return;
+                };
+                one_way_platforms.0.remove(&entity);
+            }
+        }
+    }
 }

--- a/src/collision/broad_phase.rs
+++ b/src/collision/broad_phase.rs
@@ -3,11 +3,13 @@
 //!
 //! See [`BroadPhasePlugin`].
 
+use std::marker::PhantomData;
+
 use crate::prelude::*;
 use bevy::{
     ecs::{
         entity::{EntityMapper, MapEntities},
-        system::lifetimeless::Read,
+        system::{lifetimeless::Read, StaticSystemParam, SystemParamItem},
     },
     prelude::*,
 };
@@ -19,9 +21,20 @@ use bevy::{
 /// Currently, the broad phase uses the [sweep and prune](https://en.wikipedia.org/wiki/Sweep_and_prune) algorithm.
 ///
 /// The broad phase systems run in [`PhysicsStepSet::BroadPhase`].
-pub struct BroadPhasePlugin;
+///
+/// [`CollisionHooks`] can be provided with generics to apply custom filtering for collision pairs.
+pub struct BroadPhasePlugin<H: CollisionHooks = ()>(PhantomData<H>);
 
-impl Plugin for BroadPhasePlugin {
+impl<H: CollisionHooks> Default for BroadPhasePlugin<H> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<H: CollisionHooks + 'static> Plugin for BroadPhasePlugin<H>
+where
+    for<'w, 's> SystemParamItem<'w, 's, H>: CollisionHooks,
+{
     fn build(&self, app: &mut App) {
         app.init_resource::<BroadCollisionPairs>()
             .init_resource::<AabbIntervals>();
@@ -49,7 +62,7 @@ impl Plugin for BroadPhasePlugin {
         );
 
         physics_schedule
-            .add_systems(collect_collision_pairs.in_set(BroadPhaseSet::CollectCollisions));
+            .add_systems(collect_collision_pairs::<H>.in_set(BroadPhaseSet::CollectCollisions));
     }
 }
 
@@ -82,12 +95,6 @@ pub struct BroadCollisionPairs(pub Vec<(Entity, Entity)>);
 #[reflect(Component)]
 pub struct AabbIntersections(pub Vec<Entity>);
 
-/// True if the rigid body should store [`AabbIntersections`].
-type StoreAabbIntersections = bool;
-
-/// True if the rigid body hasn't moved.
-type IsBodyInactive = bool;
-
 /// Entities with [`ColliderAabb`]s sorted along an axis by their extents.
 #[derive(Resource, Default)]
 struct AabbIntervals(
@@ -96,10 +103,22 @@ struct AabbIntervals(
         ColliderParent,
         ColliderAabb,
         CollisionLayers,
-        StoreAabbIntersections,
-        IsBodyInactive,
+        AabbIntervalFlags,
     )>,
 );
+
+bitflags::bitflags! {
+    /// Flags for AABB intervals in the broad phase.
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    pub struct AabbIntervalFlags: u8 {
+        /// Set if [`AabbIntersections`] should be stored for this entity.
+        const STORE_INTERSECTIONS = 1 << 0;
+        /// Set if the body is sleeping or static.
+        const IS_INACTIVE = 1 << 1;
+        /// Set if [`CollisionHooks::filter_pairs`] should be called for this entity.
+        const CUSTOM_FILTER = 1 << 2;
+    }
+}
 
 impl MapEntities for AabbIntervals {
     fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
@@ -117,6 +136,7 @@ fn update_aabb_intervals(
             &ColliderAabb,
             Option<&ColliderParent>,
             Option<&CollisionLayers>,
+            Option<&ActiveCollisionHooks>,
             Has<AabbIntersections>,
             Has<Sleeping>,
         ),
@@ -125,10 +145,17 @@ fn update_aabb_intervals(
     rbs: Query<&RigidBody>,
     mut intervals: ResMut<AabbIntervals>,
 ) {
-    intervals.0.retain_mut(
-        |(collider_entity, collider_parent, aabb, layers, store_intersections, is_inactive)| {
-            if let Ok((new_aabb, new_parent, new_layers, new_store_intersections, is_sleeping)) =
-                aabbs.get(*collider_entity)
+    intervals
+        .0
+        .retain_mut(|(collider_entity, collider_parent, aabb, layers, flags)| {
+            if let Ok((
+                new_aabb,
+                new_parent,
+                new_layers,
+                hooks,
+                new_store_intersections,
+                is_sleeping,
+            )) = aabbs.get(*collider_entity)
             {
                 if !new_aabb.min.is_finite() || !new_aabb.max.is_finite() {
                     return false;
@@ -140,15 +167,22 @@ fn update_aabb_intervals(
 
                 let is_static =
                     new_parent.is_some_and(|p| rbs.get(p.get()).is_ok_and(RigidBody::is_static));
-                *is_inactive = is_static || is_sleeping;
-                *store_intersections = new_store_intersections;
+
+                flags.set(AabbIntervalFlags::IS_INACTIVE, is_static || is_sleeping);
+                flags.set(
+                    AabbIntervalFlags::STORE_INTERSECTIONS,
+                    new_store_intersections,
+                );
+                flags.set(
+                    AabbIntervalFlags::CUSTOM_FILTER,
+                    hooks.is_some_and(|h| h.contains(ActiveCollisionHooks::FILTER_PAIRS)),
+                );
 
                 true
             } else {
                 false
             }
-        },
-    );
+        });
 }
 
 type AabbIntervalQueryData = (
@@ -157,6 +191,7 @@ type AabbIntervalQueryData = (
     Read<ColliderAabb>,
     Option<Read<RigidBody>>,
     Option<Read<CollisionLayers>>,
+    Option<Read<ActiveCollisionHooks>>,
     Has<AabbIntersections>,
 );
 
@@ -170,15 +205,23 @@ fn add_new_aabb_intervals(
 ) {
     let re_enabled_aabbs = aabbs.iter_many(re_enabled_colliders.read());
     let aabbs = added_aabbs.iter().chain(re_enabled_aabbs).map(
-        |(ent, parent, aabb, rb, layers, store_intersections)| {
+        |(entity, parent, aabb, rb, layers, hooks, store_intersections)| {
+            let mut flags = AabbIntervalFlags::empty();
+            flags.set(AabbIntervalFlags::STORE_INTERSECTIONS, store_intersections);
+            flags.set(
+                AabbIntervalFlags::IS_INACTIVE,
+                rb.is_some_and(|rb| rb.is_static()),
+            );
+            flags.set(
+                AabbIntervalFlags::CUSTOM_FILTER,
+                hooks.is_some_and(|h| h.contains(ActiveCollisionHooks::FILTER_PAIRS)),
+            );
             (
-                ent,
-                parent.map_or(ColliderParent(ent), |p| *p),
+                entity,
+                parent.map_or(ColliderParent(entity), |p| *p),
                 *aabb,
-                // Default to treating collider as immovable/static for filtering unnecessary collision checks
                 layers.map_or(CollisionLayers::default(), |layers| *layers),
-                rb.map_or(false, |rb| rb.is_static()),
-                store_intersections,
+                flags,
             )
         },
     );
@@ -186,30 +229,40 @@ fn add_new_aabb_intervals(
 }
 
 /// Collects bodies that are potentially colliding.
-fn collect_collision_pairs(
+fn collect_collision_pairs<H: CollisionHooks>(
     intervals: ResMut<AabbIntervals>,
     mut broad_collision_pairs: ResMut<BroadCollisionPairs>,
     mut aabb_intersection_query: Query<&mut AabbIntersections>,
-) {
+    hooks: StaticSystemParam<H>,
+    mut commands: Commands,
+) where
+    for<'w, 's> SystemParamItem<'w, 's, H>: CollisionHooks,
+{
     for mut intersections in &mut aabb_intersection_query {
         intersections.clear();
     }
 
-    sweep_and_prune(
+    sweep_and_prune::<H>(
         intervals,
         &mut broad_collision_pairs.0,
         &mut aabb_intersection_query,
+        &mut hooks.into_inner(),
+        &mut commands,
     );
 }
 
 /// Sorts the entities by their minimum extents along an axis and collects the entity pairs that have intersecting AABBs.
 ///
 /// Sweep and prune exploits temporal coherence, as bodies are unlikely to move significantly between two simulation steps. Insertion sort is used, as it is good at sorting nearly sorted lists efficiently.
-fn sweep_and_prune(
+fn sweep_and_prune<H: CollisionHooks>(
     mut intervals: ResMut<AabbIntervals>,
     broad_collision_pairs: &mut Vec<(Entity, Entity)>,
     aabb_intersection_query: &mut Query<&mut AabbIntersections>,
-) {
+    hooks: &mut H::Item<'_, '_>,
+    commands: &mut Commands,
+) where
+    for<'w, 's> SystemParamItem<'w, 's, H>: CollisionHooks,
+{
     // Sort bodies along the x-axis using insertion sort, a sorting algorithm great for sorting nearly sorted lists.
     insertion_sort(&mut intervals.0, |a, b| a.2.min.x > b.2.min.x);
 
@@ -217,44 +270,58 @@ fn sweep_and_prune(
     broad_collision_pairs.clear();
 
     // Find potential collisions by checking for AABB intersections along all axes.
-    for (i, (ent1, parent1, aabb1, layers1, store_intersections1, inactive1)) in
-        intervals.0.iter().enumerate()
-    {
-        for (ent2, parent2, aabb2, layers2, store_intersections2, inactive2) in
-            intervals.0.iter().skip(i + 1)
-        {
-            // x doesn't intersect; check this first so we can discard as soon as possible
+    for (i, (entity1, parent1, aabb1, layers1, flags1)) in intervals.0.iter().enumerate() {
+        for (entity2, parent2, aabb2, layers2, flags2) in intervals.0.iter().skip(i + 1) {
+            // x doesn't intersect; check this first so we can discard as soon as possible.
             if aabb2.min.x > aabb1.max.x {
                 break;
             }
 
-            // No collisions between bodies that haven't moved or colliders with incompatible layers or colliders with the same parent
-            if (*inactive1 && *inactive2) || !layers1.interacts_with(*layers2) || parent1 == parent2
+            // No collisions between bodies that haven't moved or colliders with incompatible layers
+            // or colliders with the same parent.
+            if flags1
+                .intersection(*flags2)
+                .contains(AabbIntervalFlags::IS_INACTIVE)
+                || !layers1.interacts_with(*layers2)
+                || parent1 == parent2
             {
                 continue;
             }
 
-            // y doesn't intersect
+            // y doesn't intersect.
             if aabb1.min.y > aabb2.max.y || aabb1.max.y < aabb2.min.y {
                 continue;
             }
 
             #[cfg(feature = "3d")]
-            // z doesn't intersect
+            // z doesn't intersect.
             if aabb1.min.z > aabb2.max.z || aabb1.max.z < aabb2.min.z {
                 continue;
             }
 
-            broad_collision_pairs.push((*ent1, *ent2));
-
-            if *store_intersections1 {
-                if let Ok(mut intersections) = aabb_intersection_query.get_mut(*ent1) {
-                    intersections.push(*ent2);
+            // Apply user-defined filter.
+            if flags1
+                .union(*flags2)
+                .contains(AabbIntervalFlags::CUSTOM_FILTER)
+            {
+                let should_collide = hooks.filter_pairs(*entity1, *entity2, commands);
+                if !should_collide {
+                    continue;
                 }
             }
-            if *store_intersections2 {
-                if let Ok(mut intersections) = aabb_intersection_query.get_mut(*ent2) {
-                    intersections.push(*ent1);
+
+            // Create a collision pair.
+            broad_collision_pairs.push((*entity1, *entity2));
+
+            // TODO: Handle this more efficiently.
+            if flags1.contains(AabbIntervalFlags::STORE_INTERSECTIONS) {
+                if let Ok(mut intersections) = aabb_intersection_query.get_mut(*entity1) {
+                    intersections.push(*entity2);
+                }
+            }
+            if flags2.contains(AabbIntervalFlags::STORE_INTERSECTIONS) {
+                if let Ok(mut intersections) = aabb_intersection_query.get_mut(*entity2) {
+                    intersections.push(*entity1);
                 }
             }
         }

--- a/src/collision/collider/world_query.rs
+++ b/src/collision/collider/world_query.rs
@@ -23,6 +23,7 @@ pub struct ColliderQuery<C: AnyCollider> {
     pub friction: Option<&'static Friction>,
     pub restitution: Option<&'static Restitution>,
     pub shape: &'static C,
+    pub active_hooks: Option<&'static ActiveCollisionHooks>,
 }
 
 impl<C: AnyCollider> ColliderQueryItem<'_, C> {
@@ -34,5 +35,11 @@ impl<C: AnyCollider> ColliderQueryItem<'_, C> {
                 .accumulated_translation
                 .as_ref()
                 .map_or_else(default, |t| t.0)
+    }
+
+    /// Returns the [`ActiveCollisionHooks`] for the collider.
+    pub fn active_hooks(&self) -> ActiveCollisionHooks {
+        self.active_hooks
+            .map_or(ActiveCollisionHooks::empty(), |h| *h)
     }
 }

--- a/src/collision/hooks.rs
+++ b/src/collision/hooks.rs
@@ -1,0 +1,191 @@
+//! Collision hooks for filtering and modifying contacts.
+use crate::prelude::*;
+use bevy::{ecs::system::SystemParam, prelude::*};
+
+/// A trait for user-defined hooks that can filter and modify contacts.
+///
+/// This can be useful for advanced contact scenarios, such as:
+///
+/// - One-way platforms
+/// - Conveyor belts
+/// - Non-uniform friction
+///
+/// Collision hooks are more flexible than built-in filtering options like [`CollisionLayers`],
+/// but can be more complex to define, and can have slightly more overhead.
+/// It is recommended to use hooks only when existing options are not sufficient.
+///
+/// Only one set of collision hooks can be defined for a given app.
+///
+/// # Defining Hooks
+///
+/// Collision hooks can be defined by implementing the [`CollisionHooks`] trait
+/// for a type implementing [`SystemParam`]. The [`SystemParam`] allows the hooks
+/// to access resources, query for components, perform [spatial queries](crate::spatial_query),
+/// or do almost anything else that a normal system can do.
+///
+/// ```
+#[cfg_attr(feature = "2d", doc = "use avian2d::prelude::*;")]
+#[cfg_attr(feature = "3d", doc = "use avian3d::prelude::*;")]
+/// use bevy::prelude::*;
+///
+/// // Define a `SystemParam` for the collision hooks.
+/// #[derive(SystemParam)]
+/// struct MyHooks<'w, 's> {
+///     interaction_query: Query<'w, 's, &InteractionGroup>,
+///     platform_query: Query<'w, 's, &Transform, With<OneWayPlatform>>,
+/// }
+///
+/// // Implement the `CollisionHooks` trait.
+/// impl CollisionHooks for MyHooks<'_, '_> {
+///     fn filter_pairs(&mut self, entity1: Entity, entity2: Entity) -> bool {
+///         // Only allow collisions between entities in the same interaction group.
+///         // This could be a basic solution for "multiple physics worlds" that don't interact.
+///         let Ok([group1, group2]) = self.interaction_query.get_many([entity1, entity2]) else {
+///            return true;
+///         };
+///         group1.0 == group2.0
+///     }
+///
+///     fn modify_contacts(&mut self, contacts: &mut Contacts) -> bool {
+///         // Allow entities to pass through the bottom and sides of one-way platforms.
+///         // See the `one_way_platform_2d` example for a full implementation.
+///         let (entity1, entity2) = (contacts.entity1, contacts.entity2);
+///         !is_hitting_top_of_platform(entity1, entity2, &self.platform_query, &contacts)
+///     }
+/// }
+///
+/// // A component that groups entities for interactions. Only entities in the same group can collide.
+/// #[derive(Component)]
+/// struct InteractionGroup(u32);
+/// #
+/// #
+/// # fn is_hitting_top_of_platform(
+/// #     entity1: Entity,
+/// #     entity2: Entity,
+/// #     platform_query: &Query<&Transform, With<OneWayPlatform>>,
+/// #     contacts: &Contacts,
+/// # ) -> bool {
+/// #     todo!()
+/// # }
+/// ```
+///
+/// The hooks can be added to the app with [`PhysicsPlugins::with_collision_hooks`]:
+///
+/// ```no_run
+#[cfg_attr(feature = "2d", doc = "# use avian2d::prelude::*;")]
+#[cfg_attr(feature = "3d", doc = "# use avian3d::prelude::*;")]
+/// # use bevy::prelude::*;
+/// #
+/// # // No-op hooks for the example.
+/// # use () as MyHooks;
+/// #
+/// fn main() {
+///     App::new()
+///         .add_plugins((
+///             DefaultPlugins,
+///             PhysicsPlugins::default().with_collision_hooks::<MyHooks>(),
+///         ))
+///         .run();
+/// }
+/// ```
+///
+/// Alternatively, manually replace the default [`BroadPhasePlugin`] and [`NarrowPhasePlugin`]
+/// with instances that have the desired hooks given using generics.
+///
+/// # Activating Hooks
+///
+/// Hooks are *only* called for collisions where at least one entity has the [`ActiveCollisionHooks`] component
+/// with the corresponding flags set. By default, no hooks are called.
+///
+/// ```
+#[cfg_attr(feature = "2d", doc = "# use avian2d::prelude::*;")]
+#[cfg_attr(feature = "3d", doc = "# use avian3d::prelude::*;")]
+/// # use bevy::prelude::*;
+/// #
+/// # fn setup(mut commands: Commands) {
+/// // Spawn a collider with filtering hooks enabled.
+/// commands.spawn((Collider::capsule(0.5, 1.5), ActiveCollisionHooks::FILTER_PAIRS));
+///
+/// // Spawn a collider with both filtering and contact modification hooks enabled.
+/// commands.spawn((
+///     Collider::capsule(0.5, 1.5),
+///     ActiveCollisionHooks::FILTER_PAIRS | ActiveCollisionHooks::MODIFY_CONTACTS
+/// ));
+///
+/// // Alternatively, all hooks can be enabled with `ActiveCollisionHooks::ALL`.
+/// commands.spawn((Collider::capsule(0.5, 1.5), ActiveCollisionHooks::ALL));
+/// # }
+/// ```
+///
+/// # Caveats
+///
+/// - Only one set of collision hooks can be defined for a given app.
+/// - Certain components and resources may not be (mutably) accessible in hooks due to the internal system
+///   having access to them simultaneously. You will get a runtime panic if you try to access them.
+#[expect(unused_variables)]
+pub trait CollisionHooks: SystemParam + Send + Sync {
+    /// A contact pair filtering hook that determines whether contacts should be computed
+    /// between `entity1` and `entity2`. If `false` is returned, contacts will not be computed.
+    ///
+    /// This is called in the broad phase, before [`Contacts`] have been computed for the pair.
+    ///
+    /// Only called if at least one entity in the contact pair has [`ActiveCollisionHooks::FILTER_PAIRS`] set.
+    fn filter_pairs(&mut self, entity1: Entity, entity2: Entity, commands: &mut Commands) -> bool {
+        true
+    }
+
+    /// A contact modification hook that allows modifying the contacts for a given contact pair.
+    /// If `false` is returned, the contact pair will be removed.
+    ///
+    /// This is called in the narrow phase, after [`Contacts`] have been computed for the pair,
+    /// but before constraints have been generated for the contact solver.
+    ///
+    /// Only called if at least one entity in the contact pair has [`ActiveCollisionHooks::MODIFY_CONTACTS`] set.
+    fn modify_contacts(&self, contacts: &mut Contacts, commands: &mut Commands) -> bool {
+        true
+    }
+}
+
+impl CollisionHooks for () {}
+
+/// A component with flags indicating which [`CollisionHooks`] should be called for collisions with an entity.
+///
+/// If either entity in a collision has hooks enabled, the hooks will be called.
+///
+/// Default: [`ActiveCollisionHooks::NONE`]
+///
+/// # Example
+///
+/// ```
+#[cfg_attr(feature = "2d", doc = "# use avian2d::prelude::*;")]
+#[cfg_attr(feature = "3d", doc = "# use avian3d::prelude::*;")]
+/// # use bevy::prelude::*;
+/// #
+/// # fn setup(mut commands: Commands) {
+/// // Spawn a collider with filtering hooks enabled.
+/// commands.spawn((Collider::capsule(0.5, 1.5), ActiveCollisionHooks::FILTER_PAIRS));
+///
+/// // Spawn a collider with both filtering and contact modification hooks enabled.
+/// commands.spawn((
+///     Collider::capsule(0.5, 1.5),
+///     ActiveCollisionHooks::FILTER_PAIRS | ActiveCollisionHooks::MODIFY_CONTACTS
+/// ));
+///
+/// // Alternatively, all hooks can be enabled with `ActiveCollisionHooks::ALL`.
+/// commands.spawn((Collider::capsule(0.5, 1.5), ActiveCollisionHooks::ALL));
+/// # }
+/// ```
+#[repr(transparent)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Component, Hash, Clone, Copy, PartialEq, Eq, Debug, Reflect)]
+#[reflect(opaque, Hash, PartialEq, Debug)]
+pub struct ActiveCollisionHooks(u8);
+
+bitflags::bitflags! {
+    impl ActiveCollisionHooks: u8 {
+        /// Set if [`CollisionHooks::filter_contact_pairs`] should be called for collisions with this entity.
+        const FILTER_PAIRS = 0b0000_0001;
+        /// Set if [`CollisionHooks::modify_contacts`] should be called for collisions with this entity.
+        const MODIFY_CONTACTS = 0b0000_0010;
+    }
+}

--- a/src/collision/hooks.rs
+++ b/src/collision/hooks.rs
@@ -1,6 +1,9 @@
 //! Collision hooks for filtering and modifying contacts.
+//!
+//! See the [`CollisionHooks`] trait for more information.
+
 use crate::prelude::*;
-use bevy::{ecs::system::SystemParam, prelude::*};
+use bevy::{ecs::system::ReadOnlySystemParam, prelude::*};
 
 /// A trait for user-defined hooks that can filter and modify contacts.
 ///
@@ -8,36 +11,48 @@ use bevy::{ecs::system::SystemParam, prelude::*};
 ///
 /// - One-way platforms
 /// - Conveyor belts
-/// - Non-uniform friction
+/// - Non-uniform friction and restitution
 ///
 /// Collision hooks are more flexible than built-in filtering options like [`CollisionLayers`],
-/// but can be more complex to define, and can have slightly more overhead.
+/// but can be more complicated to define, and can have slightly more overhead.
 /// It is recommended to use hooks only when existing options are not sufficient.
 ///
-/// Only one set of collision hooks can be defined for a given app.
+/// Only one set of collision hooks can be defined per broad phase and narrow phase.
 ///
 /// # Defining Hooks
 ///
-/// Collision hooks can be defined by implementing the [`CollisionHooks`] trait
-/// for a type implementing [`SystemParam`]. The [`SystemParam`] allows the hooks
-/// to access resources, query for components, perform [spatial queries](crate::spatial_query),
-/// or do almost anything else that a normal system can do.
+/// Collision hooks can be defined by implementing the [`CollisionHooks`] trait for a type
+/// that implements [`SystemParam`]. The system parameter allows the hooks to do things like
+/// access resources, query for components, and perform [spatial queries](crate::spatial_query).
+///
+/// Note that mutable access is not allowed for the system parameter, as hooks may be called
+/// during parallel iteration. However, access to [`Commands`] is provided for deferred changes.
+///
+/// Below is an example of using collision hooks to implement interaction groups and one-way platforms:
 ///
 /// ```
 #[cfg_attr(feature = "2d", doc = "use avian2d::prelude::*;")]
 #[cfg_attr(feature = "3d", doc = "use avian3d::prelude::*;")]
-/// use bevy::prelude::*;
+/// use bevy::{ecs::system::SystemParam, prelude::*};
+///
+/// /// A component that groups entities for interactions. Only entities in the same group can collide.
+/// #[derive(Component)]
+/// struct InteractionGroup(u32);
+///
+/// /// A component that marks an entity as a one-way platform.
+/// #[derive(Component)]
+/// struct OneWayPlatform;
 ///
 /// // Define a `SystemParam` for the collision hooks.
 /// #[derive(SystemParam)]
 /// struct MyHooks<'w, 's> {
-///     interaction_query: Query<'w, 's, &InteractionGroup>,
-///     platform_query: Query<'w, 's, &Transform, With<OneWayPlatform>>,
+///     interaction_query: Query<'w, 's, &'static InteractionGroup>,
+///     platform_query: Query<'w, 's, &'static Transform, With<OneWayPlatform>>,
 /// }
 ///
 /// // Implement the `CollisionHooks` trait.
 /// impl CollisionHooks for MyHooks<'_, '_> {
-///     fn filter_pairs(&mut self, entity1: Entity, entity2: Entity) -> bool {
+///     fn filter_pairs(&self, entity1: Entity, entity2: Entity, _commands: &mut Commands) -> bool {
 ///         // Only allow collisions between entities in the same interaction group.
 ///         // This could be a basic solution for "multiple physics worlds" that don't interact.
 ///         let Ok([group1, group2]) = self.interaction_query.get_many([entity1, entity2]) else {
@@ -46,18 +61,13 @@ use bevy::{ecs::system::SystemParam, prelude::*};
 ///         group1.0 == group2.0
 ///     }
 ///
-///     fn modify_contacts(&mut self, contacts: &mut Contacts) -> bool {
+///     fn modify_contacts(&self, contacts: &mut Contacts, _commands: &mut Commands) -> bool {
 ///         // Allow entities to pass through the bottom and sides of one-way platforms.
 ///         // See the `one_way_platform_2d` example for a full implementation.
 ///         let (entity1, entity2) = (contacts.entity1, contacts.entity2);
 ///         !is_hitting_top_of_platform(entity1, entity2, &self.platform_query, &contacts)
 ///     }
 /// }
-///
-/// // A component that groups entities for interactions. Only entities in the same group can collide.
-/// #[derive(Component)]
-/// struct InteractionGroup(u32);
-/// #
 /// #
 /// # fn is_hitting_top_of_platform(
 /// #     entity1: Entity,
@@ -69,15 +79,18 @@ use bevy::{ecs::system::SystemParam, prelude::*};
 /// # }
 /// ```
 ///
-/// The hooks can be added to the app with [`PhysicsPlugins::with_collision_hooks`]:
+/// The hooks can then be added to the app using [`PhysicsPlugins::with_collision_hooks`]:
 ///
 /// ```no_run
 #[cfg_attr(feature = "2d", doc = "# use avian2d::prelude::*;")]
 #[cfg_attr(feature = "3d", doc = "# use avian3d::prelude::*;")]
-/// # use bevy::prelude::*;
+/// # use bevy::{ecs::system::SystemParam, prelude::*};
+/// #
+/// # #[derive(SystemParam)]
+/// # struct MyHooks {}
 /// #
 /// # // No-op hooks for the example.
-/// # use () as MyHooks;
+/// # impl CollisionHooks for MyHooks {}
 /// #
 /// fn main() {
 ///     App::new()
@@ -89,8 +102,10 @@ use bevy::{ecs::system::SystemParam, prelude::*};
 /// }
 /// ```
 ///
-/// Alternatively, manually replace the default [`BroadPhasePlugin`] and [`NarrowPhasePlugin`]
-/// with instances that have the desired hooks given using generics.
+/// This is equivalent to manually replacing the default [`BroadPhasePlugin`] and [`NarrowPhasePlugin`]
+/// with instances that have the desired hooks provided using generics.
+///
+/// [`SystemParam`]: bevy::ecs::system::SystemParam
 ///
 /// # Activating Hooks
 ///
@@ -112,25 +127,34 @@ use bevy::{ecs::system::SystemParam, prelude::*};
 ///     ActiveCollisionHooks::FILTER_PAIRS | ActiveCollisionHooks::MODIFY_CONTACTS
 /// ));
 ///
-/// // Alternatively, all hooks can be enabled with `ActiveCollisionHooks::ALL`.
-/// commands.spawn((Collider::capsule(0.5, 1.5), ActiveCollisionHooks::ALL));
+/// // Alternatively, all hooks can be enabled with `ActiveCollisionHooks::all()`.
+/// commands.spawn((Collider::capsule(0.5, 1.5), ActiveCollisionHooks::all()));
 /// # }
 /// ```
 ///
 /// # Caveats
 ///
-/// - Only one set of collision hooks can be defined for a given app.
-/// - Certain components and resources may not be (mutably) accessible in hooks due to the internal system
-///   having access to them simultaneously. You will get a runtime panic if you try to access them.
+/// Collision hooks can access the ECS quite freely, but there are a few limitations:
+///
+/// - Only one set of collision hooks can be defined per broad phase and narrow phase.
+/// - Only read-only access is allowed for the hook system parameter. Use the provided [`Commands`] for deferred changes.
+///   - Note that command execution order is unspecified if the `parallel` feature is enabled.
+/// - Access to the [`BroadCollisionPairs`] resource is not allowed inside [`CollisionHooks::filter_pairs`].
+///   Trying to access it will result in a panic.
+/// - Access to the [`Collisions`] resource is not allowed inside [`CollisionHooks::modify_contacts`].
+///   Trying to access it will result in a panic.
 #[expect(unused_variables)]
-pub trait CollisionHooks: SystemParam + Send + Sync {
+pub trait CollisionHooks: ReadOnlySystemParam + Send + Sync {
     /// A contact pair filtering hook that determines whether contacts should be computed
     /// between `entity1` and `entity2`. If `false` is returned, contacts will not be computed.
     ///
     /// This is called in the broad phase, before [`Contacts`] have been computed for the pair.
     ///
     /// Only called if at least one entity in the contact pair has [`ActiveCollisionHooks::FILTER_PAIRS`] set.
-    fn filter_pairs(&mut self, entity1: Entity, entity2: Entity, commands: &mut Commands) -> bool {
+    ///
+    /// Access to the [`BroadCollisionPairs`] resource is not allowed in this method.
+    /// Trying to access it will result in a panic.
+    fn filter_pairs(&self, entity1: Entity, entity2: Entity, commands: &mut Commands) -> bool {
         true
     }
 
@@ -141,18 +165,22 @@ pub trait CollisionHooks: SystemParam + Send + Sync {
     /// but before constraints have been generated for the contact solver.
     ///
     /// Only called if at least one entity in the contact pair has [`ActiveCollisionHooks::MODIFY_CONTACTS`] set.
+    ///
+    /// Access to the [`Collisions`] resource is not allowed in this method.
+    /// Trying to access it will result in a panic.
     fn modify_contacts(&self, contacts: &mut Contacts, commands: &mut Commands) -> bool {
         true
     }
 }
 
+// No-op implementation for `()` to allow default hooks for plugins.
 impl CollisionHooks for () {}
 
 /// A component with flags indicating which [`CollisionHooks`] should be called for collisions with an entity.
 ///
-/// If either entity in a collision has hooks enabled, the hooks will be called.
+/// Hooks will only be called if either entity in a collision has the corresponding flags set.
 ///
-/// Default: [`ActiveCollisionHooks::NONE`]
+/// Default: [`ActiveCollisionHooks::empty()`]
 ///
 /// # Example
 ///
@@ -171,8 +199,8 @@ impl CollisionHooks for () {}
 ///     ActiveCollisionHooks::FILTER_PAIRS | ActiveCollisionHooks::MODIFY_CONTACTS
 /// ));
 ///
-/// // Alternatively, all hooks can be enabled with `ActiveCollisionHooks::ALL`.
-/// commands.spawn((Collider::capsule(0.5, 1.5), ActiveCollisionHooks::ALL));
+/// // Alternatively, all hooks can be enabled with `ActiveCollisionHooks::all()`.
+/// commands.spawn((Collider::capsule(0.5, 1.5), ActiveCollisionHooks::all()));
 /// # }
 /// ```
 #[repr(transparent)]
@@ -183,7 +211,7 @@ pub struct ActiveCollisionHooks(u8);
 
 bitflags::bitflags! {
     impl ActiveCollisionHooks: u8 {
-        /// Set if [`CollisionHooks::filter_contact_pairs`] should be called for collisions with this entity.
+        /// Set if [`CollisionHooks::filter_pairs`] should be called for collisions with this entity.
         const FILTER_PAIRS = 0b0000_0001;
         /// Set if [`CollisionHooks::modify_contacts`] should be called for collisions with this entity.
         const MODIFY_CONTACTS = 0b0000_0010;

--- a/src/collision/mod.rs
+++ b/src/collision/mod.rs
@@ -22,6 +22,7 @@ pub mod broad_phase;
 ))]
 pub mod contact_query;
 pub mod contact_reporting;
+pub mod hooks;
 pub mod narrow_phase;
 
 pub mod collider;

--- a/src/collision/mod.rs
+++ b/src/collision/mod.rs
@@ -47,16 +47,7 @@ use indexmap::IndexMap;
 // ==========================================
 /// A resource that stores all collision pairs.
 ///
-/// Each colliding entity pair is associated with [`Contacts`] that can be accessed and modified
-/// using the various associated methods.
-///
-/// # Usage
-///
-/// [`Collisions`] can be accessed at almost anytime, but for modifying and filtering collisions,
-/// it is recommended to use the [`PostProcessCollisions`] schedule. See its documentation
-/// for more information.
-///
-/// ## Querying Collisions
+/// # Querying Collisions
 ///
 /// The following methods can be used for querying existing collisions:
 ///
@@ -66,29 +57,13 @@ use indexmap::IndexMap;
 /// - [`collisions_with_entity`](Self::collisions_with_entity) and
 ///   [`collisions_with_entity_mut`](Self::collisions_with_entity_mut)
 ///
-/// The collisions can be accessed at any time, but modifications to contacts should be performed
-/// in the [`PostProcessCollisions`] schedule. Otherwise, the physics solver will use the old contact data.
+/// Collisions can be accessed at almost any time, but modifications to contacts should be performed
+/// in the [`PostProcessCollisions`] schedule or in [`CollisionHooks`].
 ///
-/// ## Filtering and Removing Collisions
+/// # Filtering and Modifying Collisions
 ///
-/// The following methods can be used for filtering or removing existing collisions:
-///
-/// - [`retain`](Self::retain)
-/// - [`remove_collision_pair`](Self::remove_collision_pair)
-/// - [`remove_collisions_with_entity`](Self::remove_collisions_with_entity)
-///
-/// Collision filtering and removal should be done in the [`PostProcessCollisions`] schedule.
-/// Otherwise, the physics solver will use the old contact data.
-///
-/// ## Adding New Collisions
-///
-/// The following methods can be used for adding new collisions:
-///
-/// - [`insert_collision_pair`](Self::insert_collision_pair)
-/// - [`extend`](Self::extend)
-///
-/// The most convenient place for adding new collisions is in the [`PostProcessCollisions`] schedule.
-/// Otherwise, the physics solver might not have access to them in time.
+/// Advanced collision filtering and modification can be done using [`CollisionHooks`].
+/// See its documentation for more information.
 ///
 /// # Implementation Details
 ///

--- a/src/collision/narrow_phase.rs
+++ b/src/collision/narrow_phase.rs
@@ -258,7 +258,7 @@ fn collect_collisions<C: AnyCollider, H: CollisionHooks + 'static>(
     broad_collision_pairs: Res<BroadCollisionPairs>,
     time: Res<Time>,
     hooks: StaticSystemParam<H>,
-    #[cfg(not(feature = "parallel"))] mut commands: Commands,
+    #[cfg(not(feature = "parallel"))] commands: Commands,
     #[cfg(feature = "parallel")] commands: ParallelCommands,
 ) where
     for<'w, 's> SystemParamItem<'w, 's, H>: CollisionHooks,
@@ -407,7 +407,7 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
         broad_collision_pairs: &[(Entity, Entity)],
         delta_secs: Scalar,
         hooks: &H::Item<'_, '_>,
-        #[cfg(not(feature = "parallel"))] commands: Commands,
+        #[cfg(not(feature = "parallel"))] mut commands: Commands,
         #[cfg(feature = "parallel")] par_commands: ParallelCommands,
     ) where
         for<'w, 's> SystemParamItem<'w, 's, H>: CollisionHooks,
@@ -459,7 +459,7 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
             // contact constraints for them.
             for &(entity1, entity2) in broad_collision_pairs {
                 if let Some(contacts) =
-                    self.handle_entity_pair(entity1, entity2, delta_secs, hooks, &mut commands)
+                    self.handle_entity_pair::<H>(entity1, entity2, delta_secs, hooks, &mut commands)
                 {
                     self.collisions.insert_collision_pair(contacts);
                 }

--- a/src/collision/narrow_phase.rs
+++ b/src/collision/narrow_phase.rs
@@ -16,7 +16,7 @@ use bevy::{
     ecs::{
         intern::Interned,
         schedule::{ExecutorKind, LogLevel, ScheduleBuildSettings, ScheduleLabel},
-        system::SystemParam,
+        system::{StaticSystemParam, SystemParam, SystemParamItem},
     },
     prelude::*,
 };
@@ -33,17 +33,17 @@ use bevy::{
 /// The plugin takes a collider type. This should be [`Collider`] for
 /// the vast majority of applications, but for custom collisión backends
 /// you may use any collider that implements the [`AnyCollider`] trait.
-pub struct NarrowPhasePlugin<C: AnyCollider> {
+pub struct NarrowPhasePlugin<C: AnyCollider, H: CollisionHooks = ()> {
     schedule: Interned<dyn ScheduleLabel>,
     /// If `true`, the narrow phase will generate [`ContactConstraint`]s
     /// and add them to the [`ContactConstraints`] resource.
     ///
     /// Contact constraints are used by the [`SolverPlugin`] for solving contacts.
     generate_constraints: bool,
-    _phantom: PhantomData<C>,
+    _phantom: PhantomData<(C, H)>,
 }
 
-impl<C: AnyCollider> NarrowPhasePlugin<C> {
+impl<C: AnyCollider, H: CollisionHooks> NarrowPhasePlugin<C, H> {
     /// Creates a [`NarrowPhasePlugin`] with the schedule used for running its systems
     /// and whether it should generate [`ContactConstraint`]s for the [`ContactConstraints`] resource.
     ///
@@ -59,13 +59,16 @@ impl<C: AnyCollider> NarrowPhasePlugin<C> {
     }
 }
 
-impl<C: AnyCollider> Default for NarrowPhasePlugin<C> {
+impl<C: AnyCollider, H: CollisionHooks> Default for NarrowPhasePlugin<C, H> {
     fn default() -> Self {
         Self::new(PhysicsSchedule, true)
     }
 }
 
-impl<C: AnyCollider> Plugin for NarrowPhasePlugin<C> {
+impl<C: AnyCollider, H: CollisionHooks + 'static> Plugin for NarrowPhasePlugin<C, H>
+where
+    for<'w, 's> SystemParamItem<'w, 's, H>: CollisionHooks,
+{
     fn build(&self, app: &mut App) {
         // For some systems, we only want one instance, even if there are multiple
         // NarrowPhasePlugin instances with different collider types.
@@ -129,7 +132,7 @@ impl<C: AnyCollider> Plugin for NarrowPhasePlugin<C> {
         // Collect contacts into `Collisions`.
         app.add_systems(
             self.schedule,
-            collect_collisions::<C>
+            collect_collisions::<C, H>
                 .in_set(NarrowPhaseSet::CollectCollisions)
                 // Allowing ambiguities is required so that it's possible
                 // to have multiple collision backends at the same time.
@@ -250,12 +253,22 @@ pub enum NarrowPhaseSet {
     Last,
 }
 
-fn collect_collisions<C: AnyCollider>(
+fn collect_collisions<C: AnyCollider, H: CollisionHooks + 'static>(
     mut narrow_phase: NarrowPhase<C>,
     broad_collision_pairs: Res<BroadCollisionPairs>,
     time: Res<Time>,
-) {
-    narrow_phase.update(&broad_collision_pairs, time.delta_seconds_adjusted());
+    hooks: StaticSystemParam<H>,
+    #[cfg(not(feature = "parallel"))] mut commands: Commands,
+    #[cfg(feature = "parallel")] commands: ParallelCommands,
+) where
+    for<'w, 's> SystemParamItem<'w, 's, H>: CollisionHooks,
+{
+    narrow_phase.update::<H>(
+        &broad_collision_pairs,
+        time.delta_seconds_adjusted(),
+        &hooks.into_inner(),
+        commands,
+    );
 }
 
 // TODO: It'd be nice to generate the constraint in the same parallel loop as `collect_collisions`
@@ -389,7 +402,16 @@ pub struct NarrowPhase<'w, 's, C: AnyCollider> {
 impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
     /// Updates the narrow phase by computing [`Contacts`] based on [`BroadCollisionPairs`]
     /// and adding them to [`Collisions`].
-    fn update(&mut self, broad_collision_pairs: &[(Entity, Entity)], delta_secs: Scalar) {
+    fn update<H: CollisionHooks + 'static>(
+        &mut self,
+        broad_collision_pairs: &[(Entity, Entity)],
+        delta_secs: Scalar,
+        hooks: &H::Item<'_, '_>,
+        #[cfg(not(feature = "parallel"))] commands: Commands,
+        #[cfg(feature = "parallel")] par_commands: ParallelCommands,
+    ) where
+        for<'w, 's> SystemParamItem<'w, 's, H>: CollisionHooks,
+    {
         // TODO: These scaled versions could be in their own resource
         //       and updated just before physics every frame.
         // Cache default margins scaled by the length unit.
@@ -409,13 +431,19 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
 
                     // Compute contacts for this intersection pair and generate
                     // contact constraints for them.
-                    for &(entity1, entity2) in chunks {
-                        if let Some(contacts) =
-                            self.handle_entity_pair(entity1, entity2, delta_secs)
-                        {
-                            new_collisions.push(contacts);
+                    par_commands.command_scope(|mut commands| {
+                        for &(entity1, entity2) in chunks {
+                            if let Some(contacts) = self.handle_entity_pair::<H>(
+                                entity1,
+                                entity2,
+                                delta_secs,
+                                hooks,
+                                &mut commands,
+                            ) {
+                                new_collisions.push(contacts);
+                            }
                         }
-                    }
+                    });
 
                     new_collisions
                 })
@@ -430,7 +458,9 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
             // Compute contacts for this intersection pair and generate
             // contact constraints for them.
             for &(entity1, entity2) in broad_collision_pairs {
-                if let Some(contacts) = self.handle_entity_pair(entity1, entity2, delta_secs) {
+                if let Some(contacts) =
+                    self.handle_entity_pair(entity1, entity2, delta_secs, hooks, &mut commands)
+                {
                     self.collisions.insert_collision_pair(contacts);
                 }
             }
@@ -441,12 +471,17 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
     /// or expected to start intersecting within the next frame. This includes
     /// [speculative collision](dynamics::ccd#speculative-collision).
     #[allow(clippy::too_many_arguments)]
-    pub fn handle_entity_pair(
+    pub fn handle_entity_pair<H: CollisionHooks>(
         &self,
         entity1: Entity,
         entity2: Entity,
         delta_secs: Scalar,
-    ) -> Option<Contacts> {
+        hooks: &H::Item<'_, '_>,
+        commands: &mut Commands,
+    ) -> Option<Contacts>
+    where
+        for<'w, 's> SystemParamItem<'w, 's, H>: CollisionHooks,
+    {
         let Ok([collider1, collider2]) = self.collider_query.get_many([entity1, entity2]) else {
             return None;
         };
@@ -541,7 +576,13 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
         let max_contact_distance =
             effective_speculative_margin.max(*self.contact_tolerance) + collision_margin_sum;
 
-        self.compute_contact_pair(&collider1, &collider2, max_contact_distance)
+        self.compute_contact_pair::<H>(
+            &collider1,
+            &collider2,
+            max_contact_distance,
+            hooks,
+            commands,
+        )
     }
 
     /// Computes contacts between `collider1` and `collider2`.
@@ -551,19 +592,24 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
     /// to be detected. A value greater than zero means that contacts are generated
     /// based on the closest points even if the shapes are separated.
     #[allow(clippy::type_complexity, clippy::too_many_arguments)]
-    pub fn compute_contact_pair(
+    pub fn compute_contact_pair<H: CollisionHooks>(
         &self,
         collider1: &ColliderQueryItem<C>,
         collider2: &ColliderQueryItem<C>,
         max_distance: Scalar,
-    ) -> Option<Contacts> {
+        hooks: &H::Item<'_, '_>,
+        commands: &mut Commands,
+    ) -> Option<Contacts>
+    where
+        for<'w, 's> SystemParamItem<'w, 's, H>: CollisionHooks,
+    {
         let position1 = collider1.current_position();
         let position2 = collider2.current_position();
 
         // TODO: It'd be good to persist the manifolds and let Parry match contacts.
         //       This isn't currently done because it requires using Parry's contact manifold type.
         // Compute the contact manifolds using the effective speculative margin.
-        let mut manifolds = collider1.shape.contact_manifolds(
+        let manifolds = collider1.shape.contact_manifolds(
             collider2.shape,
             position1,
             *collider1.rotation,
@@ -571,6 +617,10 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
             *collider2.rotation,
             max_distance,
         );
+
+        if manifolds.is_empty() {
+            return None;
+        }
 
         // Get the previous contacts if there are any.
         let previous_contacts = if collider1.entity < collider2.entity {
@@ -583,48 +633,57 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                 .get(&(collider2.entity, collider1.entity))
         };
 
-        let mut total_normal_impulse = 0.0;
-        let mut total_tangent_impulse = default();
+        let mut contacts = Contacts {
+            entity1: collider1.entity,
+            entity2: collider2.entity,
+            body_entity1: collider1.parent.map(|p| p.get()),
+            body_entity2: collider2.parent.map(|p| p.get()),
+            during_current_frame: true,
+            during_previous_frame: previous_contacts.is_some_and(|c| c.during_previous_frame),
+            manifolds,
+            is_sensor: collider1.is_sensor
+                || collider2.is_sensor
+                || !collider1.is_rb
+                || !collider2.is_rb,
+            total_normal_impulse: 0.0,
+            total_tangent_impulse: default(),
+        };
+
+        let active_hooks = collider1.active_hooks().union(collider2.active_hooks());
+        if active_hooks.contains(ActiveCollisionHooks::MODIFY_CONTACTS) {
+            let keep_contacts = hooks.modify_contacts(&mut contacts, commands);
+            if !keep_contacts {
+                return None;
+            }
+        }
+
+        if contacts.manifolds.is_empty() {
+            return None;
+        }
 
         // Match contacts and copy previous contact impulses for warm starting the solver.
         // TODO: This condition is pretty arbitrary, mainly to skip dense trimeshes.
         //       If we let Parry handle contact matching, this wouldn't be needed.
-        if manifolds.len() <= 4 && self.config.match_contacts {
+        if contacts.manifolds.len() <= 4 && self.config.match_contacts {
             if let Some(previous_contacts) = previous_contacts {
                 // TODO: Cache this?
                 let distance_threshold = 0.1 * self.length_unit.0;
 
-                for manifold in manifolds.iter_mut() {
+                for manifold in contacts.manifolds.iter_mut() {
                     for previous_manifold in previous_contacts.manifolds.iter() {
                         manifold.match_contacts(&previous_manifold.contacts, distance_threshold);
 
                         // Add contact impulses to total impulses.
                         for contact in manifold.contacts.iter() {
-                            total_normal_impulse += contact.normal_impulse;
-                            total_tangent_impulse += contact.tangent_impulse;
+                            contacts.total_normal_impulse += contact.normal_impulse;
+                            contacts.total_tangent_impulse += contact.tangent_impulse;
                         }
                     }
                 }
             }
         }
 
-        let contacts = Contacts {
-            entity1: collider1.entity,
-            entity2: collider2.entity,
-            body_entity1: collider1.parent.map(|p| p.get()),
-            body_entity2: collider2.parent.map(|p| p.get()),
-            during_current_frame: true,
-            during_previous_frame: previous_contacts.map_or(false, |c| c.during_previous_frame),
-            manifolds,
-            is_sensor: collider1.is_sensor
-                || collider2.is_sensor
-                || !collider1.is_rb
-                || !collider2.is_rb,
-            total_normal_impulse,
-            total_tangent_impulse,
-        };
-
-        (!contacts.manifolds.is_empty()).then_some(contacts)
+        Some(contacts)
     }
 
     /// Generates [`ContactConstraint`]s for the given bodies and their corresponding colliders
@@ -724,8 +783,8 @@ pub fn reset_collision_states(
             contacts.body_entity1.unwrap_or(contacts.entity1),
             contacts.body_entity2.unwrap_or(contacts.entity2),
         ]) {
-            let active1 = !rb1.map_or(false, |rb| rb.is_static()) && !sleeping1;
-            let active2 = !rb2.map_or(false, |rb| rb.is_static()) && !sleeping2;
+            let active1 = !rb1.is_some_and(|rb| rb.is_static()) && !sleeping1;
+            let active2 = !rb2.is_some_and(|rb| rb.is_static()) && !sleeping2;
 
             // Reset collision states if either of the bodies is active (not static or sleeping)
             // Otherwise, the bodies are still in contact.

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -607,7 +607,7 @@ fn solve_swept_ccd(
                 );
 
                 let sweep_mode = if ccd1.mode == SweepMode::Linear
-                    && body2.ccd.map_or(true, |ccd| ccd.mode == SweepMode::Linear)
+                    && body2.ccd.is_none_or(|ccd| ccd.mode == SweepMode::Linear)
                 {
                     SweepMode::Linear
                 } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,8 +152,8 @@
 )]
 //! - [Get colliding entities](CollidingEntities)
 //! - [Collision events](ContactReportingPlugin#collision-events)
-//! - [Collision hooks](CollisionHooks)
-//! - [Accessing, filtering and modifying collisions](Collisions)
+//! - [Accessing collision data](Collisions)
+//! - [Filtering and modifying contacts with hooks](CollisionHooks)
 //! - [Manual contact queries](contact_query)
 //! - [Temporarily disabling a collider](ColliderDisabled)
 //!

--- a/src/schedule/mod.rs
+++ b/src/schedule/mod.rs
@@ -120,6 +120,7 @@ impl Default for IsFirstRun {
 #[derive(Debug, Hash, PartialEq, Eq, Clone, ScheduleLabel)]
 pub struct PhysicsSchedule;
 
+// TODO: Remove this in favor of collision hooks.
 /// A schedule where you can add systems to filter or modify collisions
 /// using the [`Collisions`] resource.
 ///


### PR DESCRIPTION
# Objective

Closes #150.

Advanced contact scenarios often require filtering or modifying contacts with custom logic. Use cases include:

- One-way platforms
- Conveyor belts
- Non-uniform friction and restitution for terrain

Physics engines typically handle this with *hooks* or *callbacks* that are called during specific parts of the simulation loop. For example:

- Box2D: `b2CustomFilterFcn()` and `b2PreSolveFcn` (see [docs](https://box2d.org/documentation/md_simulation.html#autotoc_md97))
- Rapier: `PhysicsHooks` trait with `filter_contact_pair`/`filter_intersection_pair` and `modify_solver_contacts` (see [docs](https://rapier.rs/docs/user_guides/bevy_plugin/advanced_collision_detection#physics-hooks))
- Jolt: `ContactListener` with `OnContactValidate`, `OnContactAdded`, `OnContactPersisted`, and `OnContactRemoved` (see [docs](https://jrouwe.github.io/JoltPhysics/class_contact_listener.html))

Currently, we just have a `PostProcessCollisions` schedule where users can freely add systems to operate on collision data before constraints are generated. However:

- It doesn't support filtering broad phase pairs.
- It results in unnecessary iteration. Filtering and modification should happen directly when contacts are being created or added.
- It adds more scheduling overhead.
- It forces us to handle collision events and other collision logic in a sub-optimal way.

`PostProcessCollisions` is generally not a good approach for performance, and it is not enough for our needs, even if it is highly flexible. We need proper collision hooks that are called as part of the simulation loop.

## Solution

Add a `CollisionHooks` trait for types implementing `ReadOnlySystemParam`, with a `filter_pairs` method for filtering broad phase pairs, and a `modify_contacts` method for modifying and filtering contacts computed by the narrow phase.

The system parameter allows ECS access in hooks. Only read-only access is allowed, because contact modification hooks may run in parallel, *but* deferred changes are supported through `Commands` passed to the hooks.

An example implementation to support interaction groups and one-way platforms might look like this:

```rust
use avian2d::prelude::*;
use bevy::{ecs::system::SystemParam, prelude::*};

/// A component that groups entities for interactions. Only entities in the same group can collide.
#[derive(Component)]
struct InteractionGroup(u32);

/// A component that marks an entity as a one-way platform.
#[derive(Component)]
struct OneWayPlatform;

// Define a `SystemParam` for the collision hooks.
#[derive(SystemParam)]
struct MyHooks<'w, 's> {
    interaction_query: Query<'w, 's, &'static InteractionGroup>,
    platform_query: Query<'w, 's, &'static Transform, With<OneWayPlatform>>,
}

// Implement the `CollisionHooks` trait.
impl CollisionHooks for MyHooks<'_, '_> {
    fn filter_pairs(&self, entity1: Entity, entity2: Entity, _commands: &mut Commands) -> bool {
        // Only allow collisions between entities in the same interaction group.
        // This could be a basic solution for "multiple physics worlds" that don't interact.
        let Ok([group1, group2]) = self.interaction_query.get_many([entity1, entity2]) else {
            return true;
        };
        group1.0 == group2.0
    }

    fn modify_contacts(&self, contacts: &mut Contacts, commands: &mut Commands) -> bool {
        // Allow entities to pass through the bottom and sides of one-way platforms.
        // See the `one_way_platform_2d` example for a full implementation.
        let (entity1, entity2) = (contacts.entity1, contacts.entity2);
        !self.is_hitting_top_of_platform(entity1, entity2, &self.platform_query, &contacts, commands)
    }
}
```

The hooks can then be added to the app using `PhysicsPlugins::with_collision_hooks`:

```rust
fn main() {
    App::new()
        .add_plugins((
            DefaultPlugins,
            PhysicsPlugins::default().with_collision_hooks::<MyHooks>(),
        ))
        .run();
}
```

> [!NOTE]
>
> The hooks are passed to the `BroadPhasePlugin` and `NarrowPhasePlugin` with generics. An app can only have one set of hooks defined.
>
> Where are the generics on `PhysicsPlugins` then? `bevy_rapier` requires them on `RapierPhysicsPlugin`, forcing people to specify generics even if hooks aren't used, like `RapierPhysicsPlugin::<()>::default()` (see https://github.com/dimforge/bevy_rapier/issues/501).
>
> Given that this is the first thing users do with the engine, I wanted to avoid forcing unnecessary generics. I'm using a subtle trick to get around them; `PhysicsPlugins` has no generics, but there is a separate `PhysicsPluginsWithHooks` wrapper with a similar API that is returned by `with_collision_hooks`. This abstraction is largely transparent to users, and gets around unnecessary generics in the public API.

It is rare to want hooks to run for every single collision pair. Thus, hooks are *only* called for collisions where at least one entity has the new `ActiveCollisionHooks` component with the corresponding flags set. By default, no hooks are called.

```rust
// Spawn a collider with filtering hooks enabled.
commands.spawn((Collider::capsule(0.5, 1.5), ActiveCollisionHooks::FILTER_PAIRS));

// Spawn a collider with both filtering and contact modification hooks enabled.
commands.spawn((
    Collider::capsule(0.5, 1.5),
    ActiveCollisionHooks::FILTER_PAIRS | ActiveCollisionHooks::MODIFY_CONTACTS
));

// Alternatively, all hooks can be enabled with `ActiveCollisionHooks::all()`.
commands.spawn((Collider::capsule(0.5, 1.5), ActiveCollisionHooks::all()));
```

### Comparison With `bevy_rapier`

The design of the collision hooks is partially inspired by `bevy_rapier`, but with what I think is a slightly friendlier and more flexible API. Some core differences:

- Rapier has ["context views"](https://docs.rs/bevy_rapier3d/0.28.0/bevy_rapier3d/pipeline/struct.ContactModificationContextView.html) for both pair filters and contact modification, with a `raw` property you need to access. It provides read-only access to some internal Rapier data (using Nalgebra types) and a contact manifold, and write-access to a contact normal and "solver contacts". There seems to be no way to queue commands or otherwise perform changes to the ECS, only read-only access.
- My pair filters simply provide the entities and access to `Commands`, while the contact modification hook provides mutable access to the `Contacts` (*not* necessarily just one manifold) between a contact pair, and to `Commands`. Read-only data about the involved entities can be queried with the ECS.

Personally, I think `bevy_rapier`'s hooks introduce a bit too much complexity and new APIs for Bevy users; there are "context views", contact manifolds, solver contacts, a bunch of internal Rapier structures, and everything uses Nalgebra types. I tried to keep it more simple, with the same contact types people already use when accessing the `Collisions` resource, while supporting read-only ECS access using the system parameter and deferred changes using `Commands`. No weird context views or Nalgebra types.

Rapier provides solver contacts, while my implementation provides raw narrow phase contact data. Both have their trade-offs, but using raw contact data introduces less new concepts, *and* it allows earlier termination, since the data for solver contacts doesn't need to be computed (though our implementation there is somewhat different from Rapier anyway).

Currently, my implementation runs hooks per *collision pair* (`Contacts`), not per *manifold* (`ContactManifold`). This provides some more data and allows entire collision pairs to be ignored at once if desired. I'm not 100% sure which is preferable though; many other engines seem to have contact modification be per-manifold. There is a possibility that we change this at some point.

### Other Changes

- Updated the `one_way_platform_2d` example to use collision hooks, and overall improved the example code.
- The broad phase now stores `AabbIntervalFlags` instead of several booleans for AABB intervals.
- `BroadPhasePlugin`, `NarrowPhasePlugin`, and many `NarrowPhase` methods now take generics for `CollisionHooks`.
- Reworked some narrow phase contact logic slightly.
- Updated and improved some docs.

## Follow-Up Work

I have several follow-up PRs in progress:

1. Per-manifold tangent velocities (for e.g. conveyor belts) and friction and restitution (for non-uniform material properties)
2. Rename many contact types and properties for clarity, improve docs and APIs
3. Contact graph
4. Reworked contact pair management

I expect them to be ready in that order. For 3-4, I would like #564 first.

It is also highly likely that we will deprecate the `PostProcessCollisions` schedule in favor of these hooks.

---

## Migration Guide

For custom contact filtering and modification logic, it is now recommended to define `CollisionHooks` instead of manually accessing and modifying `Collisions` in the `PostProcessCollisions` schedule.

The `BroadPhasePlugin`, `NarrowPhasePlugin`, and many `NarrowPhase` methods now take generics for `CollisionHooks`.