### PR TITLE
Fix removing colliders from contact graph `EntityDataIndex`

### DIFF
--- a/src/collision/contact_types/contact_graph.rs
+++ b/src/collision/contact_types/contact_graph.rs
@@ -377,7 +377,9 @@ impl ContactGraph {
     where
         F: FnMut(ContactPair),
     {
-        let Some(&index) = self.entity_graph_index.get(entity) else {
+        // Remove the entity from the entity graph index,
+        // and get the index of the node in the graph.
+        let Some(index) = self.entity_graph_index.remove(entity, NodeIndex::END) else {
             return;
         };
 


### PR DESCRIPTION
# Objective

When a collider is removed from the contact graph, the `EntityDataIndex` used for mapping entities to graph nodes is not updated. This can cause bugs and even crashes when an entity with the same index is removed and later added back to the graph.

## Solution

Remove colliders from the `EntityDataIndex` in `ContactGraph::remove_collider_with`.