### PR TITLE
fix 2d examples not compiling

### DIFF
--- a/crates/examples_common_2d/Cargo.toml
+++ b/crates/examples_common_2d/Cargo.toml
@@ -8,6 +8,7 @@ use-debug-plugin = []
 
 [dependencies]
 bevy = { version = "0.16.0-rc.1", default-features = false, features = [
+    "bevy_animation",
     "bevy_core_pipeline",
     "bevy_state",
     "bevy_text",


### PR DESCRIPTION
# Objective

- fix 2d examples not compiling, error was: 
```
$ cargo run --example $ANY_AVIAN2D_EXAMPLE
error[E0433]: failed to resolve: use of undeclared type `Animatable`
   --> crates/avian2d/../../src/diagnostics/ui.rs:434:24
    |
434 |         text_color.0 = Animatable::interpolate(&green, &red, t.min(1.0)).into();
    |                        ^^^^^^^^^^ use of undeclared type `Animatable`
```

## Solution

- add `bevy_animation` to bevy feature flags in `examples_common_2d` 


