### PR TITLE
Refactor ChildOf from named to tuple struct

### DIFF
--- a/crates/avian2d/Cargo.toml
+++ b/crates/avian2d/Cargo.toml
@@ -73,11 +73,11 @@ bench = false
 
 [dependencies]
 avian_derive = { path = "../avian_derive", version = "0.2" }
-bevy = { version = "0.16.0-rc.2", default-features = false, features = [
+bevy = { version = "0.16.0-rc", default-features = false, features = [
     "std",
     "bevy_log",
 ] }
-bevy_math = { version = "0.16.0-rc.2" }
+bevy_math = { version = "0.16.0-rc" }
 bevy_heavy = { git = "https://github.com/Jondolf/bevy_heavy" }
 bevy_transform_interpolation = { git = "https://github.com/Jondolf/bevy_transform_interpolation" }
 libm = { version = "0.2", optional = true }
@@ -94,7 +94,7 @@ thread_local = { version = "1.1", optional = true }
 [dev-dependencies]
 examples_common_2d = { path = "../examples_common_2d" }
 benches_common_2d = { path = "../benches_common_2d" }
-bevy_math = { version = "0.16.0-rc.2", features = ["approx"] }
+bevy_math = { version = "0.16.0-rc", features = ["approx"] }
 bevy_heavy = { git = "https://github.com/Jondolf/bevy_heavy", features = [
     "approx",
 ] }

--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -75,11 +75,11 @@ bench = false
 
 [dependencies]
 avian_derive = { path = "../avian_derive", version = "0.2" }
-bevy = { version = "0.16.0-rc.2", default-features = false, features = [
+bevy = { version = "0.16.0-rc", default-features = false, features = [
     "std",
     "bevy_log",
 ] }
-bevy_math = { version = "0.16.0-rc.2" }
+bevy_math = { version = "0.16.0-rc" }
 bevy_heavy = { git = "https://github.com/Jondolf/bevy_heavy" }
 bevy_transform_interpolation = { git = "https://github.com/Jondolf/bevy_transform_interpolation" }
 libm = { version = "0.2", optional = true }
@@ -96,11 +96,11 @@ thread_local = { version = "1.1", optional = true }
 [dev-dependencies]
 examples_common_3d = { path = "../examples_common_3d" }
 benches_common_3d = { path = "../benches_common_3d" }
-bevy = { version = "0.16.0-rc.2", default-features = false, features = [
+bevy = { version = "0.16.0-rc", default-features = false, features = [
     "bevy_gltf",
     "animation",
 ] }
-bevy_math = { version = "0.16.0-rc.2", features = ["approx"] }
+bevy_math = { version = "0.16.0-rc", features = ["approx"] }
 bevy_heavy = { git = "https://github.com/Jondolf/bevy_heavy", features = [
     "approx",
 ] }

--- a/crates/benches_common_2d/Cargo.toml
+++ b/crates/benches_common_2d/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = { version = "0.16.0-rc.2", default-features = false }
+bevy = { version = "0.16.0-rc", default-features = false }
 avian2d = { path = "../avian2d", default-features = false }
 criterion = "0.5"
 

--- a/crates/benches_common_3d/Cargo.toml
+++ b/crates/benches_common_3d/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = { version = "0.16.0-rc.2", default-features = false }
+bevy = { version = "0.16.0-rc", default-features = false }
 avian3d = { path = "../avian3d", default-features = false }
 criterion = "0.5"
 

--- a/crates/examples_common_2d/Cargo.toml
+++ b/crates/examples_common_2d/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 use-debug-plugin = []
 
 [dependencies]
-bevy = { version = "0.16.0-rc.2", default-features = false, features = [
+bevy = { version = "0.16.0-rc", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_state",
     "bevy_text",

--- a/crates/examples_common_3d/Cargo.toml
+++ b/crates/examples_common_3d/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 use-debug-plugin = []
 
 [dependencies]
-bevy = { version = "0.16.0-rc.2", default-features = false, features = [
+bevy = { version = "0.16.0-rc", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_state",
     "bevy_text",

--- a/src/collision/collider/backend.rs
+++ b/src/collision/collider/backend.rs
@@ -126,7 +126,7 @@ impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
                 let parent_global_transform = world
                     .entity(ctx.entity)
                     .get::<ChildOf>()
-                    .and_then(|&ChildOf { parent }| {
+                    .and_then(|&ChildOf(parent)| {
                         world.entity(parent).get::<GlobalTransform>().copied()
                     })
                     .unwrap_or_default();
@@ -713,7 +713,7 @@ mod tests {
             .spawn((
                 collider,
                 Transform::from_xyz(1.0, 0.0, 0.0),
-                ChildOf { parent },
+                ChildOf(parent),
             ))
             .id();
 

--- a/src/collision/collider/collider_transform/plugin.rs
+++ b/src/collision/collider/collider_transform/plugin.rs
@@ -144,7 +144,7 @@ pub(crate) fn propagate_collider_transforms(
         |(entity, transform, children)| {
             for (child, child_transform, is_child_rb, child_of) in parent_query.iter_many(children) {
                 assert_eq!(
-                    child_of.parent, entity,
+                    child_of.parent(), entity,
                     "Malformed hierarchy. This probably means that your hierarchy has been improperly maintained, or contains a cycle"
                 );
                 let changed = transform.is_changed() || child_of.is_changed();
@@ -155,7 +155,7 @@ pub(crate) fn propagate_collider_transforms(
                 // SAFETY:
                 // - `child` must have consistent parentage, or the above assertion would panic.
                 // Since `child` is parented to a root entity, the entire hierarchy leading to it is consistent.
-                // - We may operate as if all descendants are consistent, since `propagate_collider_transform_recursive` will panic before 
+                // - We may operate as if all descendants are consistent, since `propagate_collider_transform_recursive` will panic before
                 //   continuing to propagate if it encounters an entity with inconsistent parentage.
                 // - Since each root entity is unique and the hierarchy is consistent and forest-like,
                 //   other root entities' `propagate_collider_transform_recursive` calls will not conflict with this one.
@@ -264,7 +264,7 @@ unsafe fn propagate_collider_transforms_recursive(
     let Some(children) = children else { return };
     for (child, child_transform, is_rb, child_of) in parent_query.iter_many(children) {
         assert_eq!(
-            child_of.parent, entity,
+            child_of.parent(), entity,
             "Malformed hierarchy. This probably means that your hierarchy has been improperly maintained, or contains a cycle"
         );
 

--- a/src/dynamics/rigid_body/mass_properties/mod.rs
+++ b/src/dynamics/rigid_body/mass_properties/mod.rs
@@ -734,13 +734,7 @@ mod tests {
 
         let child_entity = app
             .world_mut()
-            .spawn((
-                ChildOf {
-                    parent: body_entity,
-                },
-                child_collider,
-                ColliderDensity(1.0),
-            ))
+            .spawn((ChildOf(body_entity), child_collider, ColliderDensity(1.0)))
             .id();
 
         app.world_mut().run_schedule(FixedPostUpdate);
@@ -844,9 +838,7 @@ mod tests {
         let child_entity = app
             .world_mut()
             .spawn((
-                ChildOf {
-                    parent: body_entity,
-                },
+                ChildOf(body_entity),
                 Collider::circle(1.0),
                 Mass(5.0),
                 Transform::default(),

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -168,7 +168,7 @@ pub fn init_transforms<C: Component>(
     for (entity, transform, global_transform, pos, rot, previous_rot, parent, has_rigid_body) in
         &query
     {
-        let parent_transforms = parent.and_then(|&ChildOf { parent }| parents.get(parent).ok());
+        let parent_transforms = parent.and_then(|&ChildOf(parent)| parents.get(parent).ok());
         let parent_pos = parent_transforms.and_then(|(pos, _, _)| pos);
         let parent_rot = parent_transforms.and_then(|(_, rot, _)| rot);
         let parent_global_trans = parent_transforms.and_then(|(_, _, trans)| trans);

--- a/src/spatial_query/mod.rs
+++ b/src/spatial_query/mod.rs
@@ -274,7 +274,7 @@ fn update_ray_caster_positions(
         }
 
         if let Some(Ok((parent_position, parent_rotation, parent_transform))) =
-            parent.map(|&ChildOf { parent }| parents.get(parent))
+            parent.map(|&ChildOf(parent)| parents.get(parent))
         {
             let parent_position = parent_position
                 .copied()
@@ -362,7 +362,7 @@ fn update_shape_caster_positions(
         }
 
         if let Some(Ok((parent_position, parent_rotation, parent_transform))) =
-            parent.map(|&ChildOf { parent }| parents.get(parent))
+            parent.map(|&ChildOf(parent)| parents.get(parent))
         {
             let parent_position = parent_position
                 .copied()

--- a/src/sync/ancestor_marker.rs
+++ b/src/sync/ancestor_marker.rs
@@ -199,14 +199,14 @@ mod tests {
 
         let an = app.world_mut().spawn_empty().id();
 
-        let bn = app.world_mut().spawn(ChildOf { parent: an }).id();
-        let cy = app.world_mut().spawn((C, ChildOf { parent: an })).id();
+        let bn = app.world_mut().spawn(ChildOf(an)).id();
+        let cy = app.world_mut().spawn((C, ChildOf(an))).id();
 
-        let dn = app.world_mut().spawn(ChildOf { parent: cy }).id();
-        let en = app.world_mut().spawn(ChildOf { parent: cy }).id();
+        let dn = app.world_mut().spawn(ChildOf(cy)).id();
+        let en = app.world_mut().spawn(ChildOf(cy)).id();
 
-        let fy = app.world_mut().spawn((C, ChildOf { parent: dn })).id();
-        let gy = app.world_mut().spawn((C, ChildOf { parent: dn })).id();
+        let fy = app.world_mut().spawn((C, ChildOf(dn))).id();
+        let gy = app.world_mut().spawn((C, ChildOf(dn))).id();
 
         // Check that the correct entities have the `AncestorMarker<C>` component.
         assert!(app.world().entity(an).contains::<AncestorMarker<C>>());
@@ -263,14 +263,14 @@ mod tests {
 
         let an = app.world_mut().spawn_empty().id();
 
-        let bn = app.world_mut().spawn(ChildOf { parent: an }).id();
-        let cy = app.world_mut().spawn((C, ChildOf { parent: an })).id();
+        let bn = app.world_mut().spawn(ChildOf(an)).id();
+        let cy = app.world_mut().spawn((C, ChildOf(an))).id();
 
-        let dn = app.world_mut().spawn(ChildOf { parent: cy }).id();
-        let en = app.world_mut().spawn(ChildOf { parent: cy }).id();
+        let dn = app.world_mut().spawn(ChildOf(cy)).id();
+        let en = app.world_mut().spawn(ChildOf(cy)).id();
 
-        let fy = app.world_mut().spawn((C, ChildOf { parent: dn })).id();
-        let gy = app.world_mut().spawn((C, ChildOf { parent: dn })).id();
+        let fy = app.world_mut().spawn((C, ChildOf(dn))).id();
+        let gy = app.world_mut().spawn((C, ChildOf(dn))).id();
 
         // Check that the correct entities have the `AncestorMarker<C>` component.
         assert!(app.world().entity(an).contains::<AncestorMarker<C>>());
@@ -338,14 +338,14 @@ mod tests {
 
         let an = app.world_mut().spawn_empty().id();
 
-        let bn = app.world_mut().spawn(ChildOf { parent: an }).id();
-        let cy = app.world_mut().spawn((C, ChildOf { parent: an })).id();
+        let bn = app.world_mut().spawn(ChildOf(an)).id();
+        let cy = app.world_mut().spawn((C, ChildOf(an))).id();
 
-        let dn = app.world_mut().spawn(ChildOf { parent: cy }).id();
-        let en = app.world_mut().spawn(ChildOf { parent: cy }).id();
+        let dn = app.world_mut().spawn(ChildOf(cy)).id();
+        let en = app.world_mut().spawn(ChildOf(cy)).id();
 
-        let fy = app.world_mut().spawn((C, ChildOf { parent: dn })).id();
-        let gy = app.world_mut().spawn((C, ChildOf { parent: dn })).id();
+        let fy = app.world_mut().spawn((C, ChildOf(dn))).id();
+        let gy = app.world_mut().spawn((C, ChildOf(dn))).id();
 
         // Check that the correct entities have the `AncestorMarker<C>` component.
         assert!(app.world().entity(an).contains::<AncestorMarker<C>>());

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -262,7 +262,7 @@ pub fn position_to_transform(
     parents: Query<ParentComponents, With<Children>>,
 ) {
     for (mut transform, pos, rot, parent) in &mut query {
-        if let Some(&ChildOf { parent }) = parent {
+        if let Some(&ChildOf(parent)) = parent {
             if let Ok((parent_transform, parent_pos, parent_rot)) = parents.get(parent) {
                 // Compute the global transform of the parent using its Position and Rotation
                 let parent_transform = parent_transform.compute_transform();
@@ -309,7 +309,7 @@ pub fn position_to_transform(
     parents: Query<ParentComponents, With<Children>>,
 ) {
     for (mut transform, pos, rot, parent) in &mut query {
-        if let Some(&ChildOf { parent }) = parent {
+        if let Some(&ChildOf(parent)) = parent {
             if let Ok((parent_transform, parent_pos, parent_rot)) = parents.get(parent) {
                 // Compute the global transform of the parent using its Position and Rotation
                 let parent_transform = parent_transform.compute_transform();
@@ -479,13 +479,13 @@ pub fn propagate_transforms_physics(
 
             let handle = |(child, actual_child_of, is_parent_rb, is_parent_collider): (Entity, Ref<ChildOf>, bool, bool)| {
                 assert_eq!(
-                    actual_child_of.parent, entity,
+                    actual_child_of.parent(), entity,
                     "Malformed hierarchy. This probably means that your hierarchy has been improperly maintained, or contains a cycle"
                 );
                 // SAFETY:
                 // - `child` must have consistent parentage, or the above assertion would panic.
                 // Since `child` is parented to a root entity, the entire hierarchy leading to it is consistent.
-                // - We may operate as if all descendants are consistent, since `propagate_recursive` will panic before 
+                // - We may operate as if all descendants are consistent, since `propagate_recursive` will panic before
                 //   continuing to propagate if it encounters an entity with inconsistent parentage.
                 // - Since each root entity is unique and the hierarchy is consistent and forest-like,
                 //   other root entities' `propagate_recursive` calls will not conflict with this one.
@@ -591,7 +591,7 @@ unsafe fn propagate_transforms_physics_recursive(
             parent_query_1.iter_many(children)
         {
             assert_eq!(
-                actual_child_of.parent, entity,
+                actual_child_of.parent(), entity,
                 "Malformed hierarchy. This probably means that your hierarchy has been improperly maintained, or contains a cycle"
             );
             // SAFETY: The caller guarantees that `transform_query` will not be fetched
@@ -616,7 +616,7 @@ unsafe fn propagate_transforms_physics_recursive(
             parent_query_2.iter_many(children)
         {
             assert_eq!(
-                actual_child_of.parent, entity,
+                actual_child_of.parent(), entity,
                 "Malformed hierarchy. This probably means that your hierarchy has been improperly maintained, or contains a cycle"
             );
             // SAFETY: The caller guarantees that `transform_query` will not be fetched


### PR DESCRIPTION
# Objective

- Address changes to Bevy's `ChildOf` structure to fix compilation from bevyengine/bevy/pull/18672

## Solution

- Use tuple struct pattern and `parent()` method for access to parent entity