### PR TITLE
Simplify `transform_to_position` and fix rotation denormalization

### DIFF
--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -206,15 +206,6 @@ pub(crate) fn init_previous_global_transform(
     }
 }
 
-/*
-
-- Each body has a sleep timer
-- Each island has a `is_sleeping` property
-- For awake islands: If all entities can sleep, set `is_sleeping` to `true`
-- For sleeping islands: If any entity is woken up, wake up the whole island
-
-*/
-
 /// Copies `GlobalTransform` changes to [`Position`] and [`Rotation`].
 /// This allows users to use transforms for moving and positioning bodies and colliders.
 ///

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -3,7 +3,7 @@
 //!
 //! See [`SyncPlugin`].
 
-use crate::{prelude::*, prepare::PrepareSet, utils::get_pos_translation};
+use crate::{prelude::*, prepare::PrepareSet};
 use ancestor_marker::{AncestorMarker, AncestorMarkerPlugin};
 use bevy::{
     ecs::{intern::Interned, schedule::ScheduleLabel},
@@ -206,6 +206,15 @@ pub(crate) fn init_previous_global_transform(
     }
 }
 
+/*
+
+- Each body has a sleep timer
+- Each island has a `is_sleeping` property
+- For awake islands: If all entities can sleep, set `is_sleeping` to `true`
+- For sleeping islands: If any entity is woken up, wake up the whole island
+
+*/
+
 /// Copies `GlobalTransform` changes to [`Position`] and [`Rotation`].
 /// This allows users to use transforms for moving and positioning bodies and colliders.
 ///
@@ -216,66 +225,33 @@ pub fn transform_to_position(
         &GlobalTransform,
         &PreviousGlobalTransform,
         &mut Position,
-        Option<&AccumulatedTranslation>,
         &mut Rotation,
-        Option<&PreviousRotation>,
-        Option<&ComputedCenterOfMass>,
     )>,
 ) {
-    for (
-        global_transform,
-        previous_transform,
-        mut position,
-        accumulated_translation,
-        mut rotation,
-        previous_rotation,
-        center_of_mass,
-    ) in &mut query
-    {
+    for (global_transform, previous_transform, mut position, mut rotation) in &mut query {
         // Skip entity if the global transform value hasn't changed
         if *global_transform == previous_transform.0 {
             continue;
         }
 
-        let transform = global_transform.compute_transform();
-        let previous_transform = previous_transform.compute_transform();
-        let pos = position.0
-            + accumulated_translation.map_or(Vector::ZERO, |t| {
-                get_pos_translation(
-                    t,
-                    &previous_rotation.copied().unwrap_or_default(),
-                    &rotation,
-                    &center_of_mass.copied().unwrap_or_default(),
-                )
-            });
+        let global_transform = global_transform.compute_transform();
 
         #[cfg(feature = "2d")]
         {
-            position.0 = (previous_transform.translation.truncate()
-                + (transform.translation - previous_transform.translation).truncate())
-            .adjust_precision()
-                + (pos - previous_transform.translation.truncate().adjust_precision());
+            position.0 = global_transform.translation.truncate().adjust_precision();
         }
         #[cfg(feature = "3d")]
         {
-            position.0 = (previous_transform.translation
-                + (transform.translation - previous_transform.translation))
-                .adjust_precision()
-                + (pos - previous_transform.translation.adjust_precision());
+            position.0 = global_transform.translation.adjust_precision();
         }
 
         #[cfg(feature = "2d")]
         {
-            let rot = Rotation::from(transform.rotation.adjust_precision());
-            let prev_rot = Rotation::from(previous_transform.rotation.adjust_precision());
-            *rotation = prev_rot * (prev_rot.inverse() * rot) * (prev_rot.inverse() * *rotation);
+            *rotation = Rotation::from(global_transform.rotation.adjust_precision());
         }
         #[cfg(feature = "3d")]
         {
-            rotation.0 = (previous_transform.rotation
-                * (previous_transform.rotation.inverse() * transform.rotation)
-                * (previous_transform.rotation.inverse() * rotation.f32()))
-            .adjust_precision();
+            rotation.0 = global_transform.rotation.adjust_precision();
         }
     }
 }


### PR DESCRIPTION
# Objective

Fixes #573 (hopefully)
Fixes #618

The `transform_to_position` system is currently doing some rather complicated computations that appear to be prone to causing error and rotation denormalization.

It is somewhat difficult to understand what exactly the system is even doing (it has been a long time since I wrote it), but it essentially seems to apply the change between `PreviousGlobalTransform` and `GlobalTransform`, with several seemingly unnecessary extra steps, instead of simply setting `Position` and `Rotation` to match `GlobalTransform`.

## Solution

Significantly simplify `transform_to_position`, and simply set `Position` and `Rotation` to match `GlobalTransform`.

In my testing, this fixes the denormalization issue in #618, and I suspect that it may have also helped with #573. Confirmation from @coreh or someone else struggling with the runtime panic would be appreciated!

### Additional Information

I'm not entirely sure why I originally wrote this the way I did. [This commit](https://github.com/Jondolf/avian/pull/96/commits/c16a9de598c4330c2743b8af01a550b637c99a59) implies that it was done to fix some problem with change detection (maybe for sleeping?) but the version in this PR seems to work perfectly fine based on my brief testing.

I haven't noticed this breaking anything else, and I don't see why it would have, but if someone does notice regressions, please let me know!