### PR TITLE
Update to Bevy 0.16.0-rc.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,3 @@ resolver = "2"
 
 [profile.dev]
 opt-level = 1 # Use slightly better optimization, so examples work
-
-[patch.crates-io]
-bevy = { path = "../bevy" }
-bevy_math = { path = "../bevy/crates/bevy_math" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,7 @@ resolver = "2"
 
 [profile.dev]
 opt-level = 1 # Use slightly better optimization, so examples work
+
+[patch.crates-io]
+bevy = { path = "../bevy" }
+bevy_math = { path = "../bevy/crates/bevy_math" }

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ cargo run --example cubes --no-default-features --features "3d f64 parry-f64"
 
 | Bevy    | Avian |
 | ------- | ----- |
+| 0.16 RC | main  |
 | 0.15    | 0.2   |
 | 0.14    | 0.1   |
 

--- a/crates/avian2d/Cargo.toml
+++ b/crates/avian2d/Cargo.toml
@@ -98,6 +98,7 @@ glam = { version = "0.29", features = ["bytemuck"] }
 approx = "0.5"
 bytemuck = "1.19"
 criterion = { version = "0.5", features = ["html_reports"] }
+# TODO: Update to the latest version when it's available.
 # bevy_mod_debugdump = { version = "0.12" }
 
 [package.metadata.docs.rs]

--- a/crates/avian2d/Cargo.toml
+++ b/crates/avian2d/Cargo.toml
@@ -62,10 +62,10 @@ bench = false
 
 [dependencies]
 avian_derive = { path = "../avian_derive", version = "0.2" }
-bevy = { version = "0.15", default-features = false }
-bevy_math = { version = "0.15" }
-bevy_heavy = { version = "0.1" }
-bevy_transform_interpolation = { version = "0.1" }
+bevy = { version = "0.16.0-dev", default-features = false }
+bevy_math = { version = "0.16.0-dev" }
+bevy_heavy = { path = "../../../bevy_heavy" }
+bevy_transform_interpolation = { path = "../../../bevy_transform_interpolation" }
 libm = { version = "0.2", optional = true }
 parry2d = { version = "0.17", optional = true }
 parry2d-f64 = { version = "0.17", optional = true }
@@ -80,13 +80,13 @@ bitflags = "2.5.0"
 [dev-dependencies]
 examples_common_2d = { path = "../examples_common_2d" }
 benches_common_2d = { path = "../benches_common_2d" }
-bevy_math = { version = "0.15", features = ["approx"] }
-bevy_heavy = { version = "0.1", features = ["approx"] }
+bevy_math = { version = "0.16.0-dev", features = ["approx"] }
+bevy_heavy = { path = "../../../bevy_heavy", features = ["approx"] }
 glam = { version = "0.29", features = ["bytemuck"] }
 approx = "0.5"
 bytemuck = "1.19"
 criterion = { version = "0.5", features = ["html_reports"] }
-bevy_mod_debugdump = { version = "0.12" }
+# bevy_mod_debugdump = { version = "0.12" }
 
 [[example]]
 name = "dynamic_character_2d"

--- a/crates/avian2d/Cargo.toml
+++ b/crates/avian2d/Cargo.toml
@@ -68,10 +68,13 @@ bench = false
 
 [dependencies]
 avian_derive = { path = "../avian_derive", version = "0.2" }
-bevy = { version = "0.16.0-dev", default-features = false }
-bevy_math = { version = "0.16.0-dev" }
-bevy_heavy = { path = "../../../bevy_heavy" }
-bevy_transform_interpolation = { path = "../../../bevy_transform_interpolation" }
+bevy = { version = "0.16.0-rc.1", default-features = false, features = [
+    "std",
+    "bevy_log",
+] }
+bevy_math = { version = "0.16.0-rc.1" }
+bevy_heavy = { git = "https://github.com/Jondolf/bevy_heavy" }
+bevy_transform_interpolation = { git = "https://github.com/Jondolf/bevy_transform_interpolation" }
 libm = { version = "0.2", optional = true }
 parry2d = { version = "0.17", optional = true }
 parry2d-f64 = { version = "0.17", optional = true }
@@ -87,8 +90,10 @@ bitflags = "2.5.0"
 [dev-dependencies]
 examples_common_2d = { path = "../examples_common_2d" }
 benches_common_2d = { path = "../benches_common_2d" }
-bevy_math = { version = "0.16.0-dev", features = ["approx"] }
-bevy_heavy = { path = "../../../bevy_heavy", features = ["approx"] }
+bevy_math = { version = "0.16.0-rc.1", features = ["approx"] }
+bevy_heavy = { git = "https://github.com/Jondolf/bevy_heavy", features = [
+    "approx",
+] }
 glam = { version = "0.29", features = ["bytemuck"] }
 approx = "0.5"
 bytemuck = "1.19"

--- a/crates/avian2d/examples/chain_2d.rs
+++ b/crates/avian2d/examples/chain_2d.rs
@@ -71,11 +71,11 @@ fn follow_mouse(
     windows: Query<&Window, With<PrimaryWindow>>,
     camera: Query<(&Camera, &GlobalTransform)>,
     mut follower: Query<&mut Transform, With<FollowMouse>>,
-) {
+) -> Result {
     if buttons.pressed(MouseButton::Left) {
-        let window = windows.single();
-        let (camera, camera_transform) = camera.single();
-        let mut follower_position = follower.single_mut();
+        let window = windows.single()?;
+        let (camera, camera_transform) = camera.single()?;
+        let mut follower_position = follower.single_mut()?;
 
         if let Some(cursor_world_pos) = window
             .cursor_position()
@@ -85,4 +85,6 @@ fn follow_mouse(
                 cursor_world_pos.extend(follower_position.translation.z);
         }
     }
+
+    Ok(())
 }

--- a/crates/avian2d/examples/debugdump_2d.rs
+++ b/crates/avian2d/examples/debugdump_2d.rs
@@ -1,11 +1,13 @@
 //! Run with:
 //! `cargo run --example debugdump_2d > dump.dot  && dot -Tsvg dump.dot > dump.svg`
 
-/*
-use avian2d::prelude::*;
-use bevy::prelude::*;
+// use avian2d::prelude::*;
+// use bevy::prelude::*;
 
 fn main() {
+    todo!("`bevy_mod_debugdump` is not compatible with Bevy 0.16 yet. This example will be updated when it is.");
+
+    /*
     let mut app = App::new();
 
     app.add_plugins((PhysicsPlugins::default(), PhysicsDebugPlugin::default()));
@@ -15,8 +17,7 @@ fn main() {
     // - SubstepSchedule
     // - FixedPostUpdate
     // - Update
-    bevy_mod_debugdump::print_schedule_graph(&mut app, PhysicsSchedule);
-}
-*/
 
-fn main() {}
+    bevy_mod_debugdump::print_schedule_graph(&mut app, PhysicsSchedule);
+    */
+}

--- a/crates/avian2d/examples/debugdump_2d.rs
+++ b/crates/avian2d/examples/debugdump_2d.rs
@@ -1,6 +1,7 @@
 //! Run with:
 //! `cargo run --example debugdump_2d > dump.dot  && dot -Tsvg dump.dot > dump.svg`
 
+/*
 use avian2d::prelude::*;
 use bevy::prelude::*;
 
@@ -16,3 +17,6 @@ fn main() {
     // - Update
     bevy_mod_debugdump::print_schedule_graph(&mut app, PhysicsSchedule);
 }
+*/
+
+fn main() {}

--- a/crates/avian2d/examples/determinism_2d.rs
+++ b/crates/avian2d/examples/determinism_2d.rs
@@ -205,7 +205,7 @@ fn clear_scene(
 ) {
     step.0 = 0;
     for entity in &query {
-        commands.entity(entity).despawn_recursive();
+        commands.entity(entity).despawn();
     }
 }
 

--- a/crates/avian2d/examples/dynamic_character_2d/plugin.rs
+++ b/crates/avian2d/examples/dynamic_character_2d/plugin.rs
@@ -136,11 +136,11 @@ fn keyboard_input(
     let direction = horizontal as Scalar;
 
     if direction != 0.0 {
-        movement_event_writer.send(MovementAction::Move(direction));
+        movement_event_writer.write(MovementAction::Move(direction));
     }
 
     if keyboard_input.just_pressed(KeyCode::Space) {
-        movement_event_writer.send(MovementAction::Jump);
+        movement_event_writer.write(MovementAction::Jump);
     }
 }
 
@@ -151,11 +151,11 @@ fn gamepad_input(
 ) {
     for gamepad in gamepads.iter() {
         if let Some(x) = gamepad.get(GamepadAxis::LeftStickX) {
-            movement_event_writer.send(MovementAction::Move(x as Scalar));
+            movement_event_writer.write(MovementAction::Move(x as Scalar));
         }
 
         if gamepad.just_pressed(GamepadButton::South) {
-            movement_event_writer.send(MovementAction::Jump);
+            movement_event_writer.write(MovementAction::Jump);
         }
     }
 }

--- a/crates/avian2d/examples/kinematic_character_2d/plugin.rs
+++ b/crates/avian2d/examples/kinematic_character_2d/plugin.rs
@@ -150,11 +150,11 @@ fn keyboard_input(
     let direction = horizontal as Scalar;
 
     if direction != 0.0 {
-        movement_event_writer.send(MovementAction::Move(direction));
+        movement_event_writer.write(MovementAction::Move(direction));
     }
 
     if keyboard_input.just_pressed(KeyCode::Space) {
-        movement_event_writer.send(MovementAction::Jump);
+        movement_event_writer.write(MovementAction::Jump);
     }
 }
 
@@ -165,11 +165,11 @@ fn gamepad_input(
 ) {
     for gamepad in gamepads.iter() {
         if let Some(x) = gamepad.get(GamepadAxis::LeftStickX) {
-            movement_event_writer.send(MovementAction::Move(x as Scalar));
+            movement_event_writer.write(MovementAction::Move(x as Scalar));
         }
 
         if gamepad.just_pressed(GamepadButton::South) {
-            movement_event_writer.send(MovementAction::Jump);
+            movement_event_writer.write(MovementAction::Jump);
         }
     }
 }

--- a/crates/avian2d/examples/one_way_platform_2d.rs
+++ b/crates/avian2d/examples/one_way_platform_2d.rs
@@ -8,9 +8,11 @@
 
 use avian2d::{math::*, prelude::*};
 use bevy::{
-    ecs::system::{lifetimeless::Read, SystemParam},
+    ecs::{
+        entity::hash_set::EntityHashSet,
+        system::{lifetimeless::Read, SystemParam},
+    },
     prelude::*,
-    utils::HashSet,
 };
 use examples_common_2d::ExampleCommonPlugin;
 
@@ -46,7 +48,7 @@ struct JumpImpulse(Scalar);
 // Here we use required components, but you could also add it manually.
 #[derive(Clone, Eq, PartialEq, Debug, Default, Component)]
 #[require(ActiveCollisionHooks(|| ActiveCollisionHooks::MODIFY_CONTACTS))]
-pub struct OneWayPlatform(HashSet<Entity>);
+pub struct OneWayPlatform(EntityHashSet);
 
 /// A component to control how an actor interacts with a one-way platform.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Default, Component, Reflect)]

--- a/crates/avian2d/examples/sensor.rs
+++ b/crates/avian2d/examples/sensor.rs
@@ -108,7 +108,7 @@ fn keyboard_input1(
     }
     let space = keyboard_input.pressed(KeyCode::Space);
     if space {
-        movement_event_writer.send(MovementAction::Stop);
+        movement_event_writer.write(MovementAction::Stop);
         return;
     }
 
@@ -120,7 +120,7 @@ fn keyboard_input1(
     let vertical = up as i8 - down as i8;
     let direction = Vector::new(horizontal as Scalar, vertical as Scalar);
     if direction != Vector::ZERO {
-        movement_event_writer.send(MovementAction::Velocity(direction));
+        movement_event_writer.write(MovementAction::Velocity(direction));
     }
 }
 // use position offset
@@ -140,7 +140,7 @@ fn keyboard_input2(
     let vertical = up as i8 - down as i8;
     let direction = Vector::new(horizontal as Scalar, vertical as Scalar);
     if direction != Vector::ZERO {
-        movement_event_writer.send(MovementAction::Offset(direction));
+        movement_event_writer.write(MovementAction::Offset(direction));
     }
 }
 
