### PR TITLE
Fix `From<Rotation>` implementation for `Rot2`

### DIFF
--- a/src/position.rs
+++ b/src/position.rs
@@ -546,7 +546,7 @@ impl From<Rot2> for Rotation {
 impl From<Rotation> for Rot2 {
     /// Creates a [`Rot2`] from a [`Rotation`].
     fn from(rot: Rotation) -> Self {
-        Self::from_sin_cos(rot.cos as f32, rot.sin as f32)
+        Self::from_sin_cos(rot.sin as f32, rot.cos as f32)
     }
 }
 


### PR DESCRIPTION
# Objective

Fixes #617.

`sin` and `cos` are the wrong way around for our `From<Rotation>` implementation for Bevy's `Rot2`. This is currently used for center of mass updates in 2D, and the wrong order causes the center of mass vector to be perpendicular to what it should be.

## Solution

Fix the order.