### PR TITLE
Remove unsafe `ColliderAabb` initialization

### DIFF
--- a/src/collision/collider/backend.rs
+++ b/src/collision/collider/backend.rs
@@ -2,7 +2,7 @@
 //!
 //! See [`ColliderBackendPlugin`].
 
-use core::{any::type_name, marker::PhantomData};
+use core::marker::PhantomData;
 
 use crate::{broad_phase::BroadPhaseSet, prelude::*, prepare::PrepareSet, sync::SyncConfig};
 #[cfg(all(feature = "bevy_scene", feature = "default-collider"))]
@@ -12,7 +12,6 @@ use bevy::{
         intern::Interned,
         schedule::ScheduleLabel,
         system::{StaticSystemParam, SystemId, SystemState},
-        world::WorldEntityFetch,
     },
     prelude::*,
 };
@@ -111,7 +110,7 @@ impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
         let hooks = app.world_mut().register_component_hooks::<C>();
 
         // Initialize missing components for colliders.
-        hooks.on_add(|world, entity, _| {
+        hooks.on_add(|mut world, entity, _| {
             let existing_global_transform = world
                 .entity(entity)
                 .get::<GlobalTransform>()
@@ -147,8 +146,7 @@ impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
             #[cfg(feature = "2d")]
             let scale = scale.xy();
 
-            let cell = world.as_unsafe_world_cell_readonly();
-            let mut entity_mut = unsafe { entity.fetch_deferred_mut(cell).unwrap() };
+            let mut entity_mut = world.entity_mut(entity);
 
             // Make sure the collider is initialized with the correct scale.
             // This overwrites the scale set by the constructor, but that one is
@@ -160,33 +158,6 @@ impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
 
             let collider = entity_mut.get::<C>().unwrap();
 
-            let aabb = {
-                let mut context_state = {
-                    // SAFETY: No other code takes a ref to this resource,
-                    //         and `ContextState` is not publicly visible,
-                    //         so `C::Context` is unable to borrow this resource.
-                    //         This does not perform any structural world changes,
-                    //         so reading mutably through a read-only cell is OK.
-                    //         (We can't get a non-readonly cell from a DeferredWorld)
-                    unsafe { cell.get_resource_mut::<ContextState<C>>() }
-                }
-                .unwrap_or_else(|| {
-                    panic!(
-                        "context state for `{}` was removed",
-                        type_name::<C::Context>()
-                    )
-                });
-                let collider_context = context_state.0.get(&world);
-                let context = AabbContext::new(entity, &collider_context);
-                entity_mut
-                    .get::<ColliderAabb>()
-                    .copied()
-                    .unwrap_or(collider.aabb_with_context(
-                        Vector::ZERO,
-                        Rotation::default(),
-                        context,
-                    ))
-            };
             let density = entity_mut
                 .get::<ColliderDensity>()
                 .copied()
@@ -197,10 +168,6 @@ impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
             } else {
                 collider.mass_properties(density.0)
             };
-
-            if let Some(mut collider_aabb) = entity_mut.get_mut::<ColliderAabb>() {
-                *collider_aabb = aabb;
-            }
 
             if let Some(mut collider_mass_properties) =
                 entity_mut.get_mut::<ColliderMassProperties>()

--- a/src/collision/collider/backend.rs
+++ b/src/collision/collider/backend.rs
@@ -11,7 +11,7 @@ use bevy::{
     ecs::{
         intern::Interned,
         schedule::ScheduleLabel,
-        system::{StaticSystemParam, SystemId, SystemState},
+        system::{StaticSystemParam, SystemId},
     },
     prelude::*,
 };
@@ -87,9 +87,6 @@ impl<C: ScalableCollider> Default for ColliderBackendPlugin<C> {
     }
 }
 
-#[derive(Resource)]
-struct ContextState<C: ScalableCollider>(SystemState<C::Context>);
-
 impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
     fn build(&self, app: &mut App) {
         // Register required components for the collider type.
@@ -103,9 +100,6 @@ impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
             let collider_removed_id = app.world_mut().register_system(collider_removed);
             app.insert_resource(ColliderRemovalSystem(collider_removed_id));
         }
-
-        let context_state = SystemState::new(app.world_mut());
-        app.insert_resource(ContextState::<C>(context_state));
 
         let hooks = app.world_mut().register_component_hooks::<C>();
 

--- a/src/collision/collider/mod.rs
+++ b/src/collision/collider/mod.rs
@@ -529,9 +529,9 @@ impl From<Transform> for ColliderTransform {
 #[reflect(Debug, Component, Default, PartialEq)]
 pub struct Sensor;
 
-/// The Axis-Aligned Bounding Box of a [collider](Collider).
+/// The Axis-Aligned Bounding Box of a [collider](Collider) in world space.
 ///
-/// The coordinates are in world space (global coordinates).
+/// Note that the AABB will be [`ColliderAabb::INVALID`] until the first physics update.
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
@@ -543,7 +543,19 @@ pub struct ColliderAabb {
     pub max: Vector,
 }
 
+impl Default for ColliderAabb {
+    fn default() -> Self {
+        ColliderAabb::INVALID
+    }
+}
+
 impl ColliderAabb {
+    /// An invalid [`ColliderAabb`] that represents an empty AABB.
+    pub const INVALID: Self = Self {
+        min: Vector::INFINITY,
+        max: Vector::NEG_INFINITY,
+    };
+
     /// Creates a new [`ColliderAabb`] from the given `center` and `half_size`.
     pub fn new(center: Vector, half_size: Vector) -> Self {
         Self {
@@ -630,15 +642,6 @@ impl ColliderAabb {
         let y_overlaps = self.min.y <= other.max.y && self.max.y >= other.min.y;
         let z_overlaps = self.min.z <= other.max.z && self.max.z >= other.min.z;
         x_overlaps && y_overlaps && z_overlaps
-    }
-}
-
-impl Default for ColliderAabb {
-    fn default() -> Self {
-        ColliderAabb {
-            min: Vector::INFINITY,
-            max: Vector::NEG_INFINITY,
-        }
     }
 }
 


### PR DESCRIPTION
# Objective

#527 used a read-only `UnsafeWorldCell` for the initialization of `ColliderAabb` in an `on_add` hook for `Collider`. However, it uses methods that provide mutable access, which is unsafe and panics with debug assertions.

## Solution

Remove the whole AABB initialization logic and use of `unsafe`. Having it didn't make sense since the initial positions are likely wrong anyway.

`ColliderAabb` is now explicitly specified to be `ColliderAabb::INVALID` until the first physics update.