### PR TITLE
Add direnv flake for nix-based systems

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake . --show-trace

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Cargo.lock
 /.idea
 /.vscode
 /benches/target
+/.direnv

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,32 @@
+{
+  description = "Avian devshell";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { ... }@inputs:
+    inputs.flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import inputs.rust-overlay) ];
+        pkgs = import inputs.nixpkgs { inherit system overlays; };
+      in with pkgs; {
+        devShells.default = mkShell rec {
+          buildInputs = [
+            # Rust
+            rust-bin.nightly.latest.default udev alsa-lib vulkan-loader
+
+            # X11
+            xorg.libX11 xorg.libXcursor xorg.libXi xorg.libXrandr
+
+            # Wayland
+            libxkbcommon wayland
+          ];
+
+          LD_LIBRARY_PATH = "${lib.makeLibraryPath buildInputs}";
+        };
+      }
+    );
+}


### PR DESCRIPTION
# Objective

- Compiling on nix-based systems is a hassle without devshell flakes when relying on direnv since it would have to be removed and readded during every commit. Further creating a working devshell for nix is additional time lost that could be spent instead on improving the project.

## Solution

- Including the direnv flake will alleviate the problem and should hopefully be a non-issue for everyone else.