### PR TITLE
Fix test after 0.15.1 breakage

### DIFF
--- a/src/tests/determinism_2d.rs
+++ b/src/tests/determinism_2d.rs
@@ -41,6 +41,10 @@ fn cross_platform_determinism_2d() {
             .with_length_unit(0.5)
             .build()
             .disable::<ColliderHierarchyPlugin>(),
+        #[cfg(feature = "bevy_scene")]
+        AssetPlugin::default(),
+        #[cfg(feature = "bevy_scene")]
+        bevy::scene::ScenePlugin::default(),
     ))
     .insert_resource(TimeUpdateStrategy::ManualDuration(Duration::from_secs_f32(
         1.0 / 64.0,


### PR DESCRIPTION
# Objective

CI is failing because Bevy 0.15.1 had a breaking change that reverted the default behavior for missing system parameters back to panicking (even though patch releases shouldn't have any meaningful breaking changes...) and one of our tests was relying on the behavior in 0.15.0.

## Solution

Add the relevant plugins to fix the panic.