### PR TITLE
Fix collisions not being cleared for immediately despawned entities

### DIFF
--- a/src/collision/narrow_phase.rs
+++ b/src/collision/narrow_phase.rs
@@ -796,6 +796,8 @@ pub fn reset_collision_states(
                 contacts.during_current_frame = true;
             }
         } else {
+            // One of the entities does not exist, so the collision has ended.
+            contacts.during_previous_frame = true;
             contacts.during_current_frame = false;
         }
     }


### PR DESCRIPTION
# Objective

Fixes #533

There is currently a bug where despawning an entity as soon as a collision starts never ends up removing the collision, meaning that `CollisionEnded` is not sent and the despawned entity is not removed from `CollidingEntities`. This is caused by collision states not being updated correctly for despawns.

## Solution

Reset the collision states when an entity is missing such that the collision will be treated as ended.

Note that the way this is handled will change substantially when we implement a contact graph and rework contact management, but regardless, I think it is important to have a fix for it now as it is a serious bug.