### PR TITLE
Per-manifold material properties and tangent velocity

### DIFF
--- a/crates/avian2d/examples/custom_collider.rs
+++ b/crates/avian2d/examples/custom_collider.rs
@@ -88,11 +88,8 @@ impl AnyCollider for CircleCollider {
             let point1 = normal1 * self.radius;
             let point2 = normal2 * other.radius;
 
-            vec![ContactManifold {
-                index: 0,
-                normal1,
-                normal2,
-                contacts: vec![ContactData {
+            vec![ContactManifold::new(
+                vec![ContactData {
                     feature_id1: PackedFeatureId::face(0),
                     feature_id2: PackedFeatureId::face(0),
                     point1,
@@ -104,7 +101,10 @@ impl AnyCollider for CircleCollider {
                     normal_impulse: 0.0,
                     tangent_impulse: 0.0,
                 }],
-            }]
+                normal1,
+                normal2,
+                0,
+            )]
         } else {
             vec![]
         }

--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -109,6 +109,14 @@ name = "chain_3d"
 required-features = ["3d", "default-collider"]
 
 [[example]]
+name = "collider_constructors"
+required-features = ["3d", "default-collider", "bevy_scene"]
+
+[[example]]
+name = "conveyor_belt"
+required-features = ["3d", "default-collider"]
+
+[[example]]
 name = "cubes"
 required-features = ["3d", "default-collider"]
 
@@ -142,10 +150,6 @@ required-features = ["3d", "default-collider", "bevy_picking"]
 
 [[example]]
 name = "trimesh_shapes_3d"
-required-features = ["3d", "default-collider", "bevy_scene"]
-
-[[example]]
-name = "collider_constructors"
 required-features = ["3d", "default-collider", "bevy_scene"]
 
 [[example]]

--- a/crates/avian3d/examples/conveyor_belt.rs
+++ b/crates/avian3d/examples/conveyor_belt.rs
@@ -25,8 +25,8 @@ fn main() {
 #[derive(Component)]
 #[require(ActiveCollisionHooks(|| ActiveCollisionHooks::MODIFY_CONTACTS))]
 struct ConveyorBelt {
-    local_direction: Vector,
-    speed: Scalar,
+    local_direction: Vec3,
+    speed: f32,
 }
 
 // Define a custom `SystemParam` for our collision hooks.
@@ -60,7 +60,8 @@ impl CollisionHooks for ConveyorHooks<'_, '_> {
         // Iterate over all contact surfaces between the conveyor belt and the other collider,
         // and apply a relative velocity to simulate the movement of the conveyor belt's surface.
         for manifold in contacts.manifolds.iter_mut() {
-            manifold.tangent_velocity = sign * conveyor_belt.speed * direction;
+            let tangent_velocity = sign * conveyor_belt.speed * direction;
+            manifold.tangent_velocity = tangent_velocity.adjust_precision();
         }
 
         // Return `true` to accept the contact pair.

--- a/crates/avian3d/examples/conveyor_belt.rs
+++ b/crates/avian3d/examples/conveyor_belt.rs
@@ -1,5 +1,6 @@
 //! Demonstrates how to use `CollisionHooks::modify_contacts`
 //! and `tangent_velocity` to simulate conveyor belts.
+
 use avian3d::{math::*, prelude::*};
 use bevy::{
     ecs::system::{lifetimeless::Read, SystemParam},
@@ -53,10 +54,12 @@ impl CollisionHooks for ConveyorHooks<'_, '_> {
             return true;
         };
 
+        // Calculate the conveyor belt's direction in world space.
+        let direction = global_transform.rotation() * conveyor_belt.local_direction;
+
         // Iterate over all contact surfaces between the conveyor belt and the other collider,
         // and apply a relative velocity to simulate the movement of the conveyor belt's surface.
         for manifold in contacts.manifolds.iter_mut() {
-            let direction = global_transform.rotation() * conveyor_belt.local_direction;
             manifold.tangent_velocity = sign * conveyor_belt.speed * direction;
         }
 

--- a/crates/avian3d/examples/conveyor_belt.rs
+++ b/crates/avian3d/examples/conveyor_belt.rs
@@ -20,7 +20,7 @@ fn main() {
         .run();
 }
 
-// Enable contact modification for one-way platforms with the `ActiveCollisionHooks` component.
+// Enable contact modification for conveyor belts with the `ActiveCollisionHooks` component.
 // Here we use required components, but you could also add it manually.
 #[derive(Component)]
 #[require(ActiveCollisionHooks(|| ActiveCollisionHooks::MODIFY_CONTACTS))]

--- a/crates/avian3d/examples/conveyor_belt.rs
+++ b/crates/avian3d/examples/conveyor_belt.rs
@@ -1,0 +1,174 @@
+//! Demonstrates how to use `CollisionHooks::modify_contacts`
+//! and `tangent_velocity` to simulate conveyor belts.
+use avian3d::{math::*, prelude::*};
+use bevy::{
+    ecs::system::{lifetimeless::Read, SystemParam},
+    prelude::*,
+};
+use examples_common_3d::ExampleCommonPlugin;
+
+fn main() {
+    App::new()
+        .add_plugins((
+            DefaultPlugins,
+            ExampleCommonPlugin,
+            // Add our collision hooks to modify contacts for conveyor belts.
+            PhysicsPlugins::default().with_collision_hooks::<ConveyorHooks>(),
+        ))
+        .add_systems(Startup, setup)
+        .run();
+}
+
+// Enable contact modification for one-way platforms with the `ActiveCollisionHooks` component.
+// Here we use required components, but you could also add it manually.
+#[derive(Component)]
+#[require(ActiveCollisionHooks(|| ActiveCollisionHooks::MODIFY_CONTACTS))]
+struct ConveyorBelt {
+    local_direction: Vector,
+    speed: Scalar,
+}
+
+// Define a custom `SystemParam` for our collision hooks.
+// It can have read-only access to queries, resources, and other system parameters.
+#[derive(SystemParam)]
+struct ConveyorHooks<'w, 's> {
+    conveyor_query: Query<'w, 's, (Read<ConveyorBelt>, Read<GlobalTransform>)>,
+}
+
+// Implement the `CollisionHooks` trait for our custom system parameter.
+impl CollisionHooks for ConveyorHooks<'_, '_> {
+    fn modify_contacts(&self, contacts: &mut Contacts, _commands: &mut Commands) -> bool {
+        // Get the conveyor belt and its global transform.
+        // We don't know which entity is the conveyor belt, if any, so we need to check both.
+        // This also affects the sign used for the conveyor belt's speed to apply it in the correct direction.
+        let (Ok((conveyor_belt, global_transform)), sign) = self
+            .conveyor_query
+            .get(contacts.entity1)
+            .map_or((self.conveyor_query.get(contacts.entity2), 1.0), |q| {
+                (Ok(q), -1.0)
+            })
+        else {
+            // If neither entity is a conveyor belt, return `true` early
+            // to accept the contact pair without any modifications.
+            return true;
+        };
+
+        // Iterate over all contact surfaces between the conveyor belt and the other collider,
+        // and apply a relative velocity to simulate the movement of the conveyor belt's surface.
+        for manifold in contacts.manifolds.iter_mut() {
+            let direction = global_transform.rotation() * conveyor_belt.local_direction;
+            manifold.tangent_velocity = sign * conveyor_belt.speed * direction;
+        }
+
+        // Return `true` to accept the contact pair.
+        true
+    }
+}
+
+fn setup(
+    mut commands: Commands,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+    mut meshes: ResMut<Assets<Mesh>>,
+) {
+    let long_conveyor = Cuboid::new(18.0, 0.1, 6.0);
+    let short_conveyor = Cuboid::new(14.0, 0.1, 6.0);
+
+    let long_conveyor_mesh = meshes.add(long_conveyor);
+    let short_conveyor_mesh = meshes.add(short_conveyor);
+
+    let long_conveyor_material = materials.add(Color::srgb(0.3, 0.3, 0.3));
+    let short_conveyor_material = materials.add(Color::srgb(0.2, 0.2, 0.2));
+
+    // Spawn four conveyor belts.
+    commands.spawn((
+        RigidBody::Static,
+        Collider::from(long_conveyor),
+        Friction::new(1.0),
+        ConveyorBelt {
+            local_direction: Vec3::X,
+            speed: 6.0,
+        },
+        Transform::from_xyz(-3.0, -0.25, 7.0)
+            .with_rotation(Quat::from_rotation_z(2_f32.to_radians())),
+        Mesh3d(long_conveyor_mesh.clone()),
+        MeshMaterial3d(long_conveyor_material.clone()),
+    ));
+    commands.spawn((
+        RigidBody::Static,
+        Collider::from(long_conveyor),
+        Friction::new(1.0),
+        ConveyorBelt {
+            local_direction: Vec3::NEG_X,
+            speed: 6.0,
+        },
+        Transform::from_xyz(3.0, -0.25, -7.0)
+            .with_rotation(Quat::from_rotation_z(-2_f32.to_radians())),
+        Mesh3d(long_conveyor_mesh),
+        MeshMaterial3d(long_conveyor_material.clone()),
+    ));
+    commands.spawn((
+        RigidBody::Static,
+        Collider::from(short_conveyor),
+        Friction::new(1.0),
+        ConveyorBelt {
+            local_direction: Vec3::X,
+            speed: 3.0,
+        },
+        Transform::from_xyz(9.0, -0.25, 3.0).with_rotation(
+            Quat::from_rotation_y(90_f32.to_radians()) * Quat::from_rotation_z(2_f32.to_radians()),
+        ),
+        Mesh3d(short_conveyor_mesh.clone()),
+        MeshMaterial3d(short_conveyor_material.clone()),
+    ));
+    commands.spawn((
+        RigidBody::Static,
+        Collider::from(short_conveyor),
+        Friction::new(1.0),
+        ConveyorBelt {
+            local_direction: Vec3::NEG_X,
+            speed: 3.0,
+        },
+        Transform::from_xyz(-9.0, -0.25, -3.0).with_rotation(
+            Quat::from_rotation_y(90_f32.to_radians()) * Quat::from_rotation_z(-2_f32.to_radians()),
+        ),
+        Mesh3d(short_conveyor_mesh),
+        MeshMaterial3d(short_conveyor_material),
+    ));
+
+    // Spawn cube stacks on top of one of the conveyor belts.
+    let cuboid_mesh = meshes.add(Cuboid::default());
+    let cuboid_material = materials.add(Color::srgb(0.2, 0.7, 0.9));
+    for x in -2..2 {
+        for y in 0..3 {
+            for z in -2..2 {
+                let position = Vec3::new(x as f32 + 10.0, y as f32 + 1.0, z as f32);
+                commands.spawn((
+                    RigidBody::Dynamic,
+                    // This small margin just helps prevent hitting internal edges
+                    // while sliding from one conveyor to another.
+                    CollisionMargin(0.01),
+                    Collider::cuboid(0.98, 0.98, 0.98),
+                    Transform::from_translation(position),
+                    Mesh3d(cuboid_mesh.clone()),
+                    MeshMaterial3d(cuboid_material.clone()),
+                ));
+            }
+        }
+    }
+
+    // Directional light
+    commands.spawn((
+        DirectionalLight {
+            illuminance: 5000.0,
+            shadows_enabled: true,
+            ..default()
+        },
+        Transform::default().looking_at(Vec3::new(-1.0, -2.5, -1.5), Vec3::Y),
+    ));
+
+    // Camera
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_translation(Vec3::new(20.0, 10.0, 20.0)).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
+}

--- a/src/collision/contact_query.rs
+++ b/src/collision/contact_query.rs
@@ -192,18 +192,18 @@ pub fn contact_manifolds(
                     return vec![];
                 }
 
-                return vec![ContactManifold {
-                    normal1,
-                    normal2,
-                    contacts: vec![ContactData::new(
+                return vec![ContactManifold::new(
+                    vec![ContactData::new(
                         contact.point1.into(),
                         contact.point2.into(),
                         normal1,
                         normal2,
                         -contact.dist,
                     )],
-                    index: 0,
-                }];
+                    normal1,
+                    normal2,
+                    0,
+                )];
             }
         }
     }
@@ -231,10 +231,8 @@ pub fn contact_manifolds(
                 return None;
             }
 
-            let manifold = ContactManifold {
-                normal1,
-                normal2,
-                contacts: manifold
+            let manifold = ContactManifold::new(
+                manifold
                     .contacts()
                     .iter()
                     .map(|contact| {
@@ -248,8 +246,10 @@ pub fn contact_manifolds(
                         .with_feature_ids(contact.fid1.into(), contact.fid2.into())
                     })
                     .collect(),
-                index: manifold_index,
-            };
+                normal1,
+                normal2,
+                manifold_index,
+            );
 
             manifold_index += 1;
 

--- a/src/collision/mod.rs
+++ b/src/collision/mod.rs
@@ -374,7 +374,7 @@ pub struct ContactManifold {
     /// The same normal is shared by all `points` in a manifold,
     pub normal: Vector,
     /// The effective coefficient of dynamic [friction](Friction) used for the contact surface.
-    pub dynamic_friction: Scalar,
+    pub friction: Scalar,
     /// The effective coefficient of [restitution](Restitution) used for the contact surface.
     pub restitution: Scalar,
     /// The desired relative linear speed of the bodies along the surface,
@@ -413,7 +413,7 @@ impl ContactManifold {
             #[cfg(feature = "3d")]
             points: points.into_iter().collect(),
             normal,
-            dynamic_friction: 0.0,
+            friction: 0.0,
             restitution: 0.0,
             #[cfg(feature = "2d")]
             tangent_speed: 0.0,

--- a/src/collision/narrow_phase.rs
+++ b/src/collision/narrow_phase.rs
@@ -653,7 +653,7 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
         // Set the initial surface properties.
         // TODO: This could be done in `contact_manifolds` to avoid the extra iteration.
         manifolds.iter_mut().for_each(|manifold| {
-            manifold.dynamic_friction = friction;
+            manifold.friction = friction;
             manifold.restitution = restitution;
             #[cfg(feature = "2d")]
             {
@@ -783,7 +783,7 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                 collision_margin,
                 // TODO: Shouldn't this be the effective speculative margin?
                 *self.default_speculative_margin,
-                contact_manifold.dynamic_friction,
+                contact_manifold.friction,
                 contact_manifold.restitution,
                 #[cfg(feature = "2d")]
                 contact_manifold.tangent_speed,

--- a/src/collision/narrow_phase.rs
+++ b/src/collision/narrow_phase.rs
@@ -750,8 +750,12 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                 collision_margin,
                 // TODO: Shouldn't this be the effective speculative margin?
                 *self.default_speculative_margin,
-                friction,
-                restitution,
+                friction.dynamic_coefficient,
+                restitution.coefficient,
+                #[cfg(feature = "2d")]
+                contact_manifold.tangent_speed,
+                #[cfg(feature = "3d")]
+                contact_manifold.tangent_velocity,
                 contact_softness,
                 self.config.match_contacts,
                 delta_secs,

--- a/src/collision/narrow_phase.rs
+++ b/src/collision/narrow_phase.rs
@@ -617,17 +617,20 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
 
         // Set the initial surface properties.
         // TODO: This could be done in `contact_manifolds` to avoid the extra iteration.
+        let friction = collider1
+            .friction
+            .unwrap_or(&self.default_friction)
+            .combine(*collider2.friction.unwrap_or(&self.default_friction))
+            .dynamic_coefficient;
+        let restitution = collider1
+            .restitution
+            .unwrap_or(&self.default_restitution)
+            .combine(*collider2.restitution.unwrap_or(&self.default_restitution))
+            .coefficient;
+
         manifolds.iter_mut().for_each(|manifold| {
-            manifold.dynamic_friction = collider1
-                .friction
-                .unwrap_or(&self.default_friction)
-                .combine(*collider2.friction.unwrap_or(&self.default_friction))
-                .dynamic_coefficient;
-            manifold.restitution = collider1
-                .restitution
-                .unwrap_or(&self.default_restitution)
-                .combine(*collider2.restitution.unwrap_or(&self.default_restitution))
-                .coefficient;
+            manifold.dynamic_friction = friction;
+            manifold.restitution = restitution;
             #[cfg(feature = "2d")]
             {
                 manifold.tangent_speed = 0.0;

--- a/src/dynamics/rigid_body/physics_material.rs
+++ b/src/dynamics/rigid_body/physics_material.rs
@@ -36,9 +36,7 @@ impl CoefficientCombine {
     }
 }
 
-/// A resource for the default [`Friction`] to use for physics objects.
-///
-/// Friction can be set for individual colliders and rigid bodies using the [`Friction`] component.
+/// A resource for the default [`Friction`] to use for colliders.
 ///
 /// Defaults to dynamic and static friction coefficients of `0.5` with a combine rule of [`CoefficientCombine::Average`].
 #[derive(Resource, Clone, Copy, Debug, Default, Deref, DerefMut, PartialEq, Reflect)]
@@ -47,9 +45,7 @@ impl CoefficientCombine {
 #[reflect(Debug, Default, PartialEq)]
 pub struct DefaultFriction(pub Friction);
 
-/// A resource for the default [`Restitution`] to use for physics objects.
-///
-/// Restitution can be set for individual colliders and rigid bodies using the [`Restitution`] component.
+/// A resource for the default [`Restitution`] to use for colliders.
 ///
 /// Defaults to a coefficient of `0.0` with a combine rule of [`CoefficientCombine::Average`].
 #[derive(Resource, Clone, Copy, Debug, Default, Deref, DerefMut, PartialEq, Reflect)]
@@ -58,7 +54,7 @@ pub struct DefaultFriction(pub Friction);
 #[reflect(Debug, Default, PartialEq)]
 pub struct DefaultRestitution(pub Restitution);
 
-/// A component for [dry friction], controlling how strongly a [rigid body](RigidBody) or [collider](Collider)
+/// A component for [dry friction], controlling how strongly the surface of a [collider](Collider)
 /// opposes sliding along other surfaces while in contact.
 ///
 /// For surfaces that are at rest relative to each other, **static friction** is used.
@@ -68,9 +64,8 @@ pub struct DefaultRestitution(pub Restitution);
 /// The friction coefficients should typically be between 0 and 1, where 0 corresponds to no friction at all, and 1 corresponds to high friction.
 /// However, any non-negative value is allowed.
 ///
-/// If a collider does not have [`Friction`] specified, the [`Friction`] of its rigid body entity will be used instead.
-/// If that is not specified either, collisions use the [`DefaultFriction`] resource. The default dynamic and static friction
-/// coefficients are set to `0.5`.
+/// If a collider does not have [`Friction`] specified, the [`DefaultFriction`] resource is used instead.
+/// The default dynamic and static friction coefficients are set to `0.5`.
 ///
 /// [dry friction]: https://en.wikipedia.org/wiki/Friction#Dry_friction
 /// [Coulomb friction model]: https://en.wikipedia.org/wiki/Friction#Dry_friction
@@ -224,15 +219,14 @@ impl From<Scalar> for Friction {
     }
 }
 
-/// A component for [restitution], controlling how bouncy a [rigid body](RigidBody) or [collider](Collider) is.
+/// A component for [restitution], controlling how bouncy the surface of a [collider](Collider) is.
 ///
 /// The coefficient should be between 0 and 1, where 0 corresponds to a **perfectly inelastic** collision with zero bounce,
 /// and 1 corresponds to a **perfectly elastic** collision that tries to preserve all kinetic energy.
 /// Values larger than 1 can result in unstable or explosive behavior.
 ///
-/// If a collider does not have [`Restitution`] specified, the [`Restitution`] of its rigid body entity will be used instead.
-/// If that is not specified either, collisions use the [`DefaultRestitution`] resource. The default restitution is set to 0,
-/// meaning that objects are not bouncy by default.
+/// If a collider does not have [`Restitution`] specified, the [`DefaultRestitution`] resource is used instead.
+/// The default restitution is set to 0, meaning that objects are not bouncy by default.
 ///
 /// [restitution]: https://en.wikipedia.org/wiki/Coefficient_of_restitution
 ///

--- a/src/dynamics/rigid_body/physics_material.rs
+++ b/src/dynamics/rigid_body/physics_material.rs
@@ -36,7 +36,9 @@ impl CoefficientCombine {
     }
 }
 
-/// A resource for the default [`Friction`] to use for colliders.
+/// A resource for the default [`Friction`] to use for physics objects.
+///
+/// Friction can be set for individual colliders and rigid bodies using the [`Friction`] component.
 ///
 /// Defaults to dynamic and static friction coefficients of `0.5` with a combine rule of [`CoefficientCombine::Average`].
 #[derive(Resource, Clone, Copy, Debug, Default, Deref, DerefMut, PartialEq, Reflect)]
@@ -45,7 +47,9 @@ impl CoefficientCombine {
 #[reflect(Debug, Default, PartialEq)]
 pub struct DefaultFriction(pub Friction);
 
-/// A resource for the default [`Restitution`] to use for colliders.
+/// A resource for the default [`Restitution`] to use for physics objects.
+///
+/// Restitution can be set for individual colliders and rigid bodies using the [`Restitution`] component.
 ///
 /// Defaults to a coefficient of `0.0` with a combine rule of [`CoefficientCombine::Average`].
 #[derive(Resource, Clone, Copy, Debug, Default, Deref, DerefMut, PartialEq, Reflect)]
@@ -54,7 +58,7 @@ pub struct DefaultFriction(pub Friction);
 #[reflect(Debug, Default, PartialEq)]
 pub struct DefaultRestitution(pub Restitution);
 
-/// A component for [dry friction], controlling how strongly the surface of a [collider](Collider)
+/// A component for [dry friction], controlling how strongly a [rigid body](RigidBody) or [collider](Collider)
 /// opposes sliding along other surfaces while in contact.
 ///
 /// For surfaces that are at rest relative to each other, **static friction** is used.
@@ -64,8 +68,9 @@ pub struct DefaultRestitution(pub Restitution);
 /// The friction coefficients should typically be between 0 and 1, where 0 corresponds to no friction at all, and 1 corresponds to high friction.
 /// However, any non-negative value is allowed.
 ///
-/// If a collider does not have [`Friction`] specified, the [`DefaultFriction`] resource is used instead.
-/// The default dynamic and static friction coefficients are set to `0.5`.
+/// If a collider does not have [`Friction`] specified, the [`Friction`] of its rigid body entity will be used instead.
+/// If that is not specified either, collisions use the [`DefaultFriction`] resource. The default dynamic and static friction
+/// coefficients are set to `0.5`.
 ///
 /// [dry friction]: https://en.wikipedia.org/wiki/Friction#Dry_friction
 /// [Coulomb friction model]: https://en.wikipedia.org/wiki/Friction#Dry_friction
@@ -219,14 +224,15 @@ impl From<Scalar> for Friction {
     }
 }
 
-/// A component for [restitution], controlling how bouncy the surface of a [collider](Collider) is.
+/// A component for [restitution], controlling how bouncy a [rigid body](RigidBody) or [collider](Collider) is.
 ///
 /// The coefficient should be between 0 and 1, where 0 corresponds to a **perfectly inelastic** collision with zero bounce,
 /// and 1 corresponds to a **perfectly elastic** collision that tries to preserve all kinetic energy.
 /// Values larger than 1 can result in unstable or explosive behavior.
 ///
-/// If a collider does not have [`Restitution`] specified, the [`DefaultRestitution`] resource is used instead.
-/// The default restitution is set to 0, meaning that objects are not bouncy by default.
+/// If a collider does not have [`Restitution`] specified, the [`Restitution`] of its rigid body entity will be used instead.
+/// If that is not specified either, collisions use the [`DefaultRestitution`] resource. The default restitution is set to 0,
+/// meaning that objects are not bouncy by default.
 ///
 /// [restitution]: https://en.wikipedia.org/wiki/Coefficient_of_restitution
 ///

--- a/src/dynamics/solver/contact/mod.rs
+++ b/src/dynamics/solver/contact/mod.rs
@@ -68,7 +68,7 @@ pub struct ContactConstraint {
     /// The entity of the first collider in the contact.
     pub collider_entity2: Entity,
     /// The combined coefficient of dynamic [friction](Friction) of the bodies.
-    pub dynamic_friction: Scalar,
+    pub friction: Scalar,
     /// The combined coefficient of [restitution](Restitution) of the bodies.
     pub restitution: Scalar,
     /// The desired relative linear speed of the bodies along the surface,
@@ -107,7 +107,7 @@ impl ContactConstraint {
         collider_transform2: Option<ColliderTransform>,
         collision_margin: impl Into<CollisionMargin>,
         speculative_margin: impl Into<SpeculativeMargin>,
-        dynamic_friction: Scalar,
+        friction: Scalar,
         restitution: Scalar,
         #[cfg(feature = "2d")] tangent_speed: Scalar,
         #[cfg(feature = "3d")] tangent_velocity: Vector,
@@ -129,7 +129,7 @@ impl ContactConstraint {
             entity2: body2.entity,
             collider_entity1,
             collider_entity2,
-            dynamic_friction,
+            friction,
             restitution,
             #[cfg(feature = "2d")]
             tangent_speed,
@@ -194,7 +194,7 @@ impl ContactConstraint {
                     softness,
                 ),
                 // There should only be a friction part if the coefficient of friction is non-negative.
-                tangent_part: (dynamic_friction > 0.0).then_some(ContactTangentPart::generate(
+                tangent_part: (friction > 0.0).then_some(ContactTangentPart::generate(
                     inverse_mass_sum,
                     i1,
                     i2,
@@ -324,7 +324,7 @@ impl ContactConstraint {
             }
         }
 
-        let friction = self.dynamic_friction;
+        let friction = self.friction;
         let tangent_directions =
             self.tangent_directions(body1.linear_velocity.0, body2.linear_velocity.0);
 

--- a/src/dynamics/solver/contact/mod.rs
+++ b/src/dynamics/solver/contact/mod.rs
@@ -67,10 +67,24 @@ pub struct ContactConstraint {
     pub collider_entity1: Entity,
     /// The entity of the first collider in the contact.
     pub collider_entity2: Entity,
-    /// The combined [`Friction`] of the bodies.
-    pub friction: Friction,
-    /// The combined [`Restitution`] of the bodies.
-    pub restitution: Restitution,
+    /// The combined coefficient of dynamic [friction](Friction) of the bodies.
+    pub dynamic_friction: Scalar,
+    /// The combined coefficient of [restitution](Restitution) of the bodies.
+    pub restitution: Scalar,
+    /// The desired relative linear speed of the bodies along the surface,
+    /// expressed in world space as `tangent_speed2 - tangent_speed1`.
+    ///
+    /// Defaults to zero. If set to a non-zero value, this can be used to simulate effects
+    /// such as conveyor belts.
+    #[cfg(feature = "2d")]
+    pub tangent_speed: Scalar,
+    /// The desired relative linear velocity of the bodies along the surface,
+    /// expressed in world space as `tangent_velocity2 - tangent_velocity1`.
+    ///
+    /// Defaults to zero. If set to a non-zero value, this can be used to simulate effects
+    /// such as conveyor belts.
+    #[cfg(feature = "3d")]
+    pub tangent_velocity: Vector,
     /// The world-space contact normal shared by all points in the contact manifold.
     pub normal: Vector,
     /// The contact points in the manifold. Each point shares the same `normal`.
@@ -93,8 +107,10 @@ impl ContactConstraint {
         collider_transform2: Option<ColliderTransform>,
         collision_margin: impl Into<CollisionMargin>,
         speculative_margin: impl Into<SpeculativeMargin>,
-        friction: Friction,
-        restitution: Restitution,
+        dynamic_friction: Scalar,
+        restitution: Scalar,
+        #[cfg(feature = "2d")] tangent_speed: Scalar,
+        #[cfg(feature = "3d")] tangent_velocity: Vector,
         softness: SoftnessCoefficients,
         warm_start: bool,
         delta_secs: Scalar,
@@ -122,8 +138,12 @@ impl ContactConstraint {
             entity2: body2.entity,
             collider_entity1,
             collider_entity2,
-            friction,
+            dynamic_friction,
             restitution,
+            #[cfg(feature = "2d")]
+            tangent_speed,
+            #[cfg(feature = "3d")]
+            tangent_velocity,
             normal,
             points: Vec::with_capacity(manifold.contacts.len()),
             manifold_index: manifold_id,
@@ -180,17 +200,15 @@ impl ContactConstraint {
                     softness,
                 ),
                 // There should only be a friction part if the coefficient of friction is non-negative.
-                tangent_part: (friction.dynamic_coefficient > 0.0).then_some(
-                    ContactTangentPart::generate(
-                        inverse_mass_sum,
-                        i1,
-                        i2,
-                        r1,
-                        r2,
-                        tangents,
-                        warm_start.then_some(contact.tangent_impulse),
-                    ),
-                ),
+                tangent_part: (dynamic_friction > 0.0).then_some(ContactTangentPart::generate(
+                    inverse_mass_sum,
+                    i1,
+                    i2,
+                    r1,
+                    r2,
+                    tangents,
+                    warm_start.then_some(contact.tangent_impulse),
+                )),
                 max_normal_impulse: 0.0,
                 local_anchor1,
                 local_anchor2,
@@ -312,7 +330,7 @@ impl ContactConstraint {
             }
         }
 
-        let friction = self.friction;
+        let friction = self.dynamic_friction;
         let tangent_directions =
             self.tangent_directions(body1.linear_velocity.0, body2.linear_velocity.0);
 
@@ -333,6 +351,10 @@ impl ContactConstraint {
             let impulse = friction_part.solve_impulse(
                 tangent_directions,
                 relative_velocity,
+                #[cfg(feature = "2d")]
+                self.tangent_speed,
+                #[cfg(feature = "3d")]
+                self.tangent_velocity,
                 friction,
                 point.normal_part.impulse,
             );
@@ -379,7 +401,7 @@ impl ContactConstraint {
 
             // Compute the incremental normal impulse to account for restitution.
             let mut impulse = -point.normal_part.effective_mass
-                * (normal_speed + self.restitution.coefficient * point.normal_speed);
+                * (normal_speed + self.restitution * point.normal_speed);
 
             // Clamp the accumulated impulse.
             let new_impulse = (point.normal_part.impulse + impulse).max(0.0);

--- a/src/dynamics/solver/contact/tangent_part.rs
+++ b/src/dynamics/solver/contact/tangent_part.rs
@@ -154,7 +154,7 @@ impl ContactTangentPart {
         // The desired relative velocity along the contact surface, used to simulate things like conveyor belts.
         #[cfg(feature = "2d")] surface_speed: Scalar,
         #[cfg(feature = "3d")] surface_velocity: Vector,
-        dynamic_friction: Scalar,
+        friction: Scalar,
         normal_impulse: Scalar,
     ) -> Vector {
         // Compute the maximum bound for the friction impulse.
@@ -179,8 +179,7 @@ impl ContactTangentPart {
         //
         // -coefficient * length(normal_impulse) <= impulse_magnitude <= coefficient * length(normal_impulse)
 
-        // TODO: Separate static and dynamic friction
-        let impulse_limit = dynamic_friction * normal_impulse;
+        let impulse_limit = friction * normal_impulse;
 
         #[cfg(feature = "2d")]
         {

--- a/src/dynamics/solver/mod.rs
+++ b/src/dynamics/solver/mod.rs
@@ -467,7 +467,7 @@ fn solve_restitution(
     let threshold = solver_config.restitution_threshold * length_unit.0;
 
     for constraint in constraints.iter_mut() {
-        let restitution = constraint.restitution.coefficient;
+        let restitution = constraint.restitution;
 
         if restitution == 0.0 {
             continue;


### PR DESCRIPTION
# Objective

Follow-up to #610.

Now that we have contact modification hooks, we should add support for modifying the surface properties of contacts. This can enable use cases like conveyor belts or non-uniform friction and restitution for different parts of a mesh.

## Solution

Add `friction`, `restitution`, and `tangent_speed`/`tangent_velocity` properties to `ContactManifold`. These are copied over for each `ContactConstraint`.

> [!NOTE]
> **Why not have a hook for modifying `ContactConstraint` directly instead?**
>
> While we could technically do this right now, once we have wide SIMD constraints, `ContactConstraint` will also have its own SIMD version that is not as user-friendly and depends on feature flags. Providing hooks for modifying that is not very viable, and it would not be good for UX. Splitting contact modification into two hooks for different types of contact types could also be confusing for users.

The new *tangent velocity* is a way to emulate relative movement of contact surfaces, which is often used for conveyor belts. A new `conveyor_belt` example has been added to demonstrate this.

https://github.com/user-attachments/assets/3f07b4f1-6ff9-4b00-80db-5500ba43940b

Engines like Rapier, Jolt, and Box2D also have tangent velocity and other material properties, but the capabilities for contact modification are different.

- **Rapier**: Friction, restitution, and tangent velocity can be set for each solver contact point.
- **Jolt**: Friction, restitution, and tangent velocity can be set for each contact manifold.
- **Box2D**: Friction, restitution, and tangent velocity cannot be modified in pre-solve hooks, *but* friction and restitution have their own optional callbacks for basic mixing logic (I believe Jolt also has this), and chain shapes support per-segment materials. So, surface properties can only be set per shape (pair), but it is still decently flexible for 2D.

I opted for Jolt's approach of per-manifold configuration for now. It lets you have different material properties for e.g. different triangles of a trimesh, while keeping memory usage fairly minimal by not storing the properties for each individual contact point. I think this is a good balance of flexibility and cost.

If important use cases that require per-point surface properties arise, we could switch to that, but I'd prefer to keep things more simple and minimal for now.