### PR TITLE
Fix the default layers used by `ColliderConstructorHierarchy`

### DIFF
--- a/src/collision/collider/constructor.rs
+++ b/src/collision/collider/constructor.rs
@@ -115,7 +115,7 @@ pub struct ColliderConstructorHierarchy {
     pub default_constructor: Option<ColliderConstructor>,
     /// The default [`CollisionLayers`] used for colliders in the hierarchy.
     ///
-    /// [`CollisionLayers::ALL`] by default.
+    /// [`CollisionLayers::default()`] by default, with the first layer and all filters.
     pub default_layers: CollisionLayers,
     /// The default [`ColliderDensity`] used for colliders in the hierarchy.
     ///
@@ -141,7 +141,7 @@ impl ColliderConstructorHierarchy {
     pub fn new(default_constructor: impl Into<Option<ColliderConstructor>>) -> Self {
         Self {
             default_constructor: default_constructor.into(),
-            default_layers: CollisionLayers::ALL,
+            default_layers: CollisionLayers::default(),
             default_density: ColliderDensity(1.0),
             config: default(),
         }


### PR DESCRIPTION
# Objective

#476 changed `CollisionLayers` to use one membership (the first layer) and all filters by default. However, `ColliderConstructorHierarchy` is still using the old default!

## Solution

Use `CollisionLayers::default()` (one membership, all filters) by default for `ColliderConstructorHierarchy`.

---

## Migration Guide

`ColliderConstructorHierarchy` now defaults to one membership (the first layer) and all filters for the `CollisionLayers` of generated colliders. This is consistent with how `CollisionLayers` already works normally.