### PR TITLE
Rename `Contacts` to `ContactPair`

### DIFF
--- a/crates/avian2d/examples/one_way_platform_2d.rs
+++ b/crates/avian2d/examples/one_way_platform_2d.rs
@@ -244,7 +244,7 @@ impl CollisionHooks for PlatformerCollisionHooks<'_, '_> {
     /// Even if an entity is changed to [`PassThroughOneWayPlatform::Never`], it will be allowed to pass
     /// through a [`OneWayPlatform`] if it is already penetrating the platform. Once it exits the platform,
     /// it will no longer be allowed to pass through.
-    fn modify_contacts(&self, contacts: &mut Contacts, commands: &mut Commands) -> bool {
+    fn modify_contacts(&self, contacts: &mut ContactPair, commands: &mut Commands) -> bool {
         // This is the contact modification hook, called after collision detection,
         // but before constraints are created for the solver. Mutable access to the ECS
         // is not allowed, but we can queue commands to perform deferred changes.

--- a/crates/avian3d/examples/conveyor_belt.rs
+++ b/crates/avian3d/examples/conveyor_belt.rs
@@ -38,14 +38,14 @@ struct ConveyorHooks<'w, 's> {
 
 // Implement the `CollisionHooks` trait for our custom system parameter.
 impl CollisionHooks for ConveyorHooks<'_, '_> {
-    fn modify_contacts(&self, contact_pair: &mut Contacts, _commands: &mut Commands) -> bool {
+    fn modify_contacts(&self, contacts: &mut ContactPair, _commands: &mut Commands) -> bool {
         // Get the conveyor belt and its global transform.
         // We don't know which entity is the conveyor belt, if any, so we need to check both.
         // This also affects the sign used for the conveyor belt's speed to apply it in the correct direction.
         let (Ok((conveyor_belt, global_transform)), sign) = self
             .conveyor_query
-            .get(contact_pair.entity1)
-            .map_or((self.conveyor_query.get(contact_pair.entity2), 1.0), |q| {
+            .get(contacts.entity1)
+            .map_or((self.conveyor_query.get(contacts.entity2), 1.0), |q| {
                 (Ok(q), -1.0)
             })
         else {
@@ -59,7 +59,7 @@ impl CollisionHooks for ConveyorHooks<'_, '_> {
 
         // Iterate over all contact surfaces between the conveyor belt and the other collider,
         // and apply a relative velocity to simulate the movement of the conveyor belt's surface.
-        for manifold in contact_pair.manifolds.iter_mut() {
+        for manifold in contacts.manifolds.iter_mut() {
             let tangent_velocity = sign * conveyor_belt.speed * direction;
             manifold.tangent_velocity = tangent_velocity.adjust_precision();
         }

--- a/crates/avian3d/examples/custom_broad_phase.rs
+++ b/crates/avian3d/examples/custom_broad_phase.rs
@@ -92,7 +92,7 @@ fn collect_collision_pairs(
             // The narrow phase will determine if the entities are touching and compute contact data.
             // NOTE: To handle sensors, collision hooks, and child colliders, you may need to configure
             //       `flags` and other properties of the contact pair. This is not done here for simplicity.
-            collisions.add_pair_with_key(Contacts::new(entity1, entity2), key);
+            collisions.add_pair_with_key(ContactPair::new(entity1, entity2), key);
         }
     }
 }

--- a/src/collision/broad_phase.rs
+++ b/src/collision/broad_phase.rs
@@ -327,7 +327,7 @@ fn sweep_and_prune<H: CollisionHooks>(
 
             // Create a new contact pair as non-touching.
             // The narrow phase will determine if the entities are touching and compute contact data.
-            let mut contacts = Contacts::new(*entity1, *entity2);
+            let mut contacts = ContactPair::new(*entity1, *entity2);
 
             // Initialize flags and other data for the contact pair.
             contacts.body_entity1 = Some(collider_of1.rigid_body);

--- a/src/collision/contact_types/contact_graph.rs
+++ b/src/collision/contact_types/contact_graph.rs
@@ -7,7 +7,7 @@ use crate::data_structures::{
 use crate::prelude::*;
 use bevy::{platform_support::collections::HashSet, prelude::*};
 
-use super::{ContactPairFlags, ContactPair};
+use super::{ContactPair, ContactPairFlags};
 
 /// A resource that stores all contact pairs in the physics world
 /// in an [undirected graph](UnGraph).
@@ -206,7 +206,10 @@ impl ContactGraph {
     ///
     /// Use [`ContactPair::is_touching`](ContactPair::is_touching) to determine if the actual collider shapes are touching.
     #[inline]
-    pub fn collisions_with_mut(&mut self, entity: Entity) -> impl Iterator<Item = &mut ContactPair> {
+    pub fn collisions_with_mut(
+        &mut self,
+        entity: Entity,
+    ) -> impl Iterator<Item = &mut ContactPair> {
         if let Some(&index) = self.entity_graph_index.get(entity) {
             self.internal.edge_weights_mut(index)
         } else {

--- a/src/collision/contact_types/mod.rs
+++ b/src/collision/contact_types/mod.rs
@@ -19,7 +19,7 @@ use bevy::prelude::*;
 /// are overlapping, even if the colliders themselves are not touching.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
-pub struct Contacts {
+pub struct ContactPair {
     /// The first collider entity in the contact.
     pub entity1: Entity,
     /// The second collider entity in the contact.
@@ -36,7 +36,7 @@ pub struct Contacts {
     pub flags: ContactPairFlags,
 }
 
-/// Flags indicating the status and type of a [contact pair](Contacts).
+/// Flags indicating the status and type of a [contact pair](ContactPair).
 #[repr(transparent)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Hash, Clone, Copy, PartialEq, Eq, Debug, Reflect)]
@@ -62,8 +62,8 @@ bitflags::bitflags! {
     }
 }
 
-impl Contacts {
-    /// Creates a new [`Contacts`] with the given entities.
+impl ContactPair {
+    /// Creates a new [`ContactPair`] with the given entities.
     #[inline]
     pub fn new(entity1: Entity, entity2: Entity) -> Self {
         Self {

--- a/src/collision/contact_types/system_param.rs
+++ b/src/collision/contact_types/system_param.rs
@@ -1,7 +1,7 @@
 use crate::data_structures::pair_key::PairKey;
 use bevy::{ecs::system::SystemParam, prelude::*};
 
-use super::{ContactGraph, ContactPairFlags, Contacts};
+use super::{ContactGraph, ContactPairFlags, ContactPair};
 
 /// A [`SystemParam`] for accessing and querying collision data.
 ///
@@ -68,7 +68,7 @@ impl Collisions<'_> {
     /// Returns a touching contact pair between two entities.
     /// If the pair does not exist, `None` is returned.
     #[inline]
-    pub fn get(&self, entity1: Entity, entity2: Entity) -> Option<&Contacts> {
+    pub fn get(&self, entity1: Entity, entity2: Entity) -> Option<&ContactPair> {
         self.graph.get(entity1, entity2)
     }
 
@@ -91,7 +91,7 @@ impl Collisions<'_> {
 
     /// Returns an iterator yielding immutable access to all touching contact pairs.
     #[inline]
-    pub fn iter(&self) -> impl Iterator<Item = &Contacts> {
+    pub fn iter(&self) -> impl Iterator<Item = &ContactPair> {
         self.graph
             .iter()
             .filter(|contacts| contacts.flags.contains(ContactPairFlags::TOUCHING))
@@ -100,7 +100,7 @@ impl Collisions<'_> {
     /// Returns an iterator yielding immutable access to all touching contact pairs
     /// involving the given entity.
     #[inline]
-    pub fn collisions_with(&self, entity: Entity) -> impl Iterator<Item = &Contacts> {
+    pub fn collisions_with(&self, entity: Entity) -> impl Iterator<Item = &ContactPair> {
         self.graph
             .collisions_with(entity)
             .filter(|contacts| contacts.is_touching())

--- a/src/collision/contact_types/system_param.rs
+++ b/src/collision/contact_types/system_param.rs
@@ -1,7 +1,7 @@
 use crate::data_structures::pair_key::PairKey;
 use bevy::{ecs::system::SystemParam, prelude::*};
 
-use super::{ContactGraph, ContactPairFlags, ContactPair};
+use super::{ContactGraph, ContactPair, ContactPairFlags};
 
 /// A [`SystemParam`] for accessing and querying collision data.
 ///

--- a/src/collision/hooks.rs
+++ b/src/collision/hooks.rs
@@ -61,7 +61,7 @@ use bevy::{ecs::system::ReadOnlySystemParam, prelude::*};
 ///         group1.0 == group2.0
 ///     }
 ///
-///     fn modify_contacts(&self, contacts: &mut Contacts, _commands: &mut Commands) -> bool {
+///     fn modify_contacts(&self, contacts: &mut ContactPair, _commands: &mut Commands) -> bool {
 ///         // Allow entities to pass through the bottom and sides of one-way platforms.
 ///         // See the `one_way_platform_2d` example for a full implementation.
 ///         let (entity1, entity2) = (contacts.entity1, contacts.entity2);
@@ -73,7 +73,7 @@ use bevy::{ecs::system::ReadOnlySystemParam, prelude::*};
 /// #     entity1: Entity,
 /// #     entity2: Entity,
 /// #     platform_query: &Query<&Transform, With<OneWayPlatform>>,
-/// #     contacts: &Contacts,
+/// #     contacts: &ContactPair,
 /// # ) -> bool {
 /// #     todo!()
 /// # }
@@ -148,7 +148,7 @@ pub trait CollisionHooks: ReadOnlySystemParam + Send + Sync {
     /// A contact pair filtering hook that determines whether contacts should be computed
     /// between `entity1` and `entity2`. If `false` is returned, contacts will not be computed.
     ///
-    /// This is called in the broad phase, before [`Contacts`] have been computed for the pair.
+    /// This is called in the broad phase, before the [`ContactPair`] has been computed.
     ///
     /// The provided [`Commands`] can be used for deferred ECS operations that run after
     /// broad phase pairs have been found.
@@ -166,11 +166,11 @@ pub trait CollisionHooks: ReadOnlySystemParam + Send + Sync {
     /// A contact modification hook that allows modifying the contacts for a given contact pair.
     /// If `false` is returned, the contact pair will be removed.
     ///
-    /// This is called in the narrow phase, after [`Contacts`] have been computed for the pair,
+    /// This is called in the narrow phase, after the [`ContactPair`] has been computed for the pair,
     /// but before constraints have been generated for the contact solver.
     ///
     /// The provided [`Commands`] can be used for deferred ECS operations that run after
-    /// narrow phase [`Contacts`] have been computed and constraints have been generated.
+    /// the narrow phase has computed contact pairs and generated constraints.
     ///
     /// # Notes
     ///
@@ -180,7 +180,7 @@ pub trait CollisionHooks: ReadOnlySystemParam + Send + Sync {
     /// - Command execution order is unspecified if the `parallel` feature is enabled.
     /// - Access to the [`ContactGraph`] resource is not allowed in this method.
     ///   Trying to access it will result in a panic.
-    fn modify_contacts(&self, contacts: &mut Contacts, commands: &mut Commands) -> bool {
+    fn modify_contacts(&self, contacts: &mut ContactPair, commands: &mut Commands) -> bool {
         true
     }
 }

--- a/src/collision/narrow_phase/system_param.rs
+++ b/src/collision/narrow_phase/system_param.rs
@@ -555,7 +555,7 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
     pub fn generate_constraints(
         &self,
         contact_pair_index: usize,
-        contacts: &Contacts,
+        contacts: &ContactPair,
         constraints: &mut Vec<ContactConstraint>,
         body1: &RigidBodyQueryReadOnlyItem,
         body2: &RigidBodyQueryReadOnlyItem,

--- a/src/debug_render/mod.rs
+++ b/src/debug_render/mod.rs
@@ -25,13 +25,13 @@ use bevy::{
 /// - [AABBs](ColliderAabb)
 /// - [Collider] wireframes
 /// - Using different colors for [sleeping](Sleeping) bodies
-/// - [Contacts]
+/// - [Contacts](ContactPair)
 /// - [Joints](dynamics::solver::joints)
 /// - [`RayCaster`]
 /// - [`ShapeCaster`]
 /// - Changing the visibility of entities to only show debug rendering
 ///
-/// By default, [AABBs](ColliderAabb) and [contacts](Contacts) are not debug rendered.
+/// By default, [AABBs](ColliderAabb) and [contacts](ContactPair) are not debug rendered.
 /// You can configure the [`PhysicsGizmos`] retrieved from `GizmoConfigStore` for the global configuration
 /// and the [`DebugRender`] component for entity-level configuration.
 ///

--- a/src/diagnostics/ui.rs
+++ b/src/diagnostics/ui.rs
@@ -188,7 +188,7 @@ fn build_diagnostic_texts(cmd: &mut RelatedSpawnerCommands<ChildOf>) {
         // Other counters
         cmd.counter_text("Colliders", PhysicsEntityDiagnostics::COLLIDER_COUNT);
         cmd.counter_text("Joints", PhysicsEntityDiagnostics::JOINT_COUNT);
-        cmd.counter_text("Contacts", CollisionDiagnostics::CONTACT_COUNT);
+        cmd.counter_text("Contact Pairs", CollisionDiagnostics::CONTACT_COUNT);
         cmd.counter_text(
             "Contact Constraints",
             SolverDiagnostics::CONTACT_CONSTRAINT_COUNT,

--- a/src/dynamics/solver/contact/mod.rs
+++ b/src/dynamics/solver/contact/mod.rs
@@ -87,7 +87,7 @@ pub struct ContactConstraint {
     pub points: Vec<ContactConstraintPoint>,
     /// The index of the contact pair in the [`ContactGraph`].
     pub contact_pair_index: usize,
-    /// The index of the [`ContactManifold`] in the [`Contacts`] stored for the two bodies.
+    /// The index of the [`ContactManifold`] in the [`ContactPair`] stored for the two bodies.
     pub manifold_index: usize,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -530,8 +530,8 @@ pub mod prelude {
             },
             collision_events::{CollisionEnded, CollisionEventsEnabled, CollisionStarted},
             contact_types::{
-                Collisions, ContactGraph, ContactManifold, ContactPairFlags, ContactPoint,
-                Contacts, SingleContact,
+                Collisions, ContactGraph, ContactManifold, ContactPair, ContactPairFlags,
+                ContactPoint, SingleContact,
             },
             hooks::{ActiveCollisionHooks, CollisionHooks},
             narrow_phase::{NarrowPhaseConfig, NarrowPhasePlugin},


### PR DESCRIPTION
# Objective

Especially after #683, we use the term "contact pair" a lot. However, the contact pair type is called `Contacts`. This name is very ambiguous: does it represent all contacts in the world, all contacts between two entities, contacts belonging to a specific contact surface, or something else?

## Solution

Rename `Contacts` to `ContactPair`. It much more accurately describes what the type represents: contact data for a pair of entities that may be in contact. This is also the name used by Rapier.

---

## Migration Guide

`Contacts` has been renamed to `ContactPair`.