@@ -219,16 +219,16 @@ fn update_velocity_text(
     character_query: Query<(&LinearVelocity, Has<Sleeping>), With<Character>>,
     pressure_plate_query: Query<Has<Sleeping>, With<PressurePlate>>,
     mut text_query: Query<&mut Text, With<CharacterVelocityText>>,
-) {
-    if let (Ok((velocity, character_sleeping)), Ok(pressure_plate_sleeping)) = (
-        character_query.get_single(),
-        pressure_plate_query.get_single(),
-    ) {
-        text_query.single_mut().0 = format!(
+) -> Result {
+    if let (Ok((velocity, character_sleeping)), Ok(pressure_plate_sleeping)) =
+        (character_query.single(), pressure_plate_query.single())
+    {
+        text_query.single_mut()?.0 = format!(
             "Velocity: {:.4}, {:.4}\nCharacter sleeping:{}\nPressure plate sleeping: {}",
             velocity.x, velocity.y, character_sleeping, pressure_plate_sleeping
         );
     }
+    Ok(())
 }
 
 fn log_events(mut started: EventReader<CollisionStarted>, mut ended: EventReader<CollisionEnded>) {

--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -70,10 +70,13 @@ bench = false
 
 [dependencies]
 avian_derive = { path = "../avian_derive", version = "0.2" }
-bevy = { version = "0.16.0-dev", default-features = false }
-bevy_math = { version = "0.16.0-dev" }
-bevy_heavy = { path = "../../../bevy_heavy" }
-bevy_transform_interpolation = { path = "../../../bevy_transform_interpolation" }
+bevy = { version = "0.16.0-rc.1", default-features = false, features = [
+    "std",
+    "bevy_log",
+] }
+bevy_math = { version = "0.16.0-rc.1" }
+bevy_heavy = { git = "https://github.com/Jondolf/bevy_heavy" }
+bevy_transform_interpolation = { git = "https://github.com/Jondolf/bevy_transform_interpolation" }
 libm = { version = "0.2", optional = true }
 parry3d = { version = "0.17", optional = true }
 parry3d-f64 = { version = "0.17", optional = true }
@@ -89,12 +92,14 @@ bitflags = "2.5.0"
 [dev-dependencies]
 examples_common_3d = { path = "../examples_common_3d" }
 benches_common_3d = { path = "../benches_common_3d" }
-bevy = { version = "0.16.0-dev", default-features = false, features = [
+bevy = { version = "0.16.0-rc.1", default-features = false, features = [
     "bevy_gltf",
     "animation",
 ] }
-bevy_math = { version = "0.16.0-dev", features = ["approx"] }
-bevy_heavy = { path = "../../../bevy_heavy", features = ["approx"] }
+bevy_math = { version = "0.16.0-rc.1", features = ["approx"] }
+bevy_heavy = { git = "https://github.com/Jondolf/bevy_heavy", features = [
+    "approx",
+] }
 approx = "0.5"
 criterion = { version = "0.5", features = ["html_reports"] }
 # bevy_mod_debugdump = { version = "0.12" }

--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -102,6 +102,7 @@ bevy_heavy = { git = "https://github.com/Jondolf/bevy_heavy", features = [
 ] }
 approx = "0.5"
 criterion = { version = "0.5", features = ["html_reports"] }
+# TODO: Update to the latest version when it's available.
 # bevy_mod_debugdump = { version = "0.12" }
 
 [lints]

--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -64,10 +64,10 @@ bench = false
 
 [dependencies]
 avian_derive = { path = "../avian_derive", version = "0.2" }
-bevy = { version = "0.15", default-features = false }
-bevy_math = { version = "0.15" }
-bevy_heavy = { version = "0.1" }
-bevy_transform_interpolation = { version = "0.1" }
+bevy = { version = "0.16.0-dev", default-features = false }
+bevy_math = { version = "0.16.0-dev" }
+bevy_heavy = { path = "../../../bevy_heavy" }
+bevy_transform_interpolation = { path = "../../../bevy_transform_interpolation" }
 libm = { version = "0.2", optional = true }
 parry3d = { version = "0.17", optional = true }
 parry3d-f64 = { version = "0.17", optional = true }
@@ -82,15 +82,15 @@ bitflags = "2.5.0"
 [dev-dependencies]
 examples_common_3d = { path = "../examples_common_3d" }
 benches_common_3d = { path = "../benches_common_3d" }
-bevy = { version = "0.15", default-features = false, features = [
+bevy = { version = "0.16.0-dev", default-features = false, features = [
     "bevy_gltf",
     "animation",
 ] }
-bevy_math = { version = "0.15", features = ["approx"] }
-bevy_heavy = { version = "0.1", features = ["approx"] }
+bevy_math = { version = "0.16.0-dev", features = ["approx"] }
+bevy_heavy = { path = "../../../bevy_heavy", features = ["approx"] }
 approx = "0.5"
 criterion = { version = "0.5", features = ["html_reports"] }
-bevy_mod_debugdump = { version = "0.12" }
+# bevy_mod_debugdump = { version = "0.12" }
 
 [[example]]
 name = "dynamic_character_3d"

--- a/crates/avian3d/examples/custom_constraint.rs
+++ b/crates/avian3d/examples/custom_constraint.rs
@@ -92,8 +92,8 @@ impl XpbdConstraint<2> for CustomDistanceConstraint {
 
 impl MapEntities for CustomDistanceConstraint {
     fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
-        self.entity1 = entity_mapper.map_entity(self.entity1);
-        self.entity2 = entity_mapper.map_entity(self.entity2);
+        self.entity1 = entity_mapper.get_mapped(self.entity1);
+        self.entity2 = entity_mapper.get_mapped(self.entity2);
     }
 }
 

--- a/crates/avian3d/examples/debugdump_3d.rs
+++ b/crates/avian3d/examples/debugdump_3d.rs
@@ -1,12 +1,13 @@
 //! Run with:
 //! `cargo run --example debugdump_3d > dump.dot  && dot -Tsvg dump.dot > dump.svg`
 
-/*
-use avian3d::debug_render::PhysicsDebugPlugin;
-use avian3d::prelude::*;
-use bevy::prelude::*;
+// use avian3d::prelude::*;
+// use bevy::prelude::*;
 
 fn main() {
+    todo!("`bevy_mod_debugdump` is not compatible with Bevy 0.16 yet. This example will be updated when it is.");
+
+    /*
     let mut app = App::new();
 
     app.add_plugins((PhysicsPlugins::default(), PhysicsDebugPlugin::default()));
@@ -17,7 +18,5 @@ fn main() {
     // - FixedPostUpdate
     // - Update
     bevy_mod_debugdump::print_schedule_graph(&mut app, PhysicsSchedule);
+    */
 }
-*/
-
-fn main() {}

--- a/crates/avian3d/examples/debugdump_3d.rs
+++ b/crates/avian3d/examples/debugdump_3d.rs
@@ -1,6 +1,7 @@
 //! Run with:
 //! `cargo run --example debugdump_3d > dump.dot  && dot -Tsvg dump.dot > dump.svg`
 
+/*
 use avian3d::debug_render::PhysicsDebugPlugin;
 use avian3d::prelude::*;
 use bevy::prelude::*;
@@ -17,3 +18,6 @@ fn main() {
     // - Update
     bevy_mod_debugdump::print_schedule_graph(&mut app, PhysicsSchedule);
 }
+*/
+
+fn main() {}

--- a/crates/avian3d/examples/diagnostics.rs
+++ b/crates/avian3d/examples/diagnostics.rs
@@ -19,7 +19,7 @@ fn main() {
             // in a debug UI. Requires the `diagnostic_ui` feature.
             PhysicsDiagnosticsUiPlugin,
             // Optional: Add the `FrameTimeDiagnosticsPlugin` to display frame time.
-            FrameTimeDiagnosticsPlugin,
+            FrameTimeDiagnosticsPlugin::default(),
         ))
         // The `PhysicsDiagnosticsUiSettings` resource can be used to configure the diagnostics UI.
         //

--- a/crates/avian3d/examples/dynamic_character_3d/plugin.rs
+++ b/crates/avian3d/examples/dynamic_character_3d/plugin.rs
@@ -144,11 +144,11 @@ fn keyboard_input(
     let direction = Vector2::new(horizontal as Scalar, vertical as Scalar).clamp_length_max(1.0);
 
     if direction != Vector2::ZERO {
-        movement_event_writer.send(MovementAction::Move(direction));
+        movement_event_writer.write(MovementAction::Move(direction));
     }
 
     if keyboard_input.just_pressed(KeyCode::Space) {
-        movement_event_writer.send(MovementAction::Jump);
+        movement_event_writer.write(MovementAction::Jump);
     }
 }
 
@@ -162,13 +162,13 @@ fn gamepad_input(
             gamepad.get(GamepadAxis::LeftStickX),
             gamepad.get(GamepadAxis::LeftStickY),
         ) {
-            movement_event_writer.send(MovementAction::Move(
+            movement_event_writer.write(MovementAction::Move(
                 Vector2::new(x as Scalar, y as Scalar).clamp_length_max(1.0),
             ));
         }
 
         if gamepad.just_pressed(GamepadButton::South) {
-            movement_event_writer.send(MovementAction::Jump);
+            movement_event_writer.write(MovementAction::Jump);
         }
     }
 }

--- a/crates/avian3d/examples/kinematic_character_3d/plugin.rs
+++ b/crates/avian3d/examples/kinematic_character_3d/plugin.rs
@@ -159,11 +159,11 @@ fn keyboard_input(
     let direction = Vector2::new(horizontal as Scalar, vertical as Scalar).clamp_length_max(1.0);
 
     if direction != Vector2::ZERO {
-        movement_event_writer.send(MovementAction::Move(direction));
+        movement_event_writer.write(MovementAction::Move(direction));
     }
 
     if keyboard_input.just_pressed(KeyCode::Space) {
-        movement_event_writer.send(MovementAction::Jump);
+        movement_event_writer.write(MovementAction::Jump);
     }
 }
 
@@ -177,13 +177,13 @@ fn gamepad_input(
             gamepad.get(GamepadAxis::LeftStickX),
             gamepad.get(GamepadAxis::LeftStickY),
         ) {
-            movement_event_writer.send(MovementAction::Move(
+            movement_event_writer.write(MovementAction::Move(
                 Vector2::new(x as Scalar, y as Scalar).clamp_length_max(1.0),
             ));
         }
 
         if gamepad.just_pressed(GamepadButton::South) {
-            movement_event_writer.send(MovementAction::Jump);
+            movement_event_writer.write(MovementAction::Jump);
         }
     }
 }

--- a/crates/avian3d/examples/picking.rs
+++ b/crates/avian3d/examples/picking.rs
@@ -96,8 +96,8 @@ fn setup_scene(
             ))
             .observe(update_material_on::<Pointer<Over>>(hover_matl.clone()))
             .observe(update_material_on::<Pointer<Out>>(white_matl.clone()))
-            .observe(update_material_on::<Pointer<Down>>(pressed_matl.clone()))
-            .observe(update_material_on::<Pointer<Up>>(hover_matl.clone()))
+            .observe(update_material_on::<Pointer<Pressed>>(pressed_matl.clone()))
+            .observe(update_material_on::<Pointer<Released>>(hover_matl.clone()))
             .observe(rotate_on_drag);
     }
 
@@ -107,7 +107,7 @@ fn setup_scene(
         MeshMaterial3d(ground_matl.clone()),
         RigidBody::Static,
         Collider::cuboid(50.0, 0.1, 50.0),
-        PickingBehavior::IGNORE, // Disable picking for the ground plane.
+        Pickable::IGNORE, // Disable picking for the ground plane.
     ));
 
     // Light
@@ -148,7 +148,7 @@ fn update_material_on<E>(
     // versions of this observer, each triggered by a different event and with a different hardcoded
     // material. Instead, the event type is a generic, and the material is passed in.
     move |trigger, mut query| {
-        if let Ok(mut material) = query.get_mut(trigger.entity()) {
+        if let Ok(mut material) = query.get_mut(trigger.target()) {
             material.0 = new_material.clone();
         }
     }
@@ -168,7 +168,7 @@ fn draw_pointer_intersections(pointers: Query<&PointerInteraction>, mut gizmos: 
 
 /// An observer to rotate an entity when it is dragged.
 fn rotate_on_drag(drag: Trigger<Pointer<Drag>>, mut transforms: Query<&mut Transform>) {
-    let mut transform = transforms.get_mut(drag.entity()).unwrap();
+    let mut transform = transforms.get_mut(drag.target()).unwrap();
     transform.rotate_y(drag.delta.x * 0.02);
     transform.rotate_x(drag.delta.y * 0.02);
 }

--- a/crates/benches_common_2d/Cargo.toml
+++ b/crates/benches_common_2d/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = { version = "0.16.0-dev", default-features = false }
+bevy = { version = "0.16.0-rc.1", default-features = false }
 avian2d = { path = "../avian2d", default-features = false }
 criterion = "0.5"

--- a/crates/benches_common_2d/Cargo.toml
+++ b/crates/benches_common_2d/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = { version = "0.15", default-features = false }
+bevy = { version = "0.16.0-dev", default-features = false }
 avian2d = { path = "../avian2d", default-features = false }
 criterion = "0.5"

--- a/crates/benches_common_2d/src/lib.rs
+++ b/crates/benches_common_2d/src/lib.rs
@@ -11,12 +11,7 @@ pub fn bench_app<M: Measurement>(
         move || {
             let mut app = App::new();
 
-            app.add_plugins((
-                MinimalPlugins,
-                HierarchyPlugin,
-                TransformPlugin,
-                PhysicsPlugins::default(),
-            ));
+            app.add_plugins((MinimalPlugins, TransformPlugin, PhysicsPlugins::default()));
 
             setup(&mut app);
 

--- a/crates/benches_common_3d/Cargo.toml
+++ b/crates/benches_common_3d/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = { version = "0.16.0-dev", default-features = false }
+bevy = { version = "0.16.0-rc.1", default-features = false }
 avian3d = { path = "../avian3d", default-features = false }
 criterion = "0.5"

--- a/crates/benches_common_3d/Cargo.toml
+++ b/crates/benches_common_3d/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = { version = "0.15", default-features = false }
+bevy = { version = "0.16.0-dev", default-features = false }
 avian3d = { path = "../avian3d", default-features = false }
 criterion = "0.5"

--- a/crates/benches_common_3d/src/lib.rs
+++ b/crates/benches_common_3d/src/lib.rs
@@ -11,12 +11,7 @@ pub fn bench_app<M: Measurement>(
         move || {
             let mut app = App::new();
 
-            app.add_plugins((
-                MinimalPlugins,
-                HierarchyPlugin,
-                TransformPlugin,
-                PhysicsPlugins::default(),
-            ));
+            app.add_plugins((MinimalPlugins, TransformPlugin, PhysicsPlugins::default()));
 
             setup(&mut app);
 

--- a/crates/examples_common_2d/Cargo.toml
+++ b/crates/examples_common_2d/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 use-debug-plugin = []
 
 [dependencies]
-bevy = { version = "0.15", default-features = false, features = [
+bevy = { version = "0.16.0-dev", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_state",
     "bevy_text",

--- a/crates/examples_common_2d/Cargo.toml
+++ b/crates/examples_common_2d/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 use-debug-plugin = []
 
 [dependencies]
-bevy = { version = "0.16.0-dev", default-features = false, features = [
+bevy = { version = "0.16.0-rc.1", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_state",
     "bevy_text",

--- a/crates/examples_common_2d/src/lib.rs
+++ b/crates/examples_common_2d/src/lib.rs
@@ -14,7 +14,7 @@ impl Plugin for ExampleCommonPlugin {
         app.add_plugins((
             PhysicsDiagnosticsPlugin,
             PhysicsDiagnosticsUiPlugin,
-            FrameTimeDiagnosticsPlugin,
+            FrameTimeDiagnosticsPlugin::default(),
         ));
 
         // Configure the default physics diagnostics UI.

--- a/crates/examples_common_2d/src/lib.rs
+++ b/crates/examples_common_2d/src/lib.rs
@@ -12,7 +12,7 @@ pub struct ExampleCommonPlugin;
 impl Plugin for ExampleCommonPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins((
-            FrameTimeDiagnosticsPlugin,
+            FrameTimeDiagnosticsPlugin::default(),
             #[cfg(feature = "use-debug-plugin")]
             PhysicsDebugPlugin::default(),
         ))

--- a/crates/examples_common_3d/Cargo.toml
+++ b/crates/examples_common_3d/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 use-debug-plugin = []
 
 [dependencies]
-bevy = { version = "0.15", default-features = false, features = [
+bevy = { version = "0.16.0-dev", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_state",
     "bevy_text",

--- a/crates/examples_common_3d/Cargo.toml
+++ b/crates/examples_common_3d/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 use-debug-plugin = []
 
 [dependencies]
-bevy = { version = "0.16.0-dev", default-features = false, features = [
+bevy = { version = "0.16.0-rc.1", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_state",
     "bevy_text",

--- a/crates/examples_common_3d/src/lib.rs
+++ b/crates/examples_common_3d/src/lib.rs
@@ -14,7 +14,7 @@ impl Plugin for ExampleCommonPlugin {
         app.add_plugins((
             PhysicsDiagnosticsPlugin,
             PhysicsDiagnosticsUiPlugin,
-            FrameTimeDiagnosticsPlugin,
+            FrameTimeDiagnosticsPlugin::default(),
         ));
 
         // Configure the default physics diagnostics UI.

--- a/crates/examples_common_3d/src/lib.rs
+++ b/crates/examples_common_3d/src/lib.rs
@@ -12,7 +12,7 @@ pub struct ExampleCommonPlugin;
 impl Plugin for ExampleCommonPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins((
-            FrameTimeDiagnosticsPlugin,
+            FrameTimeDiagnosticsPlugin::default(),
             #[cfg(feature = "use-debug-plugin")]
             PhysicsDebugPlugin::default(),
         ))

--- a/src/collision/broad_phase.rs
+++ b/src/collision/broad_phase.rs
@@ -128,7 +128,7 @@ bitflags::bitflags! {
 impl MapEntities for AabbIntervals {
     fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
         for interval in self.0.iter_mut() {
-            interval.0 = entity_mapper.map_entity(interval.0);
+            interval.0 = entity_mapper.get_mapped(interval.0);
         }
     }
 }
@@ -248,7 +248,7 @@ fn collect_collision_pairs<H: CollisionHooks>(
         intersections.clear();
     }
 
-    let start = bevy::utils::Instant::now();
+    let start = crate::utils::Instant::now();
 
     sweep_and_prune::<H>(
         intervals,

--- a/src/collision/collider/backend.rs
+++ b/src/collision/collider/backend.rs
@@ -100,9 +100,9 @@ impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
         let hooks = app.world_mut().register_component_hooks::<C>();
 
         // Initialize missing components for colliders.
-        hooks.on_add(|mut world, entity, _| {
+        hooks.on_add(|mut world, ctx| {
             let existing_global_transform = world
-                .entity(entity)
+                .entity(ctx.entity)
                 .get::<GlobalTransform>()
                 .copied()
                 .unwrap_or_default();
@@ -120,12 +120,12 @@ impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
                 // the `Transform` component before the collider is initialized, which in turn means that it will
                 // always be initialized with the correct `GlobalTransform`.
                 let parent_global_transform = world
-                    .entity(entity)
-                    .get::<Parent>()
+                    .entity(ctx.entity)
+                    .get::<ChildOf>()
                     .and_then(|parent| world.entity(parent.get()).get::<GlobalTransform>().copied())
                     .unwrap_or_default();
                 let transform = world
-                    .entity(entity)
+                    .entity(ctx.entity)
                     .get::<Transform>()
                     .copied()
                     .unwrap_or_default();
@@ -140,12 +140,12 @@ impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
             // This overwrites the scale set by the constructor, but that one is
             // meant to be only changed after initialization.
             world
-                .entity_mut(entity)
+                .entity_mut(ctx.entity)
                 .get_mut::<C>()
                 .unwrap()
                 .set_scale(scale.adjust_precision(), 10);
 
-            let mut entity_ref = world.entity_mut(entity);
+            let mut entity_ref = world.entity_mut(ctx.entity);
             let collider = entity_ref.get::<C>().unwrap();
 
             let aabb = entity_ref
@@ -178,13 +178,16 @@ impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
         // and updates rigid bodies when their collider is removed.
         app.world_mut()
             .register_component_hooks::<C>()
-            .on_remove(|mut world, entity, _| {
+            .on_remove(|mut world, ctx| {
                 // Remove the `ColliderMarker` associated with the collider.
                 // TODO: If the same entity had multiple *different* types of colliders, this would
                 //       get removed even if just one collider was removed. This is a very niche edge case though.
-                world.commands().entity(entity).remove::<ColliderMarker>();
+                world
+                    .commands()
+                    .entity(ctx.entity)
+                    .remove::<ColliderMarker>();
 
-                let entity_ref = world.entity_mut(entity);
+                let entity_ref = world.entity_mut(ctx.entity);
 
                 // Get the rigid body entity that the collider is attached to.
                 let Some(parent) = entity_ref.get::<ColliderParent>().copied() else {
@@ -193,11 +196,10 @@ impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
 
                 // Get the ID of the one-shot system run for collider removals.
                 let ColliderRemovalSystem(system_id) =
-                    world.resource::<ColliderRemovalSystem>().to_owned();
-                let system_id = *system_id;
+                    *world.resource::<ColliderRemovalSystem>().to_owned();
 
                 // Handle collider removal.
-                world.commands().run_system_with_input(system_id, parent);
+                world.commands().run_system_with(system_id, parent);
             });
 
         // When the `Sensor` component is added to a collider, queue its rigid body for a mass property update.
@@ -205,7 +207,7 @@ impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
             |trigger: Trigger<OnAdd, Sensor>,
              mut commands: Commands,
              query: Query<(&ColliderMassProperties, &ColliderParent)>| {
-                if let Ok((collider_mass_properties, parent)) = query.get(trigger.entity()) {
+                if let Ok((collider_mass_properties, parent)) = query.get(trigger.target()) {
                     // If the collider mass properties are zero, there is nothing to subtract.
                     if *collider_mass_properties == ColliderMassProperties::ZERO {
                         return;
@@ -228,7 +230,7 @@ impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
                 &mut ColliderMassProperties,
             )>| {
                 if let Ok((collider, density, mut collider_mass_properties)) =
-                    collider_query.get_mut(trigger.entity())
+                    collider_query.get_mut(trigger.target())
                 {
                     // Update collider mass props.
                     *collider_mass_properties =
@@ -624,9 +626,9 @@ fn update_aabb<C: AnyCollider>(
 pub fn update_collider_scale<C: ScalableCollider>(
     mut colliders: ParamSet<(
         // Root bodies
-        Query<(&Transform, &mut C), (Without<Parent>, Changed<Transform>)>,
+        Query<(&Transform, &mut C), (Without<ChildOf>, Changed<Transform>)>,
         // Child colliders
-        Query<(&ColliderTransform, &mut C), (With<Parent>, Changed<ColliderTransform>)>,
+        Query<(&ColliderTransform, &mut C), (With<ChildOf>, Changed<ColliderTransform>)>,
     )>,
     sync_config: Res<SyncConfig>,
 ) {
@@ -717,7 +719,6 @@ mod tests {
             MassPropertyPlugin::new(FixedPostUpdate),
             ColliderBackendPlugin::<Collider>::new(FixedPostUpdate),
             ColliderHierarchyPlugin::new(FixedPostUpdate),
-            HierarchyPlugin,
         ));
 
         let collider = Collider::capsule(0.5, 2.0);
@@ -735,7 +736,7 @@ mod tests {
         let child = app
             .world_mut()
             .spawn((collider, Transform::from_xyz(1.0, 0.0, 0.0)))
-            .set_parent(parent)
+            .insert(ChildOf(parent))
             .id();
 
         app.world_mut().run_schedule(FixedPostUpdate);

--- a/src/collision/collider/constructor.rs
+++ b/src/collision/collider/constructor.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
-use bevy::prelude::*;
-use bevy::utils::HashMap;
+use bevy::{platform_support::collections::HashMap, prelude::*};
 
 /// A component that will automatically generate [`Collider`]s on its descendants at runtime.
 /// The type of the generated collider can be specified using [`ColliderConstructor`].
@@ -736,7 +735,6 @@ mod tests {
             AssetPlugin::default(),
             #[cfg(feature = "bevy_scene")]
             ScenePlugin,
-            HierarchyPlugin,
             PhysicsPlugins::default(),
         ))
         .init_resource::<Assets<Mesh>>();

--- a/src/collision/collider/constructor.rs
+++ b/src/collision/collider/constructor.rs
@@ -8,7 +8,7 @@ use bevy::{platform_support::collections::HashMap, prelude::*};
 ///
 /// In contrast to [`ColliderConstructor`], this component will *not* generate a collider on its own entity.
 ///
-/// If this component is used on a scene, such as one spawned by a [`SceneBundle`], it will
+/// If this component is used on a scene, such as one spawned by a [`SceneRoot`], it will
 /// wait until the scene is loaded before generating colliders.
 ///
 /// The exact configuration for each descendant can be specified using the helper methods

--- a/src/collision/collider/hierarchy.rs
+++ b/src/collision/collider/hierarchy.rs
@@ -211,12 +211,12 @@ pub(crate) fn propagate_collider_transforms(
 ) {
     root_query.par_iter_mut().for_each(
         |(entity, transform, children)| {
-            for (child, child_transform, is_child_rb, parent) in parent_query.iter_many(children) {
+            for (child, child_transform, is_child_rb, child_of) in parent_query.iter_many(children) {
                 assert_eq!(
-                    parent.get(), entity,
+                    child_of.parent, entity,
                     "Malformed hierarchy. This probably means that your hierarchy has been improperly maintained, or contains a cycle"
                 );
-                let changed = transform.is_changed() || parent.is_changed();
+                let changed = transform.is_changed() || child_of.is_changed();
                 let parent_transform = ColliderTransform::from(*transform);
                 let child_transform = ColliderTransform::from(*child_transform);
                 let scale = parent_transform.scale * child_transform.scale;
@@ -331,9 +331,9 @@ unsafe fn propagate_collider_transforms_recursive(
     };
 
     let Some(children) = children else { return };
-    for (child, child_transform, is_rb, parent) in parent_query.iter_many(children) {
+    for (child, child_transform, is_rb, child_of) in parent_query.iter_many(children) {
         assert_eq!(
-            parent.get(), entity,
+            child_of.parent, entity,
             "Malformed hierarchy. This probably means that your hierarchy has been improperly maintained, or contains a cycle"
         );
 
@@ -362,7 +362,7 @@ unsafe fn propagate_collider_transforms_recursive(
                 collider_query,
                 parent_query,
                 child,
-                changed || parent.is_changed(),
+                changed || child_of.is_changed(),
             );
         }
     }

--- a/src/collision/collider/hierarchy.rs
+++ b/src/collision/collider/hierarchy.rs
@@ -18,7 +18,7 @@ use narrow_phase::NarrowPhaseSet;
 /// - Updates [`ColliderParent`].
 /// - Propagates [`ColliderTransform`].
 ///
-/// This plugin requires Bevy's `HierarchyPlugin` and that colliders have the `ColliderMarker` component,
+/// This plugin requires that colliders have the [`ColliderMarker`] component,
 /// which is added automatically for colliders if the [`ColliderBackendPlugin`] is enabled.
 pub struct ColliderHierarchyPlugin {
     schedule: Interned<dyn ScheduleLabel>,
@@ -43,23 +43,12 @@ impl Default for ColliderHierarchyPlugin {
     }
 }
 
-#[derive(SystemSet, Clone, Copy, Debug, PartialEq, Eq, Hash)]
-struct MarkColliderAncestors;
-
 impl Plugin for ColliderHierarchyPlugin {
     fn build(&self, app: &mut App) {
         // Mark ancestors of colliders with `AncestorMarker<ColliderMarker>`.
         // This is used to speed up `ColliderTransform` propagation by skipping
         // trees that have no colliders.
-        app.add_plugins(
-            AncestorMarkerPlugin::<ColliderMarker>::new(self.schedule)
-                .add_markers_in_set(MarkColliderAncestors),
-        );
-
-        app.configure_sets(
-            self.schedule,
-            MarkColliderAncestors.before(PrepareSet::PropagateTransforms),
-        );
+        app.add_plugins(AncestorMarkerPlugin::<ColliderMarker>::default());
 
         // Update collider parents.
         app.add_systems(
@@ -106,12 +95,6 @@ impl Plugin for ColliderHierarchyPlugin {
         // Update child collider positions before narrow phase collision detection.
         // Only traverses trees with `AncestorMarker<ColliderMarker>`.
         physics_schedule.add_systems(update_child_collider_position.in_set(NarrowPhaseSet::First));
-    }
-
-    fn finish(&self, app: &mut App) {
-        if !app.is_plugin_added::<HierarchyPlugin>() {
-            warn!("`ColliderHierarchyPlugin` requires Bevy's `HierarchyPlugin` to function. If you don't need collider hierarchies, consider disabling this plugin.",);
-        }
     }
 }
 
@@ -214,7 +197,7 @@ type ShouldPropagate = Or<(With<AncestorMarker<ColliderMarker>>, With<ColliderMa
 pub(crate) fn propagate_collider_transforms(
     mut root_query: Query<
         (Entity, Ref<Transform>, &Children),
-        (Without<Parent>, With<AncestorMarker<ColliderMarker>>),
+        (Without<ChildOf>, With<AncestorMarker<ColliderMarker>>),
     >,
     collider_query: Query<
         (
@@ -222,9 +205,9 @@ pub(crate) fn propagate_collider_transforms(
             Option<&mut ColliderTransform>,
             Option<&Children>,
         ),
-        (With<Parent>, ShouldPropagate),
+        (With<ChildOf>, ShouldPropagate),
     >,
-    parent_query: Query<(Entity, Ref<Transform>, Has<RigidBody>, Ref<Parent>), ShouldPropagate>,
+    parent_query: Query<(Entity, Ref<Transform>, Has<RigidBody>, Ref<ChildOf>), ShouldPropagate>,
 ) {
     root_query.par_iter_mut().for_each(
         |(entity, transform, children)| {
@@ -296,9 +279,9 @@ unsafe fn propagate_collider_transforms_recursive(
             Option<&mut ColliderTransform>,
             Option<&Children>,
         ),
-        (With<Parent>, ShouldPropagate),
+        (With<ChildOf>, ShouldPropagate),
     >,
-    parent_query: &Query<(Entity, Ref<Transform>, Has<RigidBody>, Ref<Parent>), ShouldPropagate>,
+    parent_query: &Query<(Entity, Ref<Transform>, Has<RigidBody>, Ref<ChildOf>), ShouldPropagate>,
     entity: Entity,
     mut changed: bool,
 ) {
@@ -316,7 +299,7 @@ unsafe fn propagate_collider_transforms_recursive(
         //   \   /
         //     D
         //
-        // D has two parents, B and C. If the propagation passes through C, but the Parent component on D points to B,
+        // D has two parents, B and C. If the propagation passes through C, but the ChildOf component on D points to B,
         // the above check will panic as the origin parent does match the recorded parent.
         //
         // Also consider the following case, where A and B are roots:

--- a/src/collision/collider/mod.rs
+++ b/src/collision/collider/mod.rs
@@ -2,9 +2,11 @@
 
 use crate::prelude::*;
 use bevy::{
-    ecs::entity::{EntityMapper, MapEntities},
+    ecs::{
+        component::Mutable,
+        entity::{hash_set::EntityHashSet, EntityMapper, MapEntities},
+    },
     prelude::*,
-    utils::HashSet,
 };
 use derive_more::From;
 
@@ -44,7 +46,7 @@ pub trait IntoCollider<C: AnyCollider> {
 
 /// A trait that generalizes over colliders. Implementing this trait
 /// allows colliders to be used with the physics engine.
-pub trait AnyCollider: Component + ComputeMassProperties {
+pub trait AnyCollider: Component<Mutability = Mutable> + ComputeMassProperties {
     /// Computes the [Axis-Aligned Bounding Box](ColliderAabb) of the collider
     /// with the given position and rotation.
     #[cfg_attr(
@@ -516,7 +518,7 @@ pub struct CollisionMargin(pub Scalar);
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, Component, Default, PartialEq)]
-pub struct CollidingEntities(pub HashSet<Entity>);
+pub struct CollidingEntities(pub EntityHashSet);
 
 impl MapEntities for CollidingEntities {
     fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {

--- a/src/collision/collider/mod.rs
+++ b/src/collision/collider/mod.rs
@@ -423,18 +423,12 @@ pub struct ColliderDisabled;
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, Component, PartialEq)]
-pub struct ColliderParent(pub(crate) Entity);
+pub struct ColliderParent(#[entities] pub(crate) Entity);
 
 impl ColliderParent {
     /// Gets the `Entity` ID of the [`RigidBody`] that this [`Collider`] is attached to.
     pub const fn get(&self) -> Entity {
         self.0
-    }
-}
-
-impl MapEntities for ColliderParent {
-    fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
-        self.0 = entity_mapper.map_entity(self.0)
     }
 }
 
@@ -747,7 +741,7 @@ impl MapEntities for CollidingEntities {
             .0
             .clone()
             .into_iter()
-            .map(|e| entity_mapper.map_entity(e))
+            .map(|e| entity_mapper.get_mapped(e))
             .collect()
     }
 }

--- a/src/collision/contact_reporting.rs
+++ b/src/collision/contact_reporting.rs
@@ -163,16 +163,16 @@ pub fn report_contacts(
     mut collision_ended_ev_writer: EventWriter<CollisionEnded>,
     mut diagnostics: ResMut<CollisionDiagnostics>,
 ) {
-    let start = bevy::utils::Instant::now();
+    let start = crate::utils::Instant::now();
 
     // TODO: Would batching events be worth it?
     for ((entity1, entity2), contacts) in collisions.get_internal().iter() {
         if contacts.during_current_frame {
-            collision_ev_writer.send(Collision(contacts.clone()));
+            collision_ev_writer.write(Collision(contacts.clone()));
 
             // Collision started
             if !contacts.during_previous_frame {
-                collision_started_ev_writer.send(CollisionStarted(*entity1, *entity2));
+                collision_started_ev_writer.write(CollisionStarted(*entity1, *entity2));
 
                 if let Ok(mut colliding_entities1) = colliders.get_mut(*entity1) {
                     colliding_entities1.insert(*entity2);
@@ -185,7 +185,7 @@ pub fn report_contacts(
 
         // Collision ended
         if !contacts.during_current_frame && contacts.during_previous_frame {
-            collision_ended_ev_writer.send(CollisionEnded(*entity1, *entity2));
+            collision_ended_ev_writer.write(CollisionEnded(*entity1, *entity2));
 
             if let Ok(mut colliding_entities1) = colliders.get_mut(*entity1) {
                 colliding_entities1.remove(entity2);

--- a/src/collision/diagnostics.rs
+++ b/src/collision/diagnostics.rs
@@ -2,8 +2,8 @@ use bevy::{
     diagnostic::DiagnosticPath,
     prelude::{ReflectResource, Resource},
     reflect::Reflect,
-    utils::Duration,
 };
+use core::time::Duration;
 
 use crate::diagnostics::{impl_diagnostic_paths, PhysicsDiagnostics};
 

--- a/src/collision/mod.rs
+++ b/src/collision/mod.rs
@@ -202,7 +202,7 @@ impl Collisions {
         let reserve = if self.get_internal().is_empty() {
             iter.size_hint().0
         } else {
-            (iter.size_hint().0 + 1) / 2
+            iter.size_hint().0.div_ceil(2)
         };
         self.get_internal_mut().reserve(reserve);
         iter.for_each(move |contacts| {

--- a/src/collision/narrow_phase.rs
+++ b/src/collision/narrow_phase.rs
@@ -271,7 +271,7 @@ fn collect_collisions<C: AnyCollider, H: CollisionHooks + 'static>(
 ) where
     for<'w, 's> SystemParamItem<'w, 's, H>: CollisionHooks,
 {
-    let start = bevy::utils::Instant::now();
+    let start = crate::utils::Instant::now();
 
     narrow_phase.update::<H>(
         &broad_collision_pairs,
@@ -296,7 +296,7 @@ fn generate_constraints<C: AnyCollider>(
     mut collision_diagnostics: ResMut<CollisionDiagnostics>,
     solver_diagnostics: Option<ResMut<SolverDiagnostics>>,
 ) {
-    let start = bevy::utils::Instant::now();
+    let start = crate::utils::Instant::now();
 
     let delta_secs = time.delta_seconds_adjusted();
 

--- a/src/debug_render/mod.rs
+++ b/src/debug_render/mod.rs
@@ -101,11 +101,11 @@ impl Plugin for PhysicsDebugPlugin {
         let config = store.config_mut::<PhysicsGizmos>().0;
         #[cfg(feature = "2d")]
         {
-            config.line_width = 2.0;
+            config.line.width = 2.0;
         }
         #[cfg(feature = "3d")]
         {
-            config.line_width = 1.5;
+            config.line.width = 1.5;
         }
 
         app.register_type::<PhysicsGizmos>()

--- a/src/diagnostics/mod.rs
+++ b/src/diagnostics/mod.rs
@@ -79,9 +79,9 @@ use crate::{schedule::PhysicsSchedule, PhysicsStepSet};
 use bevy::{
     app::{App, Plugin},
     diagnostic::{Diagnostic, DiagnosticPath, Diagnostics, RegisterDiagnostic},
-    prelude::{IntoSystemConfigs, IntoSystemSetConfigs, Res, ResMut, Resource, SystemSet},
-    utils::Duration,
+    prelude::{IntoScheduleConfigs, Res, ResMut, Resource, SystemSet},
 };
+use core::time::Duration;
 
 /// A plugin that enables writing [physics diagnostics](crate::diagnostics)
 /// to [`bevy::diagnostic::DiagnosticsStore`]. It is not enabled by default

--- a/src/diagnostics/total.rs
+++ b/src/diagnostics/total.rs
@@ -26,7 +26,7 @@ impl Plugin for PhysicsTotalDiagnosticsPlugin {
         );
 
         // Initialize `PhysicsStepStart` for tracking the time at which the physics step started.
-        app.insert_resource::<PhysicsStepStart>(PhysicsStepStart(bevy::utils::Instant::now()));
+        app.insert_resource::<PhysicsStepStart>(PhysicsStepStart(crate::utils::Instant::now()));
 
         // Add systems for updating total physics diagnostics.
         app.add_systems(
@@ -84,10 +84,10 @@ fn increment_physics_step_number(
 /// The time at which the physics step started.
 #[derive(Resource, Debug, Reflect)]
 #[reflect(Resource, Debug)]
-struct PhysicsStepStart(pub bevy::utils::Instant);
+struct PhysicsStepStart(pub crate::utils::Instant);
 
 fn update_physics_step_start(mut start: ResMut<PhysicsStepStart>) {
-    start.0 = bevy::utils::Instant::now();
+    start.0 = crate::utils::Instant::now();
 }
 
 fn update_step_time(

--- a/src/diagnostics/ui.rs
+++ b/src/diagnostics/ui.rs
@@ -6,6 +6,7 @@
 use crate::{diagnostics::*, prelude::*};
 use bevy::color::palettes::tailwind::{GREEN_400, RED_400};
 use bevy::diagnostic::{DiagnosticPath, DiagnosticsStore, FrameTimeDiagnosticsPlugin};
+use bevy::ecs::relationship::RelatedSpawnerCommands;
 use bevy::prelude::*;
 use dynamics::solver::SolverDiagnostics;
 use entity_counters::PhysicsEntityDiagnosticsPlugin;
@@ -154,7 +155,7 @@ fn setup_diagnostics_ui(mut commands: Commands, settings: Res<PhysicsDiagnostics
         .with_children(build_diagnostic_texts);
 }
 
-fn build_diagnostic_texts(cmd: &mut ChildBuilder) {
+fn build_diagnostic_texts(cmd: &mut RelatedSpawnerCommands<ChildOf>) {
     // Step counter
     cmd.diagnostic_group("Step Counter")
         .with_children(|cmd| cmd.counter_text("Step Number", PhysicsTotalDiagnostics::STEP_NUMBER));
@@ -292,7 +293,7 @@ trait CommandsExt {
     }
 }
 
-impl CommandsExt for ChildBuilder<'_> {
+impl CommandsExt for RelatedSpawnerCommands<'_, ChildOf> {
     fn diagnostic_group(&mut self, name: &str) -> EntityCommands {
         self.spawn((
             DiagnosticGroup,

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -524,7 +524,7 @@ fn solve_swept_ccd(
     narrow_phase_config: Res<NarrowPhaseConfig>,
     mut diagnostics: ResMut<SolverDiagnostics>,
 ) {
-    let start = bevy::utils::Instant::now();
+    let start = crate::utils::Instant::now();
 
     let delta_secs = time.delta_seconds_adjusted();
 

--- a/src/dynamics/integrator/mod.rs
+++ b/src/dynamics/integrator/mod.rs
@@ -173,7 +173,7 @@ fn integrate_velocities(
     time: Res<Time>,
     mut diagnostics: ResMut<SolverDiagnostics>,
 ) {
-    let start = bevy::utils::Instant::now();
+    let start = crate::utils::Instant::now();
 
     let delta_secs = time.delta_seconds_adjusted();
 
@@ -273,7 +273,7 @@ fn integrate_positions(
     time: Res<Time>,
     mut diagnostics: ResMut<SolverDiagnostics>,
 ) {
-    let start = bevy::utils::Instant::now();
+    let start = crate::utils::Instant::now();
 
     let delta_secs = time.delta_seconds_adjusted();
 

--- a/src/dynamics/rigid_body/mass_properties/components/mod.rs
+++ b/src/dynamics/rigid_body/mass_properties/components/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::prelude::*;
 use bevy::{
-    ecs::{component::ComponentId, world::DeferredWorld},
+    ecs::{component::HookContext, world::DeferredWorld},
     prelude::*,
 };
 #[cfg(feature = "3d")]
@@ -972,8 +972,8 @@ pub struct NoAutoAngularInertia;
 pub struct NoAutoCenterOfMass;
 
 /// Triggers the recomputation of mass properties for rigid bodies when automatic computation is re-enabled.
-fn on_remove_no_auto_mass_property(mut world: DeferredWorld, entity: Entity, _id: ComponentId) {
-    if let Some(mut entity_commands) = world.commands().get_entity(entity) {
+fn on_remove_no_auto_mass_property(mut world: DeferredWorld, ctx: HookContext) {
+    if let Some(mut entity_commands) = world.commands().get_entity(ctx.entity) {
         entity_commands.try_insert(RecomputeMassProperties);
     }
 }

--- a/src/dynamics/rigid_body/mass_properties/components/mod.rs
+++ b/src/dynamics/rigid_body/mass_properties/components/mod.rs
@@ -957,7 +957,7 @@ pub struct NoAutoCenterOfMass;
 
 /// Triggers the recomputation of mass properties for rigid bodies when automatic computation is re-enabled.
 fn on_remove_no_auto_mass_property(mut world: DeferredWorld, ctx: HookContext) {
-    if let Some(mut entity_commands) = world.commands().get_entity(ctx.entity) {
+    if let Ok(mut entity_commands) = world.commands().get_entity(ctx.entity) {
         entity_commands.try_insert(RecomputeMassProperties);
     }
 }

--- a/src/dynamics/rigid_body/mass_properties/mod.rs
+++ b/src/dynamics/rigid_body/mass_properties/mod.rs
@@ -468,12 +468,7 @@ mod tests {
 
     fn create_app() -> App {
         let mut app = App::new();
-        app.add_plugins((
-            MinimalPlugins,
-            PhysicsPlugins::default(),
-            TransformPlugin,
-            HierarchyPlugin,
-        ));
+        app.add_plugins((MinimalPlugins, PhysicsPlugins::default(), TransformPlugin));
         app
     }
 
@@ -737,9 +732,10 @@ mod tests {
         let child_collider = Collider::circle(2.0);
         let child_collider_mass_props = child_collider.mass_properties(1.0);
 
-        app.world_mut()
-            .entity_mut(body_entity)
-            .with_child((child_collider, ColliderDensity(1.0)));
+        let child_entity = app
+            .world_mut()
+            .spawn((ChildOf(body_entity), child_collider, ColliderDensity(1.0)))
+            .id();
 
         app.world_mut().run_schedule(FixedPostUpdate);
 
@@ -757,9 +753,7 @@ mod tests {
         assert_eq!(*center_of_mass, ComputedCenterOfMass::default());
 
         // Remove the child collider
-        app.world_mut()
-            .entity_mut(body_entity)
-            .despawn_descendants();
+        app.world_mut().entity_mut(child_entity).despawn();
 
         app.world_mut().run_schedule(FixedPostUpdate);
 
@@ -843,8 +837,12 @@ mod tests {
 
         let child_entity = app
             .world_mut()
-            .spawn((Collider::circle(1.0), Mass(5.0), Transform::default()))
-            .set_parent(body_entity)
+            .spawn((
+                ChildOf(body_entity),
+                Collider::circle(1.0),
+                Mass(5.0),
+                Transform::default(),
+            ))
             .id();
 
         app.world_mut().run_schedule(FixedPostUpdate);

--- a/src/dynamics/rigid_body/mass_properties/mod.rs
+++ b/src/dynamics/rigid_body/mass_properties/mod.rs
@@ -392,7 +392,7 @@ fn queue_mass_recomputation_on_collider_mass_change(
     >,
 ) {
     for collider_parent in &mut query {
-        if let Some(mut entity_commands) = commands.get_entity(collider_parent.get()) {
+        if let Ok(mut entity_commands) = commands.get_entity(collider_parent.get()) {
             entity_commands.insert(RecomputeMassProperties);
         }
     }
@@ -734,7 +734,13 @@ mod tests {
 
         let child_entity = app
             .world_mut()
-            .spawn((ChildOf(body_entity), child_collider, ColliderDensity(1.0)))
+            .spawn((
+                ChildOf {
+                    parent: body_entity,
+                },
+                child_collider,
+                ColliderDensity(1.0),
+            ))
             .id();
 
         app.world_mut().run_schedule(FixedPostUpdate);
@@ -838,7 +844,9 @@ mod tests {
         let child_entity = app
             .world_mut()
             .spawn((
-                ChildOf(body_entity),
+                ChildOf {
+                    parent: body_entity,
+                },
                 Collider::circle(1.0),
                 Mass(5.0),
                 Transform::default(),

--- a/src/dynamics/rigid_body/mod.rs
+++ b/src/dynamics/rigid_body/mod.rs
@@ -370,7 +370,7 @@ pub(crate) type RigidBodyActiveFilter = (Without<RigidBodyDisabled>, Without<Sle
 ///
 /// - [`ColliderDisabled`]: Disables a collider.
 /// - [`JointDisabled`]: Disables a joint constraint.
-#[derive(Reflect, Clone, Copy, Component, Debug, Default)]
+#[derive(Clone, Copy, Component, Reflect, Debug, Default)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, Component, Default)]

--- a/src/dynamics/solver/contact/mod.rs
+++ b/src/dynamics/solver/contact/mod.rs
@@ -442,7 +442,7 @@ impl ContactConstraint {
 
 impl MapEntities for ContactConstraint {
     fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
-        self.entity1 = entity_mapper.map_entity(self.entity1);
-        self.entity2 = entity_mapper.map_entity(self.entity2);
+        self.entity1 = entity_mapper.get_mapped(self.entity1);
+        self.entity2 = entity_mapper.get_mapped(self.entity2);
     }
 }

--- a/src/dynamics/solver/diagnostics.rs
+++ b/src/dynamics/solver/diagnostics.rs
@@ -2,8 +2,8 @@ use bevy::{
     diagnostic::DiagnosticPath,
     prelude::{ReflectResource, Resource},
     reflect::Reflect,
-    utils::Duration,
 };
+use core::time::Duration;
 
 use crate::diagnostics::{impl_diagnostic_paths, PhysicsDiagnostics};
 

--- a/src/dynamics/solver/joints/distance.rs
+++ b/src/dynamics/solver/joints/distance.rs
@@ -195,7 +195,7 @@ impl AngularConstraint for DistanceJoint {}
 
 impl MapEntities for DistanceJoint {
     fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
-        self.entity1 = entity_mapper.map_entity(self.entity1);
-        self.entity2 = entity_mapper.map_entity(self.entity2);
+        self.entity1 = entity_mapper.get_mapped(self.entity1);
+        self.entity2 = entity_mapper.get_mapped(self.entity2);
     }
 }

--- a/src/dynamics/solver/joints/fixed.rs
+++ b/src/dynamics/solver/joints/fixed.rs
@@ -167,7 +167,7 @@ impl AngularConstraint for FixedJoint {}
 
 impl MapEntities for FixedJoint {
     fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
-        self.entity1 = entity_mapper.map_entity(self.entity1);
-        self.entity2 = entity_mapper.map_entity(self.entity2);
+        self.entity1 = entity_mapper.get_mapped(self.entity1);
+        self.entity2 = entity_mapper.get_mapped(self.entity2);
     }
 }

--- a/src/dynamics/solver/joints/prismatic.rs
+++ b/src/dynamics/solver/joints/prismatic.rs
@@ -265,7 +265,7 @@ impl AngularConstraint for PrismaticJoint {}
 
 impl MapEntities for PrismaticJoint {
     fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
-        self.entity1 = entity_mapper.map_entity(self.entity1);
-        self.entity2 = entity_mapper.map_entity(self.entity2);
+        self.entity1 = entity_mapper.get_mapped(self.entity1);
+        self.entity2 = entity_mapper.get_mapped(self.entity2);
     }
 }

--- a/src/dynamics/solver/joints/revolute.rs
+++ b/src/dynamics/solver/joints/revolute.rs
@@ -238,7 +238,7 @@ impl AngularConstraint for RevoluteJoint {}
 
 impl MapEntities for RevoluteJoint {
     fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
-        self.entity1 = entity_mapper.map_entity(self.entity1);
-        self.entity2 = entity_mapper.map_entity(self.entity2);
+        self.entity1 = entity_mapper.get_mapped(self.entity1);
+        self.entity2 = entity_mapper.get_mapped(self.entity2);
     }
 }

--- a/src/dynamics/solver/joints/spherical.rs
+++ b/src/dynamics/solver/joints/spherical.rs
@@ -283,7 +283,7 @@ impl AngularConstraint for SphericalJoint {}
 
 impl MapEntities for SphericalJoint {
     fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
-        self.entity1 = entity_mapper.map_entity(self.entity1);
-        self.entity2 = entity_mapper.map_entity(self.entity2);
+        self.entity1 = entity_mapper.get_mapped(self.entity1);
+        self.entity2 = entity_mapper.get_mapped(self.entity2);
     }
 }

--- a/src/dynamics/solver/mod.rs
+++ b/src/dynamics/solver/mod.rs
@@ -393,7 +393,7 @@ fn warm_start(
     solver_config: Res<SolverConfig>,
     mut diagnostics: ResMut<SolverDiagnostics>,
 ) {
-    let start = bevy::utils::Instant::now();
+    let start = crate::utils::Instant::now();
 
     for constraint in constraints.iter_mut() {
         debug_assert!(!constraint.points.is_empty());
@@ -442,7 +442,7 @@ fn solve_contacts<const USE_BIAS: bool>(
     time: Res<Time>,
     mut diagnostics: ResMut<SolverDiagnostics>,
 ) {
-    let start = bevy::utils::Instant::now();
+    let start = crate::utils::Instant::now();
 
     let delta_secs = time.delta_seconds_adjusted();
     let max_overlap_solve_speed = solver_config.max_overlap_solve_speed * length_unit.0;
@@ -486,7 +486,7 @@ fn solve_restitution(
     length_unit: Res<PhysicsLengthUnit>,
     mut diagnostics: ResMut<SolverDiagnostics>,
 ) {
-    let start = bevy::utils::Instant::now();
+    let start = crate::utils::Instant::now();
 
     // The restitution threshold determining the speed required for restitution to be applied.
     let threshold = solver_config.restitution_threshold * length_unit.0;
@@ -527,7 +527,7 @@ fn store_contact_impulses(
     mut collisions: ResMut<Collisions>,
     mut diagnostics: ResMut<SolverDiagnostics>,
 ) {
-    let start = bevy::utils::Instant::now();
+    let start = crate::utils::Instant::now();
 
     for constraint in constraints.iter() {
         let Some(contacts) =
@@ -567,7 +567,7 @@ fn apply_translation(
     >,
     mut diagnostics: ResMut<SolverDiagnostics>,
 ) {
-    let start = bevy::utils::Instant::now();
+    let start = crate::utils::Instant::now();
 
     for (rb, mut pos, rot, prev_rot, mut translation, center_of_mass) in &mut bodies {
         if rb.is_static() {

--- a/src/dynamics/solver/xpbd/mod.rs
+++ b/src/dynamics/solver/xpbd/mod.rs
@@ -226,7 +226,10 @@ pub use angular_constraint::AngularConstraint;
 pub use positional_constraint::PositionConstraint;
 
 use crate::prelude::*;
-use bevy::{ecs::entity::MapEntities, prelude::*};
+use bevy::{
+    ecs::{component::Mutable, entity::MapEntities},
+    prelude::*,
+};
 
 /// A trait for all XPBD [constraints](self#constraints).
 pub trait XpbdConstraint<const ENTITY_COUNT: usize>: MapEntities {
@@ -348,7 +351,10 @@ pub trait XpbdConstraint<const ENTITY_COUNT: usize>: MapEntities {
 ///         .in_set(SubstepSolverSet::SolveUserConstraints),
 /// );
 /// ```
-pub fn solve_constraint<C: XpbdConstraint<ENTITY_COUNT> + Component, const ENTITY_COUNT: usize>(
+pub fn solve_constraint<
+    C: XpbdConstraint<ENTITY_COUNT> + Component<Mutability = Mutable>,
+    const ENTITY_COUNT: usize,
+>(
     mut commands: Commands,
     mut bodies: Query<RigidBodyQuery, Without<RigidBodyDisabled>>,
     mut constraints: Query<&mut C, (Without<RigidBody>, Without<JointDisabled>)>,

--- a/src/dynamics/solver/xpbd/mod.rs
+++ b/src/dynamics/solver/xpbd/mod.rs
@@ -75,8 +75,8 @@
 //!
 //! impl MapEntities for CustomConstraint {
 //!     fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
-//!        self.entity1 = entity_mapper.map_entity(self.entity1);
-//!        self.entity2 = entity_mapper.map_entity(self.entity2);
+//!        self.entity1 = entity_mapper.get_mapped(self.entity1);
+//!        self.entity2 = entity_mapper.get_mapped(self.entity2);
 //!     }
 //! }
 //! ```

--- a/src/picking/mod.rs
+++ b/src/picking/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Add the [`PhysicsPickingPlugin`] to enable picking for [colliders](Collider).
 //! By default, all colliders are pickable. Picking can be disabled for individual entities
-//! by adding [`PickingBehavior::IGNORE`].
+//! by adding [`Pickable::IGNORE`].
 //!
 //! To make physics picking entirely opt-in, set [`PhysicsPickingSettings::require_markers`]
 //! to `true` and add a [`PhysicsPickable`] component to the desired camera and target entities.

--- a/src/picking/mod.rs
+++ b/src/picking/mod.rs
@@ -156,7 +156,7 @@ pub fn update_hits(
     mut output_events: EventWriter<PointerHits>,
     mut diagnostics: ResMut<PhysicsPickingDiagnostics>,
 ) {
-    let start_time = bevy::utils::Instant::now();
+    let start_time = crate::utils::Instant::now();
 
     for (&ray_id, &ray) in ray_map.map().iter() {
         let Ok((camera, picking_filter, cam_pickable)) = picking_cameras.get(ray_id.camera) else {
@@ -196,7 +196,7 @@ pub fn update_hits(
                 },
             );
 
-            output_events.send(PointerHits::new(ray_id.pointer, hits, camera.order as f32));
+            output_events.write(PointerHits::new(ray_id.pointer, hits, camera.order as f32));
         }
         #[cfg(feature = "3d")]
         {
@@ -231,7 +231,7 @@ pub fn update_hits(
                     (ray_hit_data.entity, hit_data)
                 })
             {
-                output_events.send(PointerHits::new(
+                output_events.write(PointerHits::new(
                     ray_id.pointer,
                     vec![(entity, hit_data)],
                     camera.order as f32,

--- a/src/picking/mod.rs
+++ b/src/picking/mod.rs
@@ -17,7 +17,7 @@ Note that in 3D, only the closest intersection will be reported."
 
 use crate::prelude::*;
 use bevy::{
-    ecs::entity::EntityHashSet,
+    ecs::entity::hash_set::EntityHashSet,
     picking::{
         backend::{ray::RayMap, HitData, PointerHits},
         PickSet,
@@ -113,7 +113,7 @@ pub fn update_hits(
         Option<&PhysicsPickable>,
     )>,
     ray_map: Res<RayMap>,
-    pickables: Query<&PickingBehavior>,
+    pickables: Query<&Pickable>,
     marked_targets: Query<&PhysicsPickable>,
     backend_settings: Res<PhysicsPickingSettings>,
     spatial_query: SpatialQuery,
@@ -143,7 +143,7 @@ pub fn update_hits(
 
                     let is_pickable = pickables
                         .get(entity)
-                        .map(|p| *p != PickingBehavior::IGNORE)
+                        .map(|p| *p != Pickable::IGNORE)
                         .unwrap_or(true);
 
                     if marker_requirement && is_pickable {
@@ -174,7 +174,7 @@ pub fn update_hits(
 
                         let is_pickable = pickables
                             .get(entity)
-                            .map(|p| *p != PickingBehavior::IGNORE)
+                            .map(|p| *p != Pickable::IGNORE)
                             .unwrap_or(true);
 
                         marker_requirement && is_pickable

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -146,7 +146,7 @@ pub fn init_transforms<C: Component>(
             Option<&Position>,
             Option<&Rotation>,
             Option<&PreviousRotation>,
-            Option<&Parent>,
+            Option<&ChildOf>,
             Has<RigidBody>,
         ),
         Added<C>,

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -168,7 +168,7 @@ pub fn init_transforms<C: Component>(
     for (entity, transform, global_transform, pos, rot, previous_rot, parent, has_rigid_body) in
         &query
     {
-        let parent_transforms = parent.and_then(|parent| parents.get(parent.get()).ok());
+        let parent_transforms = parent.and_then(|&ChildOf { parent }| parents.get(parent).ok());
         let parent_pos = parent_transforms.and_then(|(pos, _, _)| pos);
         let parent_rot = parent_transforms.and_then(|(_, rot, _)| rot);
         let parent_global_trans = parent_transforms.and_then(|(_, _, trans)| trans);

--- a/src/schedule/time.rs
+++ b/src/schedule/time.rs
@@ -21,7 +21,7 @@ use bevy::prelude::*;
 /// ```no_run
 #[cfg_attr(feature = "2d", doc = "use avian2d::prelude::*;")]
 #[cfg_attr(feature = "3d", doc = "use avian3d::prelude::*;")]
-/// use bevy::{prelude::*, utils::Duration};
+/// use bevy::prelude::*;
 ///
 /// fn main() {
 ///     App::new()
@@ -59,7 +59,8 @@ use bevy::prelude::*;
 /// ```
 #[cfg_attr(feature = "2d", doc = "use avian2d::prelude::*;")]
 #[cfg_attr(feature = "3d", doc = "use avian3d::prelude::*;")]
-/// use bevy::{prelude::*, utils::Duration};
+/// use bevy::prelude::*;
+/// use core::time::Duration;
 ///
 /// fn run_physics(world: &mut World) {
 ///     // Advance the simulation by 10 steps at 120 Hz

--- a/src/spatial_query/mod.rs
+++ b/src/spatial_query/mod.rs
@@ -218,6 +218,10 @@ impl Plugin for SpatialQueryPlugin {
 }
 
 /// Updates the [`SpatialQueryPipeline`].
+#[cfg(all(
+    feature = "default-collider",
+    any(feature = "parry-f32", feature = "parry-f64")
+))]
 pub fn update_spatial_query_pipeline(
     mut spatial_query: SpatialQuery,
     mut diagnostics: ResMut<SpatialQueryDiagnostics>,

--- a/src/spatial_query/mod.rs
+++ b/src/spatial_query/mod.rs
@@ -222,7 +222,7 @@ pub fn update_spatial_query_pipeline(
     mut spatial_query: SpatialQuery,
     mut diagnostics: ResMut<SpatialQueryDiagnostics>,
 ) {
-    let start = bevy::utils::Instant::now();
+    let start = crate::utils::Instant::now();
 
     spatial_query.update_pipeline();
 
@@ -270,7 +270,7 @@ fn update_ray_caster_positions(
         }
 
         if let Some(Ok((parent_position, parent_rotation, parent_transform))) =
-            parent.map(|p| parents.get(p.get()))
+            parent.map(|&ChildOf { parent }| parents.get(parent))
         {
             let parent_position = parent_position
                 .copied()
@@ -358,7 +358,7 @@ fn update_shape_caster_positions(
         }
 
         if let Some(Ok((parent_position, parent_rotation, parent_transform))) =
-            parent.map(|p| parents.get(p.get()))
+            parent.map(|&ChildOf { parent }| parents.get(parent))
         {
             let parent_position = parent_position
                 .copied()
@@ -399,7 +399,7 @@ fn raycast(
     spatial_query: SpatialQuery,
     mut diagnostics: ResMut<SpatialQueryDiagnostics>,
 ) {
-    let start = bevy::utils::Instant::now();
+    let start = crate::utils::Instant::now();
 
     for (entity, mut ray, mut hits) in &mut rays {
         if ray.enabled {
@@ -418,7 +418,7 @@ fn shapecast(
     spatial_query: SpatialQuery,
     mut diagnostics: ResMut<SpatialQueryDiagnostics>,
 ) {
-    let start = bevy::utils::Instant::now();
+    let start = crate::utils::Instant::now();
 
     for (entity, shape_caster, mut hits) in &mut shape_casters {
         if shape_caster.enabled {

--- a/src/spatial_query/mod.rs
+++ b/src/spatial_query/mod.rs
@@ -213,7 +213,7 @@ type RayCasterPositionQueryComponents = (
     &'static mut RayCaster,
     Option<&'static Position>,
     Option<&'static Rotation>,
-    Option<&'static Parent>,
+    Option<&'static ChildOf>,
     Option<&'static GlobalTransform>,
 );
 
@@ -281,7 +281,7 @@ type ShapeCasterPositionQueryComponents = (
     &'static mut ShapeCaster,
     Option<&'static Position>,
     Option<&'static Rotation>,
-    Option<&'static Parent>,
+    Option<&'static ChildOf>,
     Option<&'static GlobalTransform>,
 );
 

--- a/src/spatial_query/query_filter.rs
+++ b/src/spatial_query/query_filter.rs
@@ -1,7 +1,4 @@
-use bevy::{
-    ecs::entity::{EntityHash, EntityHashSet},
-    prelude::*,
-};
+use bevy::{ecs::entity::hash_set::EntityHashSet, prelude::*};
 
 use crate::prelude::*;
 
@@ -53,7 +50,7 @@ impl SpatialQueryFilter {
     /// and has no excluded entities.
     pub const DEFAULT: Self = Self {
         mask: LayerMask::ALL,
-        excluded_entities: EntityHashSet::with_hasher(EntityHash),
+        excluded_entities: EntityHashSet::new(),
     };
 
     /// Creates a new [`SpatialQueryFilter`] with the given [`LayerMask`] determining

--- a/src/spatial_query/ray_caster.rs
+++ b/src/spatial_query/ray_caster.rs
@@ -462,6 +462,6 @@ pub struct RayHitData {
 
 impl MapEntities for RayHitData {
     fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
-        self.entity = entity_mapper.map_entity(self.entity);
+        self.entity = entity_mapper.get_mapped(self.entity);
     }
 }

--- a/src/spatial_query/ray_caster.rs
+++ b/src/spatial_query/ray_caster.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use bevy::{
     ecs::{
-        component::ComponentId,
+        component::HookContext,
         entity::{EntityMapper, MapEntities},
         world::DeferredWorld,
     },
@@ -342,8 +342,8 @@ impl RayCaster {
     }
 }
 
-fn on_add_ray_caster(mut world: DeferredWorld, entity: Entity, _component_id: ComponentId) {
-    let ray_caster = world.get::<RayCaster>(entity).unwrap();
+fn on_add_ray_caster(mut world: DeferredWorld, ctx: HookContext) {
+    let ray_caster = world.get::<RayCaster>(ctx.entity).unwrap();
     let max_hits = if ray_caster.max_hits == u32::MAX {
         10
     } else {
@@ -351,7 +351,7 @@ fn on_add_ray_caster(mut world: DeferredWorld, entity: Entity, _component_id: Co
     };
 
     // Initialize capacity for hits
-    world.get_mut::<RayHits>(entity).unwrap().vector = Vec::with_capacity(max_hits);
+    world.get_mut::<RayHits>(ctx.entity).unwrap().vector = Vec::with_capacity(max_hits);
 }
 
 /// Contains the hits of a ray cast by a [`RayCaster`].

--- a/src/spatial_query/shape_caster.rs
+++ b/src/spatial_query/shape_caster.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use bevy::{
     ecs::{
-        component::ComponentId,
+        component::HookContext,
         entity::{EntityMapper, MapEntities},
         world::DeferredWorld,
     },
@@ -408,8 +408,8 @@ impl ShapeCaster {
     }
 }
 
-fn on_add_shape_caster(mut world: DeferredWorld, entity: Entity, _component_id: ComponentId) {
-    let shape_caster = world.get::<ShapeCaster>(entity).unwrap();
+fn on_add_shape_caster(mut world: DeferredWorld, ctx: HookContext) {
+    let shape_caster = world.get::<ShapeCaster>(ctx.entity).unwrap();
     let max_hits = if shape_caster.max_hits == u32::MAX {
         10
     } else {
@@ -417,7 +417,7 @@ fn on_add_shape_caster(mut world: DeferredWorld, entity: Entity, _component_id: 
     };
 
     // Initialize capacity for hits
-    world.get_mut::<ShapeHits>(entity).unwrap().vector = Vec::with_capacity(max_hits);
+    world.get_mut::<ShapeHits>(ctx.entity).unwrap().vector = Vec::with_capacity(max_hits);
 }
 
 /// Configuration for a shape cast.

--- a/src/spatial_query/shape_caster.rs
+++ b/src/spatial_query/shape_caster.rs
@@ -608,6 +608,6 @@ pub struct ShapeHitData {
 
 impl MapEntities for ShapeHitData {
     fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
-        self.entity = entity_mapper.map_entity(self.entity);
+        self.entity = entity_mapper.get_mapped(self.entity);
     }
 }

--- a/src/sync/ancestor_marker.rs
+++ b/src/sync/ancestor_marker.rs
@@ -2,55 +2,33 @@
 
 use std::marker::PhantomData;
 
-use bevy::{
-    ecs::{intern::Interned, schedule::ScheduleLabel},
-    hierarchy::HierarchyEvent,
-    prelude::*,
-};
+use bevy::prelude::*;
 
 /// A plugin that marks the ancestors of entities that have the given component `C`
 /// with the [`AncestorMarker`] component.
 ///
 /// One use case is speeding up transform propagation: we only need to propagate
 /// down trees that have a certain type of entity, like a collider or a rigid body.
-pub struct AncestorMarkerPlugin<C: Component> {
-    schedule: Interned<dyn ScheduleLabel>,
-    system_set: Option<Interned<dyn SystemSet>>,
-    _phantom: PhantomData<C>,
-}
+pub struct AncestorMarkerPlugin<C: Component>(PhantomData<C>);
 
-impl<C: Component> AncestorMarkerPlugin<C> {
-    /// Creates a new [`AncestorMarkerPlugin`] with the schedule that the system
-    /// adding markers should run in.
-    pub fn new(schedule: impl ScheduleLabel) -> Self {
-        Self {
-            schedule: schedule.intern(),
-            system_set: None,
-            _phantom: PhantomData,
-        }
-    }
-
-    /// Configures which system set the system adding the [`AncestorMarker`]s should run in.
-    ///
-    /// Note: Unlike the normal `in_set` for system configurations, this *overwrites* the set,
-    /// so the system can only be added to a single system set at a time.
-    pub fn add_markers_in_set(mut self, set: impl SystemSet) -> Self {
-        self.system_set = Some(set.intern());
-        self
+impl<C: Component> Default for AncestorMarkerPlugin<C> {
+    fn default() -> Self {
+        Self(PhantomData)
     }
 }
 
 impl<C: Component> Plugin for AncestorMarkerPlugin<C> {
     fn build(&self, app: &mut App) {
-        // Add `AncestorMarker<C>` for the ancestors of added colliders,
+        // Add `AncestorMarker<C>` for the ancestors of colliders that are inserted as children,
         // until an ancestor that has other `AncestorMarker<C>` entities as children is encountered.
         app.add_observer(
-            |trigger: Trigger<OnAdd, C>,
+            |trigger: Trigger<OnInsert, ChildOf>,
              mut commands: Commands,
-             parent_query: Query<&Parent>,
+             collider_query: Query<&C>,
+             parent_query: Query<&ChildOf>,
              ancestor_query: Query<(), With<AncestorMarker<C>>>| {
-                let entity = trigger.entity();
-                if parent_query.contains(entity) {
+                let entity = trigger.target();
+                if collider_query.contains(entity) {
                     add_ancestor_markers(
                         entity,
                         &mut commands,
@@ -62,36 +40,25 @@ impl<C: Component> Plugin for AncestorMarkerPlugin<C> {
             },
         );
 
-        // Remove `AncestorMarker<C>` from removed colliders and their ancestors,
+        // Remove `AncestorMarker<C>` from the ancestors of colliders that have been removed or moved to another parent,
         // until an ancestor that has other `AncestorMarker<C>` entities as children is encountered.
         #[allow(clippy::type_complexity)]
         app.add_observer(
-            |trigger: Trigger<OnRemove, C>,
+            |trigger: Trigger<OnReplace, (ChildOf, C)>,
             mut commands: Commands,
+            collider_query: Query<&C>,
             child_query: Query<&Children>,
-            parent_query: Query<&Parent>,
+            parent_query: Query<&ChildOf>,
             ancestor_query: Query<
                 (Entity, Has<C>),
                 Or<(With<AncestorMarker<C>>, With<C>)>
             >| {
-                remove_ancestor_markers(trigger.entity(), &mut commands, &parent_query, &child_query, &ancestor_query, false);
+                let entity = trigger.target();
+                if collider_query.contains(entity) {
+                    remove_ancestor_markers(entity, &mut commands, &parent_query, &child_query, &ancestor_query, false);
+                }
             },
         );
-
-        // Initialize `HierarchyEvent` in case `HierarchyPlugin` is not added.
-        app.add_event::<HierarchyEvent>();
-
-        // Update markers when changes are made to the hierarchy.
-        // TODO: This should be an observer. It'd remove the need for this scheduling nonsense
-        //       and make the implementation more robust.
-        if let Some(set) = self.system_set {
-            app.add_systems(
-                self.schedule,
-                update_markers_on_hierarchy_changes::<C>.in_set(set),
-            );
-        } else {
-            app.add_systems(self.schedule, update_markers_on_hierarchy_changes::<C>);
-        }
     }
 }
 
@@ -119,82 +86,10 @@ impl<C: Component> Default for AncestorMarker<C> {
     }
 }
 
-// TODO: This should be an observer once there is a trigger for hierarchy changes.
-//       See https://github.com/bevyengine/bevy/pull/13925 for an implementation of that trigger.
-/// Marks ancestors of entities that have the given component `C` with the `AncestorMarker<C>` component.
-#[allow(clippy::type_complexity)]
-fn update_markers_on_hierarchy_changes<C: Component>(
-    mut commands: Commands,
-    entity_query: Query<(), With<C>>,
-    parent_query: Query<&Parent>,
-    child_query: Query<&Children>,
-    ancestor_query_1: Query<(), With<AncestorMarker<C>>>,
-    ancestor_query_2: Query<(Entity, Has<C>), Or<(With<AncestorMarker<C>>, With<C>)>>,
-    mut hierarchy_event: EventReader<HierarchyEvent>,
-) {
-    for event in hierarchy_event.read().cloned() {
-        match event {
-            HierarchyEvent::ChildAdded { child, parent } => {
-                if entity_query.contains(child) {
-                    // Mark the child's ancestors.
-                    add_ancestor_markers(
-                        parent,
-                        &mut commands,
-                        &parent_query,
-                        &ancestor_query_1,
-                        true,
-                    );
-                }
-            }
-
-            HierarchyEvent::ChildRemoved { child, parent } => {
-                if entity_query.contains(child) {
-                    // Remove markers from the parent and its ancestors.
-                    remove_ancestor_markers(
-                        parent,
-                        &mut commands,
-                        &parent_query,
-                        &child_query,
-                        &ancestor_query_2,
-                        true,
-                    );
-                }
-            }
-
-            HierarchyEvent::ChildMoved {
-                child,
-                previous_parent,
-                new_parent,
-            } => {
-                if entity_query.contains(child) {
-                    // Remove markers from the previous parent and its ancestors.
-                    remove_ancestor_markers(
-                        previous_parent,
-                        &mut commands,
-                        &parent_query,
-                        &child_query,
-                        &ancestor_query_2,
-                        true,
-                    );
-
-                    // Mark the new parent and its ancestors.
-                    add_ancestor_markers(
-                        new_parent,
-                        &mut commands,
-                        &parent_query,
-                        &ancestor_query_1,
-                        true,
-                    );
-                }
-            }
-        }
-    }
-}
-
 fn add_ancestor_markers<C: Component>(
     entity: Entity,
     commands: &mut Commands,
-    parent_query: &Query<&Parent>,
+    parent_query: &Query<&ChildOf>,
     ancestor_query: &Query<(), With<AncestorMarker<C>>>,
     include_self: bool,
 ) {
@@ -228,7 +123,7 @@ fn remove_component<T: Bundle>(commands: &mut Commands, entity: Entity) {
 fn remove_ancestor_markers<C: Component>(
     entity: Entity,
     commands: &mut Commands,
-    parent_query: &Query<&Parent>,
+    parent_query: &Query<&ChildOf>,
     child_query: &Query<&Children>,
     ancestor_query: &Query<(Entity, Has<C>), Or<(With<AncestorMarker<C>>, With<C>)>>,
     include_self: bool,
@@ -287,10 +182,7 @@ mod tests {
     fn add_and_remove_component() {
         let mut app = App::new();
 
-        app.add_plugins((
-            AncestorMarkerPlugin::<C>::new(FixedPostUpdate),
-            HierarchyPlugin,
-        ));
+        app.add_plugins(AncestorMarkerPlugin::<C>::default());
 
         // Set up an entity tree like the following:
         //
@@ -307,16 +199,14 @@ mod tests {
 
         let an = app.world_mut().spawn_empty().id();
 
-        let bn = app.world_mut().spawn_empty().set_parent(an).id();
-        let cy = app.world_mut().spawn(C).set_parent(an).id();
+        let bn = app.world_mut().spawn(ChildOf(an)).id();
+        let cy = app.world_mut().spawn((C, ChildOf(an))).id();
 
-        let dn = app.world_mut().spawn_empty().set_parent(cy).id();
-        let en = app.world_mut().spawn_empty().set_parent(cy).id();
+        let dn = app.world_mut().spawn(ChildOf(cy)).id();
+        let en = app.world_mut().spawn(ChildOf(cy)).id();
 
-        let fy = app.world_mut().spawn(C).set_parent(dn).id();
-        let gy = app.world_mut().spawn(C).set_parent(dn).id();
-
-        app.world_mut().run_schedule(FixedPostUpdate);
+        let fy = app.world_mut().spawn((C, ChildOf(dn))).id();
+        let gy = app.world_mut().spawn((C, ChildOf(dn))).id();
 
         // Check that the correct entities have the `AncestorMarker<C>` component.
         assert!(app.world().entity(an).contains::<AncestorMarker<C>>());
@@ -331,8 +221,6 @@ mod tests {
         let mut entity_mut = app.world_mut().entity_mut(fy);
         entity_mut.remove::<C>();
 
-        app.world_mut().run_schedule(FixedPostUpdate);
-
         assert!(app.world().entity(dn).contains::<AncestorMarker<C>>());
         assert!(app.world().entity(cy).contains::<AncestorMarker<C>>());
         assert!(app.world().entity(an).contains::<AncestorMarker<C>>());
@@ -341,8 +229,6 @@ mod tests {
         // now be removed from DN and CY, but it should remain on AN.
         let mut entity_mut = app.world_mut().entity_mut(gy);
         entity_mut.remove::<C>();
-
-        app.world_mut().run_schedule(FixedPostUpdate);
 
         assert!(!app.world().entity(dn).contains::<AncestorMarker<C>>());
         assert!(!app.world().entity(cy).contains::<AncestorMarker<C>>());
@@ -353,8 +239,6 @@ mod tests {
         let mut entity_mut = app.world_mut().entity_mut(cy);
         entity_mut.remove::<C>();
 
-        app.world_mut().run_schedule(FixedPostUpdate);
-
         assert!(!app.world().entity(an).contains::<AncestorMarker<C>>());
     }
 
@@ -362,10 +246,7 @@ mod tests {
     fn remove_children() {
         let mut app = App::new();
 
-        app.add_plugins((
-            AncestorMarkerPlugin::<C>::new(FixedPostUpdate),
-            HierarchyPlugin,
-        ));
+        app.add_plugins(AncestorMarkerPlugin::<C>::default());
 
         // Set up an entity tree like the following:
         //
@@ -382,16 +263,14 @@ mod tests {
 
         let an = app.world_mut().spawn_empty().id();
 
-        let bn = app.world_mut().spawn_empty().set_parent(an).id();
-        let cy = app.world_mut().spawn(C).set_parent(an).id();
+        let bn = app.world_mut().spawn(ChildOf(an)).id();
+        let cy = app.world_mut().spawn((C, ChildOf(an))).id();
 
-        let dn = app.world_mut().spawn_empty().set_parent(cy).id();
-        let en = app.world_mut().spawn_empty().set_parent(cy).id();
+        let dn = app.world_mut().spawn(ChildOf(cy)).id();
+        let en = app.world_mut().spawn(ChildOf(cy)).id();
 
-        let fy = app.world_mut().spawn(C).set_parent(dn).id();
-        let gy = app.world_mut().spawn(C).set_parent(dn).id();
-
-        app.world_mut().run_schedule(FixedPostUpdate);
+        let fy = app.world_mut().spawn((C, ChildOf(dn))).id();
+        let gy = app.world_mut().spawn((C, ChildOf(dn))).id();
 
         // Check that the correct entities have the `AncestorMarker<C>` component.
         assert!(app.world().entity(an).contains::<AncestorMarker<C>>());
@@ -403,10 +282,8 @@ mod tests {
         assert!(!app.world().entity(gy).contains::<AncestorMarker<C>>());
 
         // Make FY an orphan.
-        let mut entity_mut = app.world_mut().entity_mut(dn);
-        entity_mut.remove_children(&[fy]);
-
-        app.world_mut().run_schedule(FixedPostUpdate);
+        let mut entity_mut = app.world_mut().entity_mut(fy);
+        entity_mut.remove::<ChildOf>();
 
         assert!(app.world().entity(dn).contains::<AncestorMarker<C>>());
         assert!(app.world().entity(cy).contains::<AncestorMarker<C>>());
@@ -414,10 +291,8 @@ mod tests {
 
         // Make GY an orphan. The `AncestorMarker<C>` marker should
         // now be removed from DN and CY, but it should remain on AN.
-        let mut entity_mut = app.world_mut().entity_mut(dn);
-        entity_mut.remove_children(&[gy]);
-
-        app.world_mut().run_schedule(FixedPostUpdate);
+        let mut entity_mut = app.world_mut().entity_mut(gy);
+        entity_mut.remove::<ChildOf>();
 
         assert!(!app.world().entity(dn).contains::<AncestorMarker<C>>());
         assert!(!app.world().entity(cy).contains::<AncestorMarker<C>>());
@@ -425,10 +300,8 @@ mod tests {
 
         // Make CY an orphan. The `AncestorMarker<C>` marker should
         // now be removed from AN.
-        let mut entity_mut = app.world_mut().entity_mut(an);
-        entity_mut.remove_children(&[cy]);
-
-        app.world_mut().run_schedule(FixedPostUpdate);
+        let mut entity_mut = app.world_mut().entity_mut(cy);
+        entity_mut.remove::<ChildOf>();
 
         assert!(!app.world().entity(an).contains::<AncestorMarker<C>>());
 
@@ -436,26 +309,19 @@ mod tests {
         // now be added to AN.
         let mut entity_mut = app.world_mut().entity_mut(an);
         entity_mut.add_child(cy);
-
-        app.world_mut().run_schedule(FixedPostUpdate);
         assert!(app.world().entity(an).contains::<AncestorMarker<C>>());
 
         // Make CY an orphan and delete AN. This must not crash.
-        let mut entity_mut = app.world_mut().entity_mut(an);
-        entity_mut.remove_children(&[cy]);
+        let mut entity_mut = app.world_mut().entity_mut(cy);
+        entity_mut.remove::<ChildOf>();
         entity_mut.despawn();
-
-        app.world_mut().run_schedule(FixedPostUpdate);
     }
 
     #[test]
     fn move_children() {
         let mut app = App::new();
 
-        app.add_plugins((
-            AncestorMarkerPlugin::<C>::new(FixedPostUpdate),
-            HierarchyPlugin,
-        ));
+        app.add_plugins(AncestorMarkerPlugin::<C>::default());
 
         // Set up an entity tree like the following:
         //
@@ -472,16 +338,14 @@ mod tests {
 
         let an = app.world_mut().spawn_empty().id();
 
-        let bn = app.world_mut().spawn_empty().set_parent(an).id();
-        let cy = app.world_mut().spawn(C).set_parent(an).id();
+        let bn = app.world_mut().spawn(ChildOf(an)).id();
+        let cy = app.world_mut().spawn((C, ChildOf(an))).id();
 
-        let dn = app.world_mut().spawn_empty().set_parent(cy).id();
-        let en = app.world_mut().spawn_empty().set_parent(cy).id();
+        let dn = app.world_mut().spawn(ChildOf(cy)).id();
+        let en = app.world_mut().spawn(ChildOf(cy)).id();
 
-        let fy = app.world_mut().spawn(C).set_parent(dn).id();
-        let gy = app.world_mut().spawn(C).set_parent(dn).id();
-
-        app.world_mut().run_schedule(FixedPostUpdate);
+        let fy = app.world_mut().spawn((C, ChildOf(dn))).id();
+        let gy = app.world_mut().spawn((C, ChildOf(dn))).id();
 
         // Check that the correct entities have the `AncestorMarker<C>` component.
         assert!(app.world().entity(an).contains::<AncestorMarker<C>>());
@@ -496,8 +360,6 @@ mod tests {
         let mut entity_mut = app.world_mut().entity_mut(bn);
         entity_mut.add_child(fy);
 
-        app.world_mut().run_schedule(FixedPostUpdate);
-
         assert!(app.world().entity(bn).contains::<AncestorMarker<C>>());
         assert!(app.world().entity(dn).contains::<AncestorMarker<C>>());
         assert!(app.world().entity(cy).contains::<AncestorMarker<C>>());
@@ -508,8 +370,6 @@ mod tests {
         let mut entity_mut = app.world_mut().entity_mut(bn);
         entity_mut.add_child(gy);
 
-        app.world_mut().run_schedule(FixedPostUpdate);
-
         assert!(!app.world().entity(dn).contains::<AncestorMarker<C>>());
         assert!(!app.world().entity(cy).contains::<AncestorMarker<C>>());
         assert!(app.world().entity(an).contains::<AncestorMarker<C>>());
@@ -519,8 +379,6 @@ mod tests {
         let mut entity_mut = app.world_mut().entity_mut(cy);
         entity_mut.add_children(&[fy, gy]);
 
-        app.world_mut().run_schedule(FixedPostUpdate);
-
         assert!(!app.world().entity(bn).contains::<AncestorMarker<C>>());
         assert!(app.world().entity(cy).contains::<AncestorMarker<C>>());
         assert!(app.world().entity(an).contains::<AncestorMarker<C>>());
@@ -528,7 +386,5 @@ mod tests {
         // Move all children from CY to BN and remove CY. This must not crash.
         let mut entity_mut = app.world_mut().entity_mut(bn);
         entity_mut.add_children(&[dn, en, fy, gy]);
-
-        app.world_mut().run_schedule(FixedPostUpdate);
     }
 }

--- a/src/sync/ancestor_marker.rs
+++ b/src/sync/ancestor_marker.rs
@@ -114,7 +114,7 @@ fn add_ancestor_markers<C: Component>(
 
 /// Remove the component from entity, unless it is already despawned.
 fn remove_component<T: Bundle>(commands: &mut Commands, entity: Entity) {
-    if let Some(mut entity_commands) = commands.get_entity(entity) {
+    if let Ok(mut entity_commands) = commands.get_entity(entity) {
         entity_commands.remove::<T>();
     }
 }
@@ -199,14 +199,14 @@ mod tests {
 
         let an = app.world_mut().spawn_empty().id();
 
-        let bn = app.world_mut().spawn(ChildOf(an)).id();
-        let cy = app.world_mut().spawn((C, ChildOf(an))).id();
+        let bn = app.world_mut().spawn(ChildOf { parent: an }).id();
+        let cy = app.world_mut().spawn((C, ChildOf { parent: an })).id();
 
-        let dn = app.world_mut().spawn(ChildOf(cy)).id();
-        let en = app.world_mut().spawn(ChildOf(cy)).id();
+        let dn = app.world_mut().spawn(ChildOf { parent: cy }).id();
+        let en = app.world_mut().spawn(ChildOf { parent: cy }).id();
 
-        let fy = app.world_mut().spawn((C, ChildOf(dn))).id();
-        let gy = app.world_mut().spawn((C, ChildOf(dn))).id();
+        let fy = app.world_mut().spawn((C, ChildOf { parent: dn })).id();
+        let gy = app.world_mut().spawn((C, ChildOf { parent: dn })).id();
 
         // Check that the correct entities have the `AncestorMarker<C>` component.
         assert!(app.world().entity(an).contains::<AncestorMarker<C>>());
@@ -263,14 +263,14 @@ mod tests {
 
         let an = app.world_mut().spawn_empty().id();
 
-        let bn = app.world_mut().spawn(ChildOf(an)).id();
-        let cy = app.world_mut().spawn((C, ChildOf(an))).id();
+        let bn = app.world_mut().spawn(ChildOf { parent: an }).id();
+        let cy = app.world_mut().spawn((C, ChildOf { parent: an })).id();
 
-        let dn = app.world_mut().spawn(ChildOf(cy)).id();
-        let en = app.world_mut().spawn(ChildOf(cy)).id();
+        let dn = app.world_mut().spawn(ChildOf { parent: cy }).id();
+        let en = app.world_mut().spawn(ChildOf { parent: cy }).id();
 
-        let fy = app.world_mut().spawn((C, ChildOf(dn))).id();
-        let gy = app.world_mut().spawn((C, ChildOf(dn))).id();
+        let fy = app.world_mut().spawn((C, ChildOf { parent: dn })).id();
+        let gy = app.world_mut().spawn((C, ChildOf { parent: dn })).id();
 
         // Check that the correct entities have the `AncestorMarker<C>` component.
         assert!(app.world().entity(an).contains::<AncestorMarker<C>>());
@@ -338,14 +338,14 @@ mod tests {
 
         let an = app.world_mut().spawn_empty().id();
 
-        let bn = app.world_mut().spawn(ChildOf(an)).id();
-        let cy = app.world_mut().spawn((C, ChildOf(an))).id();
+        let bn = app.world_mut().spawn(ChildOf { parent: an }).id();
+        let cy = app.world_mut().spawn((C, ChildOf { parent: an })).id();
 
-        let dn = app.world_mut().spawn(ChildOf(cy)).id();
-        let en = app.world_mut().spawn(ChildOf(cy)).id();
+        let dn = app.world_mut().spawn(ChildOf { parent: cy }).id();
+        let en = app.world_mut().spawn(ChildOf { parent: cy }).id();
 
-        let fy = app.world_mut().spawn((C, ChildOf(dn))).id();
-        let gy = app.world_mut().spawn((C, ChildOf(dn))).id();
+        let fy = app.world_mut().spawn((C, ChildOf { parent: dn })).id();
+        let gy = app.world_mut().spawn((C, ChildOf { parent: dn })).id();
 
         // Check that the correct entities have the `AncestorMarker<C>` component.
         assert!(app.world().entity(an).contains::<AncestorMarker<C>>());

--- a/src/sync/ancestor_marker.rs
+++ b/src/sync/ancestor_marker.rs
@@ -102,7 +102,6 @@ fn add_ancestor_markers<C: Component>(
     // Traverse up the tree, marking entities with `AncestorMarker<C>`
     // until an entity that already has it is encountered.
     for parent_entity in parent_query.iter_ancestors(entity) {
-        println!("parent_entity: {:?}", parent_entity);
         if ancestor_query.contains(parent_entity) {
             break;
         } else {

--- a/src/sync/ancestor_marker.rs
+++ b/src/sync/ancestor_marker.rs
@@ -22,7 +22,7 @@ impl<C: Component> Plugin for AncestorMarkerPlugin<C> {
         // Add `AncestorMarker<C>` for the ancestors of colliders that are inserted as children,
         // until an ancestor that has other `AncestorMarker<C>` entities as children is encountered.
         app.add_observer(
-            |trigger: Trigger<OnInsert, ChildOf>,
+            |trigger: Trigger<OnInsert, (ChildOf, C)>,
              mut commands: Commands,
              collider_query: Query<&C>,
              parent_query: Query<&ChildOf>,
@@ -102,6 +102,7 @@ fn add_ancestor_markers<C: Component>(
     // Traverse up the tree, marking entities with `AncestorMarker<C>`
     // until an entity that already has it is encountered.
     for parent_entity in parent_query.iter_ancestors(entity) {
+        println!("parent_entity: {:?}", parent_entity);
         if ancestor_query.contains(parent_entity) {
             break;
         } else {

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -148,7 +148,7 @@ pub struct SyncConfig {
     /// Updates [`Collider::scale()`] based on transform changes,
     /// allowing you to scale colliders using [`Transform`]. Defaults to true.
     ///
-    /// This operation is run in [`PrepareSet::Finalize`]
+    /// This operation is run in [`PrepareSet::Finalize`](crate::prepare::PrepareSet::Finalize).
     pub transform_to_collider_scale: bool,
 }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -130,7 +130,7 @@ fn body_with_velocity_moves() {
 
     let mut app_query = app.world_mut().query::<(&Transform, &RigidBody)>();
 
-    let (transform, _body) = app_query.single(app.world());
+    let (transform, _body) = app_query.single(app.world()).unwrap();
 
     assert_relative_eq!(transform.translation.y, 0.);
     assert_relative_eq!(transform.translation.z, 0.);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,6 +2,8 @@
 
 use crate::prelude::*;
 
+pub(crate) use bevy::platform_support::time::Instant;
+
 /// Computes translation of `Position` based on center of mass rotation and translation
 pub(crate) fn get_pos_translation(
     com_translation: &AccumulatedTranslation,


### PR DESCRIPTION
# Objective

The first release candidate for Bevy 0.16 has been released! We should migrate our main branch to it for early adopters, and to benefit from the various new features it introduces.

## Solution

Migrate to Bevy 0.16.0-rc.1. Most changes were largely mechanical or minor cleanup, but some larger changes were also required.

The most notable change is that 0.16 removed the `HierarchyEvent`, so the `AncestorMarkerPlugin` had to be reworked. It now uses only observers instead of also using some systems, which significantly simplifies code and makes things more robust and schedule-free.

I also replaced some `HashSet<Entity>` types with `EntityHashSet` and `HashMap<Entity>` types with `EntityHashMap`.

## Follow-Up

This is only a bare-bones migration to get Avian working with the Bevy 0.16 RC. We should take advantage of the new features! 

Some ideas:

- `no_std` support
- Change `ColliderParent` to a relationship-like immutable `ColliderOf` component driven by hooks
- Rework collider debug rendering to use retained gizmos
- Migrate examples to the improved spawning API

---

## Migration Guide

Avian now supports Bevy 0.16.

The `AncestorMarkerPlugin` no longer requires a schedule or system set.