### PR TITLE
Fix `SleepingPlugin` not being optional and add `WakeUpBody` command

### DIFF
--- a/crates/avian2d/examples/one_way_platform_2d.rs
+++ b/crates/avian2d/examples/one_way_platform_2d.rs
@@ -174,9 +174,9 @@ fn pass_through_one_way_platform(
         if keyboard_input.pressed(KeyCode::ArrowDown) && keyboard_input.pressed(KeyCode::Space) {
             *pass_through_one_way_platform = PassThroughOneWayPlatform::Always;
 
-            // Wake up body when it's allowed to drop down.
+            // Wake up the body when it's allowed to drop down.
             // Otherwise it won't fall because gravity isn't simulated.
-            commands.entity(entity).remove::<Sleeping>();
+            commands.queue(WakeUpBody(entity));
         } else {
             *pass_through_one_way_platform = PassThroughOneWayPlatform::ByNormal;
         }

--- a/src/collision/collider/backend.rs
+++ b/src/collision/collider/backend.rs
@@ -664,16 +664,18 @@ struct ColliderRemovalSystem(SystemId<In<ColliderParent>>);
 fn collider_removed(
     In(parent): In<ColliderParent>,
     mut commands: Commands,
-    mut mass_prop_query: Query<&mut TimeSleeping>,
+    mut sleep_query: Query<&mut TimeSleeping>,
 ) {
     let parent = parent.get();
 
-    if let Ok(mut time_sleeping) = mass_prop_query.get_mut(parent) {
-        let mut entity_commands = commands.entity(parent);
+    let Some(mut entity_commands) = commands.get_entity(parent) else {
+        return;
+    };
 
-        // Queue the parent entity for mass property recomputation.
-        entity_commands.insert(RecomputeMassProperties);
+    // Queue the parent entity for mass property recomputation.
+    entity_commands.insert(RecomputeMassProperties);
 
+    if let Ok(mut time_sleeping) = sleep_query.get_mut(parent) {
         // Wake up the rigid body since removing the collider could also remove active contacts.
         entity_commands.remove::<Sleeping>();
         time_sleeping.0 = 0.0;

--- a/src/collision/narrow_phase.rs
+++ b/src/collision/narrow_phase.rs
@@ -724,9 +724,9 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
         // When an active body collides with a sleeping body, wake up the sleeping body.
         self.parallel_commands.command_scope(|mut commands| {
             if body1.is_sleeping {
-                commands.entity(body1.entity).remove::<Sleeping>();
+                commands.queue(WakeUpBody(body1.entity));
             } else if body2.is_sleeping {
-                commands.entity(body2.entity).remove::<Sleeping>();
+                commands.queue(WakeUpBody(body2.entity));
             }
         });
 

--- a/src/dynamics/mod.rs
+++ b/src/dynamics/mod.rs
@@ -87,7 +87,7 @@ pub mod prelude {
             },
             *,
         },
-        sleeping::{DeactivationTime, SleepingPlugin, SleepingThreshold},
+        sleeping::{DeactivationTime, SleepingPlugin, SleepingThreshold, WakeUpBody},
         solver::{
             joints::*,
             schedule::{SolverSchedulePlugin, SolverSet, SubstepCount, SubstepSchedule},

--- a/src/dynamics/rigid_body/world_query.rs
+++ b/src/dynamics/rigid_body/world_query.rs
@@ -29,7 +29,7 @@ pub struct RigidBodyQuery {
     pub restitution: Option<&'static Restitution>,
     pub locked_axes: Option<&'static LockedAxes>,
     pub dominance: Option<&'static Dominance>,
-    pub time_sleeping: &'static mut TimeSleeping,
+    pub time_sleeping: Option<&'static mut TimeSleeping>,
     pub is_sleeping: Has<Sleeping>,
     pub is_sensor: Has<Sensor>,
 }

--- a/src/dynamics/solver/xpbd/mod.rs
+++ b/src/dynamics/solver/xpbd/mod.rs
@@ -377,10 +377,13 @@ pub fn solve_constraint<C: XpbdConstraint<ENTITY_COUNT> + Component, const ENTIT
 
             // At least one of the participating bodies is active, so wake up any sleeping bodies
             for body in &mut bodies {
-                body.time_sleeping.0 = 0.0;
+                // Reset the sleep timer
+                if let Some(time_sleeping) = body.time_sleeping.as_mut() {
+                    time_sleeping.0 = 0.0;
+                }
 
                 if body.is_sleeping {
-                    commands.entity(body.entity).remove::<Sleeping>();
+                    commands.queue(WakeUpBody(body.entity));
                 }
             }
 


### PR DESCRIPTION
# Objective

Avian 0.2.0 has a regression from 0.1 where the `TimeSleeping` component is required, but it is only added automatically (as a required component) if the `SleepingPlugin` is enabled. This means that disabling the `SleepingPlugin` breaks physics.

## Solution

Make `TimeSleeping` properly optional for rigid bodies.

I also added a `WakeUpBody` `Command` to clean up some logic and abstract away resetting `TimeSleeping`.