### PR TITLE
Remove unnecessary `cfg_attr` from `from_shape` mass helpers

### DIFF
--- a/src/dynamics/rigid_body/mass_properties/components/mod.rs
+++ b/src/dynamics/rigid_body/mass_properties/components/mod.rs
@@ -188,10 +188,6 @@ impl Mass {
         doc = "let mass = Mass::from_shape(&Sphere::new(1.0), 2.0);"
     )]
     /// ```
-    #[cfg(all(
-        feature = "default-collider",
-        any(feature = "parry-f32", feature = "parry-f64")
-    ))]
     #[inline]
     pub fn from_shape<T: ComputeMassProperties>(shape: &T, density: f32) -> Self {
         Self(shape.mass(density))
@@ -344,10 +340,6 @@ impl AngularInertia {
     /// // Bevy's primitive shapes can also be used.
     /// let inertia = AngularInertia::from_shape(&Circle::new(1.0), 2.0);
     /// ```
-    #[cfg(all(
-        feature = "default-collider",
-        any(feature = "parry-f32", feature = "parry-f64")
-    ))]
     #[inline]
     pub fn from_shape<T: ComputeMassProperties>(shape: &T, mass: f32) -> Self {
         Self(shape.angular_inertia(mass))
@@ -682,10 +674,6 @@ impl AngularInertia {
     /// // Bevy's primitive shapes can also be used.
     /// let inertia = AngularInertia::from_shape(&Sphere::new(1.0), 2.0);
     /// ```
-    #[cfg(all(
-        feature = "default-collider",
-        any(feature = "parry-f32", feature = "parry-f64")
-    ))]
     #[inline]
     pub fn from_shape<T: ComputeMassProperties>(shape: &T, mass: f32) -> Self {
         let principal = shape.principal_angular_inertia(mass);
@@ -916,10 +904,6 @@ impl CenterOfMass {
         doc = "let center_of_mass = CenterOfMass::from_shape(&Sphere::new(1.0));"
     )]
     /// ```
-    #[cfg(all(
-        feature = "default-collider",
-        any(feature = "parry-f32", feature = "parry-f64")
-    ))]
     #[inline]
     pub fn from_shape<T: ComputeMassProperties>(shape: &T) -> Self {
         Self(shape.center_of_mass())
@@ -1038,10 +1022,6 @@ impl MassPropertiesBundle {
     /// ));
     /// # }
     /// ```
-    #[cfg(all(
-        feature = "default-collider",
-        any(feature = "parry-f32", feature = "parry-f64")
-    ))]
     #[inline]
     pub fn from_shape<T: ComputeMassProperties>(shape: &T, density: f32) -> Self {
         shape.mass_properties(density).to_bundle()


### PR DESCRIPTION
# Objective

Some mass property helpers like `Mass::from_shape` are currently gated behind the `default-collider` feature and Parry, even though they don't need these features anymore.

## Solution

Remove the feature gates.