### PR TITLE
Create thread-local contact status bit vecs with correct block count

### DIFF
--- a/src/collision/narrow_phase/system_param.rs
+++ b/src/collision/narrow_phase/system_param.rs
@@ -301,7 +301,13 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                 // Get the thread-local bit vector for tracking status changes.
                 let mut state_change_bits = self
                     .contact_status_bits_thread_local
-                    .get_or(|| RefCell::new(BitVec::new(contact_pair_count)))
+                    .get_or(|| {
+                        // No thread-local bit vector exists for this thread yet.
+                        // Create a new one with the same capacity as the global bit vector.
+                        let mut bit_vec = BitVec::new(contact_pair_count);
+                        bit_vec.set_bit_count_and_clear(contact_pair_count);
+                        RefCell::new(bit_vec)
+                    })
                     .borrow_mut();
 
                 let contacts = &mut contacts.weight;

--- a/src/data_structures/bit_vec.rs
+++ b/src/data_structures/bit_vec.rs
@@ -117,7 +117,12 @@ impl BitVec {
     /// Performs an in-place bitwise OR operation with another [`BitVec`].
     #[inline]
     pub fn or(&mut self, other: &Self) {
-        debug_assert!(self.block_count == other.block_count);
+        debug_assert!(
+            self.block_count == other.block_count,
+            "block counts do not match for `BitVec::or` ({} != {})",
+            self.block_count,
+            other.block_count
+        );
 
         for i in 0..self.block_count {
             self.blocks[i] |= other.blocks[i];


### PR DESCRIPTION
# Objective

Fixes #687.

The narrow phase is currently initializing the thread-local contact status bit vectors with a block count of zero. This means that for the first tick, contact status changes might not be tracked correctly. The bitwise OR to combine the bit vectors also currently panics with debug assertions enabled, because the sizes of the vectors don't match.

## Solution

Initialize thread-local contact status bit vectors with the correct block count.

I also improved the error message for the debug assertion in `BitVec::or`.