### PR TITLE
Fix outdated mentions of the default schedule

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -695,7 +695,7 @@ pub struct PhysicsPlugins {
 impl PhysicsPlugins {
     /// Creates a [`PhysicsPlugins`] plugin group using the given schedule for running the [`PhysicsSchedule`].
     ///
-    /// The default schedule is `PostUpdate`.
+    /// The default schedule is `FixedPostUpdate`.
     pub fn new(schedule: impl ScheduleLabel) -> Self {
         Self {
             schedule: schedule.intern(),

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -40,7 +40,7 @@ pub struct SyncPlugin {
 impl SyncPlugin {
     /// Creates a [`SyncPlugin`] with the schedule that is used for running the [`PhysicsSchedule`].
     ///
-    /// The default schedule is `PostUpdate`.
+    /// The default schedule is `FixedPostUpdate`.
     pub fn new(schedule: impl ScheduleLabel) -> Self {
         Self {
             schedule: schedule.intern(),
@@ -50,7 +50,7 @@ impl SyncPlugin {
 
 impl Default for SyncPlugin {
     fn default() -> Self {
-        Self::new(PostUpdate)
+        Self::new(FixedPostUpdate)
     }
 }
 


### PR DESCRIPTION
# Objective

Some places still mention `PostUpdate` as the default schedule for physics, even though it should be `FixedPostUpdate` now.

## Solution

Fix them.