### PR TITLE
Fix use of unmaintaned crate proc-macro-error

### DIFF
--- a/crates/avian_derive/Cargo.toml
+++ b/crates/avian_derive/Cargo.toml
@@ -14,6 +14,6 @@ bench = false
 
 [dependencies]
 proc-macro2 = "1.0.78"
-proc-macro-error = "1.0"
+proc-macro-error2 = "2.0"
 quote = "1.0"
 syn = "2.0"

--- a/crates/avian_derive/src/lib.rs
+++ b/crates/avian_derive/src/lib.rs
@@ -2,7 +2,7 @@
 
 use proc_macro::TokenStream;
 
-use proc_macro_error::{abort, emit_error, proc_macro_error};
+use proc_macro_error2::{abort, emit_error, proc_macro_error};
 use quote::quote;
 use syn::{parse_macro_input, spanned::Spanned, Data, DeriveInput};
 


### PR DESCRIPTION
# Objective

The Avian macro crate uses `proc-macro-error`, which is [unmaintained](https://rustsec.org/advisories/RUSTSEC-2024-0370), this also leads to an outdated version of `syn` in the dependency tree.

## Solution

Replace `proc-macro-error` with `proc-macro-error2`.
