### PR TITLE
Make avian3d::dynamics::rigid_body::forces public

### DIFF
--- a/src/dynamics/rigid_body/forces.rs
+++ b/src/dynamics/rigid_body/forces.rs
@@ -1,3 +1,6 @@
+//! Forces, torques, linear impulses, and angular impulses
+//! that can be applied to dynamic rigid bodies.
+
 use crate::prelude::*;
 use bevy::prelude::*;
 use derive_more::From;

--- a/src/dynamics/rigid_body/mod.rs
+++ b/src/dynamics/rigid_body/mod.rs
@@ -1,9 +1,9 @@
 //! Common components and bundles for rigid bodies.
 
+pub mod forces;
 pub mod mass_properties;
 
 // Components
-mod forces;
 mod locked_axes;
 mod physics_material;
 mod world_query;


### PR DESCRIPTION
# Objective

Fixes #626

## Solution

Make avian3d::dynamics::rigid_body::forces public

---

## Changelog

avian3d::dynamics::rigid_body::forces is now public
