### PR TITLE
Release `avian_derive` 0.2.2

### DIFF
--- a/crates/avian_derive/Cargo.toml
+++ b/crates/avian_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avian_derive"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Joona Aalto <jondolf.dev@gmail.com>"]


### PR DESCRIPTION
# Objective

#627 fixed the use of an unmaintained dependency in `avian_derive`.

This PR bumps the version number of `avian_derive` to 0.2.2.

## Solution

Bump the version number of `avian_derive` to 0.2.2. I have already published this patch release, so projects using Avian should pick it up automatically by running `cargo update`.