### PR TITLE
Also clamp angular and linear velocities to max speeds while solving constraints

### DIFF
--- a/src/dynamics/rigid_body/world_query.rs
+++ b/src/dynamics/rigid_body/world_query.rs
@@ -25,6 +25,8 @@ pub struct RigidBodyQuery {
     #[cfg(feature = "3d")]
     pub global_angular_inertia: &'static mut GlobalAngularInertia,
     pub center_of_mass: &'static mut ComputedCenterOfMass,
+    pub max_linear_speed: Option<&'static MaxLinearSpeed>,
+    pub max_angular_speed: Option<&'static MaxAngularSpeed>,
     pub friction: Option<&'static Friction>,
     pub restitution: Option<&'static Restitution>,
     pub locked_axes: Option<&'static LockedAxes>,
@@ -110,6 +112,30 @@ impl RigidBodyQueryItem<'_> {
             i8::MAX
         } else {
             self.dominance.map_or(0, |dominance| dominance.0)
+        }
+    }
+
+    /// Clamps both [LinearVelocity] as well as [AngularVelocity] to the
+    /// limits determined by [MaxLinearSpeed] and [MaxAngularSpeed], if present
+    pub fn clamp_velocities(&mut self) {
+        if let Some(max_linear_speed) = self.max_linear_speed {
+            let linear_speed_squared = self.linear_velocity.0.length_squared();
+            if linear_speed_squared > max_linear_speed.0.powi(2) {
+                self.linear_velocity.0 *= max_linear_speed.0 / linear_speed_squared.sqrt();
+            }
+        }
+        if let Some(max_angular_speed) = self.max_angular_speed {
+            #[cfg(feature = "2d")]
+            if self.ang_vel.abs() > max_angular_speed.0 {
+                self.ang_vel.0 = max_angular_speed.copysign(self.ang_vel.0);
+            }
+            #[cfg(feature = "3d")]
+            {
+                let angular_speed_squared = self.angular_velocity.0.length_squared();
+                if angular_speed_squared > max_angular_speed.0.powi(2) {
+                    self.angular_velocity.0 *= max_angular_speed.0 / angular_speed_squared.sqrt();
+                }
+            }
         }
     }
 }

--- a/src/dynamics/solver/contact/mod.rs
+++ b/src/dynamics/solver/contact/mod.rs
@@ -242,10 +242,12 @@ impl ContactConstraint {
             if body1.rb.is_dynamic() && body1.dominance() <= body2.dominance() {
                 body1.linear_velocity.0 -= p * inv_mass1;
                 body1.angular_velocity.0 -= inv_inertia1 * cross(r1, p);
+                body1.clamp_velocities();
             }
             if body2.rb.is_dynamic() && body2.dominance() <= body1.dominance() {
                 body2.linear_velocity.0 += p * inv_mass2;
                 body2.angular_velocity.0 += inv_inertia2 * cross(r2, p);
+                body2.clamp_velocities();
             }
         }
     }
@@ -305,10 +307,12 @@ impl ContactConstraint {
             if body1.rb.is_dynamic() && body1.dominance() <= body2.dominance() {
                 body1.linear_velocity.0 -= impulse * inv_mass1;
                 body1.angular_velocity.0 -= inv_inertia1 * cross(r1, impulse);
+                body1.clamp_velocities();
             }
             if body2.rb.is_dynamic() && body2.dominance() <= body1.dominance() {
                 body2.linear_velocity.0 += impulse * inv_mass2;
                 body2.angular_velocity.0 += inv_inertia2 * cross(r2, impulse);
+                body2.clamp_velocities();
             }
         }
 
@@ -341,10 +345,12 @@ impl ContactConstraint {
             if body1.rb.is_dynamic() && body1.dominance() <= body2.dominance() {
                 body1.linear_velocity.0 -= impulse * inv_mass1;
                 body1.angular_velocity.0 -= inv_inertia1 * cross(r1, impulse);
+                body1.clamp_velocities();
             }
             if body2.rb.is_dynamic() && body2.dominance() <= body1.dominance() {
                 body2.linear_velocity.0 += impulse * inv_mass2;
                 body2.angular_velocity.0 += inv_inertia2 * cross(r2, impulse);
+                body2.clamp_velocities();
             }
         }
     }
@@ -393,10 +399,12 @@ impl ContactConstraint {
             if body1.rb.is_dynamic() && body1.dominance() <= body2.dominance() {
                 body1.linear_velocity.0 -= impulse * inv_mass1;
                 body1.angular_velocity.0 -= inv_inertia1 * cross(r1, impulse);
+                body1.clamp_velocities();
             }
             if body2.rb.is_dynamic() && body2.dominance() <= body1.dominance() {
                 body2.linear_velocity.0 += impulse * inv_mass2;
                 body2.angular_velocity.0 += inv_inertia2 * cross(r2, impulse);
+                body2.clamp_velocities();
             }
         }
     }


### PR DESCRIPTION
# Objective

Allow `MaxLinearSpeed` and `MaxAngularSpeed` components to be used to prevent the issue described on [this Discord message](https://discord.com/channels/691052431525675048/1124043933886976171/1337193103433535570) that can cause objects to “disappear”. (Actually get corrupted with `NaN`s)

Some details on the issue:

- When many objects interact, particularly when constrained by joints (that update position and rotation instantaneously via impulse) and seemingly depending on the arbitrary solving order, it's possible for angular velocity/linear velocity to be exchanged and transferred between objects in a cascade that can produce really high velocity values (beyond reasonable floating point precision range) that then quickly diverge into non-finite values.
- I haven't been able to fully understand the exact mechanism, but believe `RigidBodyQueryItem::velocity_at_point()` is involved, producing a “lever“-like effect (that somehow doesn't properly conserve momentum, possibly due to the interaction with joint constraints)
- `MaxLinearSpeed` and `MaxAngularSpeed` can't really be used to prevent this, as during `ContactConstraint` solving it is possible for a dynamic rigid body's linear and angular velocity to (temporarily) exceed the limits specified by them, as they are presently only applied during velocity integration.

## Solution

- Added `MaxLinearSpeed` and `MaxAngularSpeed` to `RigidBodyQuery`
- Added `RigidBodyQueryItem::clamp_velocities()` method
- Clamp velocities during `ContactConstraint::warm_start()`, `ContactConstraint::solve()` and `ContactConstraint::apply_restitution()`

---

## Changelog

- Fixed: `MaxLinearSpeed` and `MaxAngularSpeed` now apply continuously during `ContactConstraint` solving, preventing dynamic rigid bodies from (temporarily) exceeding the speed limits during this computation.

## Migration Guide

- If you're using _really low_ values of `MaxLinearSpeed` and `MaxAngularSpeed` (e.g. same order of magnitude as `SolverConfig::max_overlap_solve_speed` or smaller) and encounter collision “tunneling”  issues (i.e. objects clipping through each other) consider bumping them to higher amounts, as these components now also apply during `ContactConstraint` solving and can prevent overlap solving from working properly if set too low.