### PR TITLE
Improved contact types

### DIFF
--- a/crates/avian2d/Cargo.toml
+++ b/crates/avian2d/Cargo.toml
@@ -73,6 +73,7 @@ nalgebra = { version = "0.33", features = ["convert-glam029"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 derive_more = "1"
 indexmap = "2.0.0"
+arrayvec = "0.7"
 fxhash = "0.2.1"
 itertools = "0.13"
 bitflags = "2.5.0"

--- a/crates/avian2d/examples/custom_collider.rs
+++ b/crates/avian2d/examples/custom_collider.rs
@@ -90,15 +90,12 @@ impl AnyCollider for CircleCollider {
 
             vec![ContactManifold {
                 index: 0,
-                normal1,
-                normal2,
+                normal: rotation1 * normal1,
                 contacts: vec![ContactData {
                     feature_id1: PackedFeatureId::face(0),
                     feature_id2: PackedFeatureId::face(0),
                     point1,
                     point2,
-                    normal1,
-                    normal2,
                     penetration: sum_radius - distance_squared.sqrt(),
                     // Impulses are computed by the constraint solver
                     normal_impulse: 0.0,

--- a/crates/avian2d/examples/custom_collider.rs
+++ b/crates/avian2d/examples/custom_collider.rs
@@ -79,21 +79,21 @@ impl AnyCollider for CircleCollider {
         let sum_radius = self.radius + other.radius;
 
         if distance_squared < (sum_radius + prediction_distance).powi(2) {
-            let normal1 = if distance_squared != 0.0 {
+            let local_normal1 = if distance_squared != 0.0 {
                 delta_pos.normalize_or_zero()
             } else {
                 Vector::X
             };
-            let normal2 = delta_rot.inverse() * (-normal1);
-            let point1 = normal1 * self.radius;
-            let point2 = normal2 * other.radius;
+            let local_normal2 = delta_rot.inverse() * (-local_normal1);
+            let local_point1 = local_normal1 * self.radius;
+            let local_point2 = local_normal2 * other.radius;
 
             vec![ContactManifold {
                 index: 0,
-                normal: rotation1 * normal1,
+                normal: rotation1 * local_normal1,
                 points: avian2d::data_structures::ArrayVec::from_iter([ContactPoint {
-                    point1,
-                    point2,
+                    local_point1,
+                    local_point2,
                     penetration: sum_radius - distance_squared.sqrt(),
                     // Impulses are computed by the constraint solver.
                     normal_impulse: 0.0,

--- a/crates/avian2d/examples/custom_collider.rs
+++ b/crates/avian2d/examples/custom_collider.rs
@@ -91,16 +91,16 @@ impl AnyCollider for CircleCollider {
             vec![ContactManifold {
                 index: 0,
                 normal: rotation1 * normal1,
-                contacts: vec![ContactData {
-                    feature_id1: PackedFeatureId::face(0),
-                    feature_id2: PackedFeatureId::face(0),
+                contacts: avian2d::data_structures::ArrayVec::from_iter([ContactData {
                     point1,
                     point2,
                     penetration: sum_radius - distance_squared.sqrt(),
-                    // Impulses are computed by the constraint solver
+                    // Impulses are computed by the constraint solver.
                     normal_impulse: 0.0,
                     tangent_impulse: 0.0,
-                }],
+                    feature_id1: PackedFeatureId::face(0),
+                    feature_id2: PackedFeatureId::face(0),
+                }]),
             }]
         } else {
             vec![]

--- a/crates/avian2d/examples/custom_collider.rs
+++ b/crates/avian2d/examples/custom_collider.rs
@@ -91,7 +91,7 @@ impl AnyCollider for CircleCollider {
             vec![ContactManifold {
                 index: 0,
                 normal: rotation1 * normal1,
-                contacts: avian2d::data_structures::ArrayVec::from_iter([ContactData {
+                points: avian2d::data_structures::ArrayVec::from_iter([ContactPoint {
                     point1,
                     point2,
                     penetration: sum_radius - distance_squared.sqrt(),

--- a/crates/avian2d/examples/kinematic_character_2d/plugin.rs
+++ b/crates/avian2d/examples/kinematic_character_2d/plugin.rs
@@ -326,7 +326,7 @@ fn kinematic_controller_collisions(
             let mut deepest_penetration: Scalar = Scalar::MIN;
 
             // Solve each penetrating contact in the manifold.
-            for contact in manifold.contacts.iter() {
+            for contact in manifold.points.iter() {
                 if contact.penetration > 0.0 {
                     position.0 += normal * contact.penetration;
                 }

--- a/crates/avian2d/examples/kinematic_character_2d/plugin.rs
+++ b/crates/avian2d/examples/kinematic_character_2d/plugin.rs
@@ -269,12 +269,7 @@ fn kinematic_controller_collisions(
     bodies: Query<&RigidBody>,
     collider_parents: Query<&ColliderParent, Without<Sensor>>,
     mut character_controllers: Query<
-        (
-            &mut Position,
-            &Rotation,
-            &mut LinearVelocity,
-            Option<&MaxSlopeAngle>,
-        ),
+        (&mut Position, &mut LinearVelocity, Option<&MaxSlopeAngle>),
         (With<RigidBody>, With<CharacterController>),
     >,
     time: Res<Time>,
@@ -295,7 +290,7 @@ fn kinematic_controller_collisions(
         let character_rb: RigidBody;
         let is_other_dynamic: bool;
 
-        let (mut position, rotation, mut linear_velocity, max_slope_angle) =
+        let (mut position, mut linear_velocity, max_slope_angle) =
             if let Ok(character) = character_controllers.get_mut(collider_parent1.get()) {
                 is_first = true;
                 character_rb = *bodies.get(collider_parent1.get()).unwrap();
@@ -323,9 +318,9 @@ fn kinematic_controller_collisions(
         // Each contact in a single manifold shares the same contact normal.
         for manifold in contacts.manifolds.iter() {
             let normal = if is_first {
-                -manifold.global_normal1(rotation)
+                -manifold.normal
             } else {
-                -manifold.global_normal2(rotation)
+                manifold.normal
             };
 
             let mut deepest_penetration: Scalar = Scalar::MIN;

--- a/crates/avian2d/examples/one_way_platform_2d.rs
+++ b/crates/avian2d/examples/one_way_platform_2d.rs
@@ -285,7 +285,7 @@ impl CollisionHooks for PlatformerCollisionHooks<'_, '_> {
         if one_way_platform.0.contains(&other_entity) {
             let any_penetrating = contacts.manifolds.iter().any(|manifold| {
                 manifold
-                    .contacts
+                    .points
                     .iter()
                     .any(|contact| contact.penetration > 0.0)
             });

--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -75,6 +75,7 @@ nalgebra = { version = "0.33", features = ["convert-glam029"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 derive_more = "1"
 indexmap = "2.0.0"
+arrayvec = "0.7"
 fxhash = "0.2.1"
 itertools = "0.13"
 bitflags = "2.5.0"

--- a/crates/avian3d/examples/kinematic_character_3d/plugin.rs
+++ b/crates/avian3d/examples/kinematic_character_3d/plugin.rs
@@ -285,12 +285,7 @@ fn kinematic_controller_collisions(
     bodies: Query<&RigidBody>,
     collider_parents: Query<&ColliderParent, Without<Sensor>>,
     mut character_controllers: Query<
-        (
-            &mut Position,
-            &Rotation,
-            &mut LinearVelocity,
-            Option<&MaxSlopeAngle>,
-        ),
+        (&mut Position, &mut LinearVelocity, Option<&MaxSlopeAngle>),
         (With<RigidBody>, With<CharacterController>),
     >,
     time: Res<Time>,
@@ -311,7 +306,7 @@ fn kinematic_controller_collisions(
         let character_rb: RigidBody;
         let is_other_dynamic: bool;
 
-        let (mut position, rotation, mut linear_velocity, max_slope_angle) =
+        let (mut position, mut linear_velocity, max_slope_angle) =
             if let Ok(character) = character_controllers.get_mut(collider_parent1.get()) {
                 is_first = true;
                 character_rb = *bodies.get(collider_parent1.get()).unwrap();
@@ -339,9 +334,9 @@ fn kinematic_controller_collisions(
         // Each contact in a single manifold shares the same contact normal.
         for manifold in contacts.manifolds.iter() {
             let normal = if is_first {
-                -manifold.global_normal1(rotation)
+                -manifold.normal
             } else {
-                -manifold.global_normal2(rotation)
+                manifold.normal
             };
 
             let mut deepest_penetration: Scalar = Scalar::MIN;

--- a/crates/avian3d/examples/kinematic_character_3d/plugin.rs
+++ b/crates/avian3d/examples/kinematic_character_3d/plugin.rs
@@ -342,7 +342,7 @@ fn kinematic_controller_collisions(
             let mut deepest_penetration: Scalar = Scalar::MIN;
 
             // Solve each penetrating contact in the manifold.
-            for contact in manifold.contacts.iter() {
+            for contact in manifold.points.iter() {
                 if contact.penetration > 0.0 {
                     position.0 += normal * contact.penetration;
                 }

--- a/src/collision/contact_query.rs
+++ b/src/collision/contact_query.rs
@@ -197,6 +197,13 @@ pub fn contact_manifolds(
 
                 return vec![ContactManifold {
                     normal,
+                    #[cfg(feature = "2d")]
+                    contacts: arrayvec::ArrayVec::from_iter([ContactData::new(
+                        contact.point1.into(),
+                        contact.point2.into(),
+                        -contact.dist,
+                    )]),
+                    #[cfg(feature = "3d")]
                     contacts: vec![ContactData::new(
                         contact.point1.into(),
                         contact.point2.into(),

--- a/src/collision/contact_query.rs
+++ b/src/collision/contact_query.rs
@@ -198,13 +198,13 @@ pub fn contact_manifolds(
                 return vec![ContactManifold {
                     normal,
                     #[cfg(feature = "2d")]
-                    contacts: arrayvec::ArrayVec::from_iter([ContactData::new(
+                    points: arrayvec::ArrayVec::from_iter([ContactPoint::new(
                         contact.point1.into(),
                         contact.point2.into(),
                         -contact.dist,
                     )]),
                     #[cfg(feature = "3d")]
-                    contacts: vec![ContactData::new(
+                    points: vec![ContactPoint::new(
                         contact.point1.into(),
                         contact.point2.into(),
                         -contact.dist,
@@ -236,11 +236,11 @@ pub fn contact_manifolds(
 
             let manifold = ContactManifold {
                 normal,
-                contacts: manifold
+                points: manifold
                     .contacts()
                     .iter()
                     .map(|contact| {
-                        ContactData::new(
+                        ContactPoint::new(
                             subpos1.transform_point(&contact.local_p1).into(),
                             subpos2.transform_point(&contact.local_p2).into(),
                             -contact.dist,

--- a/src/collision/mod.rs
+++ b/src/collision/mod.rs
@@ -265,7 +265,7 @@ pub struct Contacts {
 impl Contacts {
     /// Computes the sum of all impulses applied along contact normals between the contact pair.
     ///
-    /// To get the corresponding force, divide the impulse by `Time::<Substeps>::delta_seconds()`.
+    /// To get the corresponding force, divide the impulse by `Time::<Substeps>::delta_secs()`.
     pub fn total_normal_impulse(&self) -> Vector {
         self.manifolds.iter().fold(Vector::ZERO, |acc, manifold| {
             acc + manifold.normal * manifold.total_normal_impulse()
@@ -276,7 +276,7 @@ impl Contacts {
     ///
     /// This is the sum of impulse magnitudes, *not* the magnitude of the [`total_normal_impulse`](Self::total_normal_impulse).
     ///
-    /// To get the corresponding force, divide the impulse by `Time::<Substeps>::delta_seconds()`.
+    /// To get the corresponding force, divide the impulse by `Time::<Substeps>::delta_secs()`.
     pub fn total_normal_impulse_magnitude(&self) -> Scalar {
         self.manifolds
             .iter()
@@ -287,7 +287,7 @@ impl Contacts {
     /// Finds the largest impulse between the contact pair, and the associated world-space contact normal,
     /// pointing from the first shape to the second.
     ///
-    /// To get the corresponding force, divide the impulse by `Time::<Substeps>::delta_seconds()`.
+    /// To get the corresponding force, divide the impulse by `Time::<Substeps>::delta_secs()`.
     pub fn max_normal_impulse(&self) -> (Scalar, Vector) {
         let mut magnitude: Scalar = 0.0;
         let mut normal = Vector::ZERO;
@@ -301,6 +301,18 @@ impl Contacts {
         }
 
         (magnitude, normal)
+    }
+
+    /// The force corresponding to the total normal impulse applied over `delta_time`.
+    ///
+    /// Because contacts are solved over several substeps, `delta_time` should
+    /// typically use `Time<Substeps>::delta_secs()`.
+    #[deprecated(
+        note = "Use `total_normal_impulse` instead, and divide it by `Time<Substeps>::delta_secs()`",
+        since = "0.3.0"
+    )]
+    pub fn total_normal_force(&self, delta_time: Scalar) -> Scalar {
+        self.total_normal_impulse_magnitude() / delta_time
     }
 
     /// Returns `true` if a collision started during the current frame.
@@ -546,17 +558,17 @@ pub struct ContactPoint {
     pub penetration: Scalar,
     /// The impulse applied to the first body along the contact normal.
     ///
-    /// To get the corresponding force, divide the impulse by `Time<Substeps>::delta_seconds()`.
+    /// To get the corresponding force, divide the impulse by `Time<Substeps>::delta_secs()`.
     pub normal_impulse: Scalar,
     /// The impulse applied to the first body along the contact tangent. This corresponds to the impulse caused by friction.
     ///
-    /// To get the corresponding force, divide the impulse by `Time<Substeps>::delta_seconds()`.
+    /// To get the corresponding force, divide the impulse by `Time<Substeps>::delta_secs()`.
     #[cfg(feature = "2d")]
     #[doc(alias = "friction_impulse")]
     pub tangent_impulse: Scalar,
     /// The impulse applied to the first body along the contact tangent. This corresponds to the impulse caused by friction.
     ///
-    /// To get the corresponding force, divide the impulse by `Time<Substeps>::delta_seconds()`.
+    /// To get the corresponding force, divide the impulse by `Time<Substeps>::delta_secs()`.
     #[cfg(feature = "3d")]
     #[doc(alias = "friction_impulse")]
     pub tangent_impulse: Vector2,
@@ -595,7 +607,7 @@ impl ContactPoint {
     /// The force corresponding to the normal impulse applied over `delta_time`.
     ///
     /// Because contacts are solved over several substeps, `delta_time` should
-    /// typically use `Time<Substeps>::delta_seconds()`.
+    /// typically use `Time<Substeps>::delta_secs()`.
     pub fn normal_force(&self, delta_time: Scalar) -> Scalar {
         self.normal_impulse / delta_time
     }
@@ -603,7 +615,7 @@ impl ContactPoint {
     /// The force corresponding to the tangent impulse applied over `delta_time`.
     ///
     /// Because contacts are solved over several substeps, `delta_time` should
-    /// typically use `Time<Substeps>::delta_seconds()`.
+    /// typically use `Time<Substeps>::delta_secs()`.
     #[cfg(feature = "2d")]
     #[doc(alias = "friction_force")]
     pub fn tangent_force(&self, delta_time: Scalar) -> Scalar {
@@ -613,7 +625,7 @@ impl ContactPoint {
     /// The force corresponding to the tangent impulse applied over `delta_time`.
     ///
     /// Because contacts are solved over several substeps, `delta_time` should
-    /// typically use `Time<Substeps>::delta_seconds()`.
+    /// typically use `Time<Substeps>::delta_secs()`.
     #[cfg(feature = "3d")]
     #[doc(alias = "friction_force")]
     pub fn tangent_force(&self, delta_time: Scalar) -> Vector2 {

--- a/src/collision/mod.rs
+++ b/src/collision/mod.rs
@@ -340,7 +340,11 @@ impl Contacts {
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct ContactManifold {
-    /// The contacts in this manifold.
+    /// The contact points in this manifold.
+    #[cfg(feature = "2d")]
+    pub contacts: arrayvec::ArrayVec<ContactData, 2>,
+    /// The contact points in this manifold.
+    #[cfg(feature = "3d")]
     pub contacts: Vec<ContactData>,
     /// The unit contact normal in world space, pointing from the first entity to the second.
     ///

--- a/src/collision/narrow_phase.rs
+++ b/src/collision/narrow_phase.rs
@@ -645,8 +645,6 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                 || collider2.is_sensor
                 || !collider1.is_rb
                 || !collider2.is_rb,
-            total_normal_impulse: 0.0,
-            total_tangent_impulse: default(),
         };
 
         let active_hooks = collider1.active_hooks().union(collider2.active_hooks());
@@ -672,12 +670,6 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                 for manifold in contacts.manifolds.iter_mut() {
                     for previous_manifold in previous_contacts.manifolds.iter() {
                         manifold.match_contacts(&previous_manifold.points, distance_threshold);
-
-                        // Add contact impulses to total impulses.
-                        for contact in manifold.points.iter() {
-                            contacts.total_normal_impulse += contact.normal_impulse;
-                            contacts.total_tangent_impulse += contact.tangent_impulse;
-                        }
                     }
                 }
             }
@@ -776,9 +768,6 @@ pub fn reset_collision_states(
     query: Query<(Option<&RigidBody>, Has<Sleeping>)>,
 ) {
     for contacts in collisions.get_internal_mut().values_mut() {
-        contacts.total_normal_impulse = 0.0;
-        contacts.total_tangent_impulse = default();
-
         if let Ok([(rb1, sleeping1), (rb2, sleeping2)]) = query.get_many([
             contacts.body_entity1.unwrap_or(contacts.entity1),
             contacts.body_entity2.unwrap_or(contacts.entity2),

--- a/src/collision/narrow_phase.rs
+++ b/src/collision/narrow_phase.rs
@@ -671,10 +671,10 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
 
                 for manifold in contacts.manifolds.iter_mut() {
                     for previous_manifold in previous_contacts.manifolds.iter() {
-                        manifold.match_contacts(&previous_manifold.contacts, distance_threshold);
+                        manifold.match_contacts(&previous_manifold.points, distance_threshold);
 
                         // Add contact impulses to total impulses.
-                        for contact in manifold.contacts.iter() {
+                        for contact in manifold.points.iter() {
                             contacts.total_normal_impulse += contact.normal_impulse;
                             contacts.total_tangent_impulse += contact.tangent_impulse;
                         }

--- a/src/debug_render/mod.rs
+++ b/src/debug_render/mod.rs
@@ -349,7 +349,7 @@ fn debug_render_contacts(
                         * match config.contact_normal_scale {
                             ContactGizmoScale::Constant(length) => length,
                             ContactGizmoScale::Scaled(scale) => {
-                                scale * contacts.total_normal_impulse
+                                scale * contact.normal_impulse
                                     / time.delta_secs_f64().adjust_precision()
                             }
                         };

--- a/src/debug_render/mod.rs
+++ b/src/debug_render/mod.rs
@@ -319,8 +319,6 @@ fn debug_render_contacts(
             for contact in manifold.contacts.iter() {
                 let p1 = contact.global_point1(position1, rotation1);
                 let p2 = contact.global_point2(position2, rotation2);
-                let normal1 = contact.global_normal1(rotation1);
-                let normal2 = contact.global_normal2(rotation2);
 
                 // Don't render contacts that aren't penetrating
                 if contact.penetration <= Scalar::EPSILON {
@@ -356,8 +354,18 @@ fn debug_render_contacts(
                             }
                         };
 
-                    gizmos.draw_arrow(p1, p1 + normal1 * length, 0.1 * length_unit.0, color);
-                    gizmos.draw_arrow(p2, p2 + normal2 * length, 0.1 * length_unit.0, color_dim);
+                    gizmos.draw_arrow(
+                        p1,
+                        p1 + manifold.normal * length,
+                        0.1 * length_unit.0,
+                        color,
+                    );
+                    gizmos.draw_arrow(
+                        p2,
+                        p2 - manifold.normal * length,
+                        0.1 * length_unit.0,
+                        color_dim,
+                    );
                 }
             }
         }

--- a/src/debug_render/mod.rs
+++ b/src/debug_render/mod.rs
@@ -316,7 +316,7 @@ fn debug_render_contacts(
         };
 
         for manifold in contacts.manifolds.iter() {
-            for contact in manifold.contacts.iter() {
+            for contact in manifold.points.iter() {
                 let p1 = contact.global_point1(position1, rotation1);
                 let p2 = contact.global_point2(position2, rotation2);
 

--- a/src/dynamics/solver/contact/mod.rs
+++ b/src/dynamics/solver/contact/mod.rs
@@ -126,10 +126,12 @@ impl ContactConstraint {
         for mut contact in manifold.points.iter().copied() {
             // Transform contact points from collider-space to body-space.
             if let Some(transform) = collider_transform1 {
-                contact.local_point1 = transform.rotation * contact.local_point1 + transform.translation;
+                contact.local_point1 =
+                    transform.rotation * contact.local_point1 + transform.translation;
             }
             if let Some(transform) = collider_transform2 {
-                contact.local_point2 = transform.rotation * contact.local_point2 + transform.translation;
+                contact.local_point2 =
+                    transform.rotation * contact.local_point2 + transform.translation;
             }
 
             contact.penetration += collision_margin;

--- a/src/dynamics/solver/contact/mod.rs
+++ b/src/dynamics/solver/contact/mod.rs
@@ -116,14 +116,14 @@ impl ContactConstraint {
             friction,
             restitution,
             normal: manifold.normal,
-            points: Vec::with_capacity(manifold.contacts.len()),
+            points: Vec::with_capacity(manifold.points.len()),
             manifold_index: manifold_id,
         };
 
         let tangents =
             constraint.tangent_directions(body1.linear_velocity.0, body2.linear_velocity.0);
 
-        for mut contact in manifold.contacts.iter().copied() {
+        for mut contact in manifold.points.iter().copied() {
             // Transform contact points from collider-space to body-space.
             if let Some(transform) = collider_transform1 {
                 contact.point1 = transform.rotation * contact.point1 + transform.translation;

--- a/src/dynamics/solver/contact/mod.rs
+++ b/src/dynamics/solver/contact/mod.rs
@@ -102,15 +102,6 @@ impl ContactConstraint {
         let collision_margin: Scalar = collision_margin.into().0;
         let speculative_margin: Scalar = speculative_margin.into().0;
 
-        // Local-space outward contact normal on the first body.
-        // The normal is transformed from collider-space to body-space.
-        let local_normal1 = collider_transform1.map_or(manifold.normal1, |transform| {
-            transform.rotation * manifold.normal1
-        });
-
-        // The world-space normal used for the contact solve.
-        let normal = *body1.rotation * local_normal1;
-
         // TODO: Cache these?
         // TODO: How should we properly take the locked axes into account for the mass here?
         let inverse_mass_sum = body1.mass().inverse() + body2.mass().inverse();
@@ -124,7 +115,7 @@ impl ContactConstraint {
             collider_entity2,
             friction,
             restitution,
-            normal,
+            normal: manifold.normal,
             points: Vec::with_capacity(manifold.contacts.len()),
             manifold_index: manifold_id,
         };
@@ -158,8 +149,9 @@ impl ContactConstraint {
 
             // Keep the contact if (1) the separation distance is below the required threshold,
             // or if (2) the bodies are expected to come into contact within the next frame.
+            let normal_speed = relative_velocity.dot(constraint.normal);
             let keep_contact = effective_distance < speculative_margin || {
-                let delta_distance = relative_velocity.dot(normal) * delta_secs;
+                let delta_distance = normal_speed * delta_secs;
                 effective_distance + delta_distance < speculative_margin
             };
 
@@ -175,7 +167,7 @@ impl ContactConstraint {
                     i2,
                     r1,
                     r2,
-                    normal,
+                    constraint.normal,
                     warm_start.then_some(contact.normal_impulse),
                     softness,
                 ),
@@ -196,8 +188,8 @@ impl ContactConstraint {
                 local_anchor2,
                 anchor1: r1,
                 anchor2: r2,
-                normal_speed: normal.dot(relative_velocity),
-                initial_separation: -contact.penetration - (r2 - r1).dot(normal),
+                normal_speed,
+                initial_separation: -contact.penetration - (r2 - r1).dot(constraint.normal),
             };
 
             constraint.points.push(point);

--- a/src/dynamics/solver/contact/mod.rs
+++ b/src/dynamics/solver/contact/mod.rs
@@ -126,18 +126,18 @@ impl ContactConstraint {
         for mut contact in manifold.points.iter().copied() {
             // Transform contact points from collider-space to body-space.
             if let Some(transform) = collider_transform1 {
-                contact.point1 = transform.rotation * contact.point1 + transform.translation;
+                contact.local_point1 = transform.rotation * contact.local_point1 + transform.translation;
             }
             if let Some(transform) = collider_transform2 {
-                contact.point2 = transform.rotation * contact.point2 + transform.translation;
+                contact.local_point2 = transform.rotation * contact.local_point2 + transform.translation;
             }
 
             contact.penetration += collision_margin;
 
             let effective_distance = -contact.penetration;
 
-            let local_anchor1 = contact.point1 - body1.center_of_mass.0;
-            let local_anchor2 = contact.point2 - body2.center_of_mass.0;
+            let local_anchor1 = contact.local_point1 - body1.center_of_mass.0;
+            let local_anchor2 = contact.local_point2 - body2.center_of_mass.0;
 
             // Store fixed world-space anchors.
             // This improves rolling behavior for shapes like balls and capsules.

--- a/src/dynamics/solver/mod.rs
+++ b/src/dynamics/solver/mod.rs
@@ -508,8 +508,7 @@ fn store_contact_impulses(
 
         let manifold = &mut contacts.manifolds[constraint.manifold_index];
 
-        for (contact, constraint_point) in
-            manifold.contacts.iter_mut().zip(constraint.points.iter())
+        for (contact, constraint_point) in manifold.points.iter_mut().zip(constraint.points.iter())
         {
             contact.normal_impulse = constraint_point.normal_part.impulse;
             contact.tangent_impulse = constraint_point

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -490,6 +490,14 @@ pub mod schedule;
 pub mod spatial_query;
 pub mod sync;
 
+// TODO: Make this a proper module once we have more data structures, like an `UnGraph`.
+#[cfg(feature = "2d")]
+pub mod data_structures {
+    //! Special data structures used in Avian.
+
+    pub use arrayvec::ArrayVec;
+}
+
 mod type_registration;
 pub use type_registration::PhysicsTypeRegistrationPlugin;
 

--- a/src/tests/determinism_2d.rs
+++ b/src/tests/determinism_2d.rs
@@ -62,7 +62,7 @@ fn cross_platform_determinism_2d() {
     let hash = compute_hash(app.world(), query);
 
     // Update this value if simulation behavior changes.
-    let expected = 0x5b90b194;
+    let expected = 0xb9354ab8;
 
     assert!(
         hash == expected,


### PR DESCRIPTION
# Objective

A lot of Avian's current contact types store some redundant data, aren't properly optimized, and aren't explicit enough about what they represent.

This PR is a clean-up pass to make the types a bit smaller and clearer.

## Solution

### `Contacts`

- Replace `total_normal_impulse` property with `total_normal_impulse`, `total_normal_impulse_magnitude`, and `max_normal_impulse` helpers
- Deprecate `total_normal_force` helper
  - You can just divide by the substep timestep
- Remove `total_tangent_impulse` property and `total_friction_force` helper
  - These could previously technically be wrong/misleading, since each contact point can have a different tangent direction, especially in 3D, and they can also change between substeps. The tangent impulse magnitudes of each individual point can still be accessed.

### `ContactManifold`

- Rename `ContactManifold::contacts` to `ContactManifold::points`
- Use an `ArrayVec` with a capacity of 2 instead of a `Vec` to store 2D `ContactManifold` points directly on the stack
- Replace the local `normal1` and `normal2` with a single world-space `normal`
  - Internals only need the world-space normal, and it makes e.g. contact modification more straightforward
- Add `total_normal_impulse` and `max_normal_impulse` helpers

### `ContactData`

- Rename `ContactData` to `ContactPoint` (represents a point in a contact manifold)
  - Another option would be `ManifoldPoint` like in Box2D; not sure which one is better
- Rename `point1` and `point2` to `local_point1` and `local_point2` for explicitness
- Remove `normal1` and `normal2` from `ContactPoint`, since the normal is already stored in the `ContactManifold`

### Other

- Many documentation improvements
- Contact force debug rendering uses per-point forces instead of the total force for the contact pair

---

## Migration Guide

There have been several changes to Avian's contact types to make them more optimized and clearer.

### `Contacts`

- The `total_normal_impulse` property has been replaced with a `total_normal_impulse` helper method.
- The `total_normal_force` helper has been deprecated. Instead, just divide the impulse by the substep timestep.
- The `total_tangent_impulse` property and `total_friction_force` helper have been removed for being inaccurate/misleading. The tangent impulse magnitudes of each individual point can still be accessed.

### `ContactManifold`

- `ContactManifold::contacts` has been renamed to `ContactManifold::points`.
- The local `normal1` and `normal2` have been replaced with a single world-space `normal`, pointing from the first shape to the second.

### `ContactData`

- `ContactData` has been renamed to `ContactPoint`, since it specifically represents a point in a contact manifold, not general contact data.
- `point1` and `point2` have been renamed to `local_point1` and `local_point2` for explicitness
- `normal1` and `normal2` have been removed, since the normal is already stored in the `ContactManifold`.