### PR TITLE
Use a Taylor approximation for velocity damping

### DIFF
--- a/src/dynamics/integrator/mod.rs
+++ b/src/dynamics/integrator/mod.rs
@@ -193,15 +193,21 @@ fn integrate_velocities(
                 .locked_axes
                 .map_or(LockedAxes::default(), |locked_axes| *locked_axes);
 
-            // Apply damping
+            // Apply damping.
+            //
+            // This is using the first-order Taylor approximation of the exponential decay function.
+            // It is used over the Padé approximation to avoid a division.
+            //
+            // The approximation was tested to be very accurate at reasonable time steps.
+            // See https://github.com/Jondolf/avian/pull/633.
             if let Some(lin_damping) = body.lin_damping {
                 if body.lin_vel.0 != Vector::ZERO && lin_damping.0 != 0.0 {
-                    body.lin_vel.0 *= 1.0 / (1.0 + delta_secs * lin_damping.0);
+                    body.lin_vel.0 *= 1.0 - delta_secs * lin_damping.0;
                 }
             }
             if let Some(ang_damping) = body.ang_damping {
                 if body.ang_vel.0 != AngularVelocity::ZERO.0 && ang_damping.0 != 0.0 {
-                    body.ang_vel.0 *= 1.0 / (1.0 + delta_secs * ang_damping.0);
+                    body.ang_vel.0 *= 1.0 - delta_secs * ang_damping.0;
                 }
             }
 


### PR DESCRIPTION
Currently, linear and angular velocity damping are handled with a [Padé approximation](https://en.wikipedia.org/wiki/Pad%C3%A9_approximant) of [exponential decay](https://en.wikipedia.org/wiki/Exponential_decay). This formulation is also used by engines such as Rapier and Box2D. Box2D has a [brief derivation](https://box2d.org/documentation/md_simulation.html#autotoc_md58) for the math.

```rust
// Exponential
body.lin_vel.0 *= (-delta_secs * lin_damping.0).exp();

// Pade approximation
body.lin_vel.0 *= 1.0 / (1.0 + delta_secs * lin_damping.0);
```

This is run at every substep for entities with `LinearDamping` and `AngularDamping`, during velocity integration.

The Padé approximation is used to avoid calling `exp`, which is comparatively expensive and also has non-deterministic precision, meaning that a slower software implementation would likely be required.

An even faster option that avoids a division is the first-order Taylor approximation:

```rust
// First-order Taylor approximation
body.lin_vel.0 *= 1.0 - delta_secs * lin_damping.0;
```

This PR changes velocity damping to use this Taylor approximation.

## Accuracy

In my testing, the Taylor approximation produces results that are still extremely close to the exponential function when running at reasonable time steps. Here I am simulating 1,000 objects with damping coefficients ranging from 1 (top) to 0 (bottom) with an initial linear velocity towards the right.

Blue is the exponential function, red is the Palé approximation, and green is the Taylor approximation. Even with just 1 substep and a time step of 10 Hz, the results it settles at are very close:

![1 substep, 10 Hz](https://github.com/user-attachments/assets/02ca0277-68d0-44e6-a155-3693333dfebd)

With a more reasonable but still conservative setup of 4 substeps and a time step of 50 Hz, they are practically indistinguishable:

![I4 substeps, 50 Hz](https://github.com/user-attachments/assets/19213c55-3430-44a8-bc6c-33911b17ab63)

Based on these results, it seems like the Taylor approximation would provide good enough accuracy while being extremely cheap.

## Aside: Caching

We can observe that the damping formula only requires the damping coefficient and delta time for the damping factor. When using a fixed time step (which is recommended for physics), these values typically remain constant. If we cached this factor, and only updated it when the damping coefficient or time step change, we could reduce damping to a single multiplication:

```rust
body.lin_vel.0 *= lin_damping.cached_factor;
```

This is something that should be benchmarked and tested to see if the caching is worth storing the extra float.