### PR TITLE
Fix panic caused by despawning entity with `ColliderOf`

### DIFF
--- a/src/collision/collider/backend.rs
+++ b/src/collision/collider/backend.rs
@@ -183,7 +183,7 @@ impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
                 world
                     .commands()
                     .entity(ctx.entity)
-                    .remove::<ColliderMarker>();
+                    .try_remove::<ColliderMarker>();
 
                 let entity_ref = world.entity_mut(ctx.entity);
 

--- a/src/collision/collider/collider_hierarchy/plugin.rs
+++ b/src/collision/collider/collider_hierarchy/plugin.rs
@@ -36,7 +36,7 @@ impl Plugin for ColliderHierarchyPlugin {
 
                 // Make sure the collider is on the same entity as the rigid body.
                 if query.contains(entity) {
-                    commands.entity(entity).remove::<ColliderOf>();
+                    commands.entity(entity).try_remove::<ColliderOf>();
                 }
             },
         );
@@ -117,7 +117,7 @@ fn on_rigid_body_removed(
         for collider_entity in colliders.iter() {
             commands
                 .entity(collider_entity)
-                .remove::<(ColliderOf, ColliderTransform)>();
+                .try_remove::<(ColliderOf, ColliderTransform)>();
         }
     }
 }


### PR DESCRIPTION
# Objective

Fixes #676.

#671 changed the `ColliderParent` component to a `ColliderOf` relationship. Because Bevy does not normally allow relationships to point to their own entities, this required a partial manual implementation of the `Relationship` trait. However, I left the default `on_replace` implementation, which (as it turns out) panics if the target entity does not exist, which is possible when despawning an entity and the relationship points to itself.

## Solution

Manually implement `on_replace` in a non-panicking way. Also replace some panicking uses of `remove` with `try_remove`.

Ideally this would be fixed by Bevy allowing self-relationships though.