### PR TITLE
Fix contact pair removal bugs

### DIFF
--- a/src/collision/broad_phase.rs
+++ b/src/collision/broad_phase.rs
@@ -130,7 +130,7 @@ fn update_aabb_intervals(
         (
             &ColliderAabb,
             Option<&ColliderOf>,
-            Option<&CollisionLayers>,
+            &CollisionLayers,
             Has<Sensor>,
             Has<CollisionEventsEnabled>,
             Option<&ActiveCollisionHooks>,
@@ -165,7 +165,7 @@ fn update_aabb_intervals(
                     },
                     |p| *p,
                 );
-                *layers = new_layers.map_or(CollisionLayers::default(), |layers| *layers);
+                *layers = *new_layers;
 
                 let is_static = new_collider_of.is_some_and(|collider_of| {
                     rbs.get(collider_of.rigid_body)
@@ -196,7 +196,7 @@ type AabbIntervalQueryData = (
     Option<Read<ColliderOf>>,
     Read<ColliderAabb>,
     Option<Read<RigidBody>>,
-    Option<Read<CollisionLayers>>,
+    Read<CollisionLayers>,
     Has<Sensor>,
     Has<CollisionEventsEnabled>,
     Option<Read<ActiveCollisionHooks>>,
@@ -232,7 +232,7 @@ fn add_new_aabb_intervals(
                 entity,
                 collider_of.map_or(ColliderOf { rigid_body: entity }, |p| *p),
                 *aabb,
-                layers.map_or(CollisionLayers::default(), |layers| *layers),
+                *layers,
                 flags,
             )
         },

--- a/src/collision/collider/backend.rs
+++ b/src/collision/collider/backend.rs
@@ -92,6 +92,7 @@ impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
         // Register required components for the collider type.
         let _ = app.try_register_required_components::<C, ColliderMarker>();
         let _ = app.try_register_required_components::<C, ColliderAabb>();
+        let _ = app.try_register_required_components::<C, CollisionLayers>();
         let _ = app.try_register_required_components::<C, ColliderDensity>();
         let _ = app.try_register_required_components::<C, ColliderMassProperties>();
 

--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -349,7 +349,13 @@ impl From<TrimeshFlags> for parry::shape::TriMeshFlags {
 /// `Collider` is currently not `Reflect`. If you need to reflect it, you can use [`ColliderConstructor`] as a workaround.
 #[derive(Clone, Component, Debug)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
-#[require(ColliderMarker, ColliderAabb, ColliderDensity, ColliderMassProperties)]
+#[require(
+    ColliderMarker,
+    ColliderAabb,
+    CollisionLayers,
+    ColliderDensity,
+    ColliderMassProperties
+)]
 pub struct Collider {
     /// The raw unscaled collider shape.
     shape: SharedShape,

--- a/src/collision/collider/world_query.rs
+++ b/src/collision/collider/world_query.rs
@@ -25,6 +25,7 @@ pub struct ColliderQuery<C: AnyCollider> {
     pub friction: Option<&'static Friction>,
     pub restitution: Option<&'static Restitution>,
     pub shape: &'static C,
+    pub layers: &'static CollisionLayers,
     pub active_hooks: Option<&'static ActiveCollisionHooks>,
 }
 

--- a/src/collision/layers.rs
+++ b/src/collision/layers.rs
@@ -253,7 +253,7 @@ impl Not for LayerMask {
 /// The memberships and filters are stored as [`LayerMask`]s, which represent [bitmasks] for layers.
 /// The first bit `0b0001` is reserved for the default layer, which all entities belong to by default.
 ///
-/// Colliders without this component have all filters and can interact with any layer.
+/// By default, colliders have all filters and can interact with any layer.
 ///
 /// [bitmasks]: https://en.wikipedia.org/wiki/Mask_(computing)
 ///

--- a/src/collision/narrow_phase/mod.rs
+++ b/src/collision/narrow_phase/mod.rs
@@ -344,7 +344,12 @@ fn remove_collider_on<E: Event, C: Component>(
 
     // Remove the collider from the contact graph.
     contact_graph.remove_collider_with(entity, |contact_pair| {
-        // Send collision ended event.
+        // If the contact pair was not touching, we don't need to do anything.
+        if !contact_pair.flags.contains(ContactPairFlags::TOUCHING) {
+            return;
+        }
+
+        // Send a collision ended event.
         if contact_pair
             .flags
             .contains(ContactPairFlags::CONTACT_EVENTS)

--- a/src/collision/narrow_phase/system_param.rs
+++ b/src/collision/narrow_phase/system_param.rs
@@ -315,7 +315,10 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                 // Check if the AABBs of the colliders still overlap and the contact pair is valid.
                 let overlap = collider1.aabb.intersects(&collider2.aabb);
 
-                if !overlap {
+                // Also check if the collision layers are still compatible and the contact pair is valid.
+                // TODO: Ideally, we would have fine-grained change detection for `CollisionLayers`
+                //       rather than checking it for every pair here.
+                if !overlap || !collider1.layers.interacts_with(*collider2.layers) {
                     // The AABBs no longer overlap. The contact pair should be removed.
                     contacts.flags.set(ContactPairFlags::DISJOINT_AABB, true);
                     state_change_bits.set(contact_index);

--- a/src/spatial_query/pipeline.rs
+++ b/src/spatial_query/pipeline.rs
@@ -84,7 +84,7 @@ impl SpatialQueryPipeline {
                 &'a Position,
                 &'a Rotation,
                 &'a Collider,
-                Option<&'a CollisionLayers>,
+                &'a CollisionLayers,
             ),
         >,
         added_colliders: impl Iterator<Item = Entity>,
@@ -96,7 +96,7 @@ impl SpatialQueryPipeline {
                     (
                         make_isometry(position.0, *rotation),
                         collider.clone(),
-                        layers.map_or(CollisionLayers::default(), |layers| *layers),
+                        *layers,
                     ),
                 )
             })

--- a/src/spatial_query/system_param.rs
+++ b/src/spatial_query/system_param.rs
@@ -65,7 +65,7 @@ pub struct SpatialQuery<'w, 's> {
             &'static Position,
             &'static Rotation,
             &'static Collider,
-            Option<&'static CollisionLayers>,
+            &'static CollisionLayers,
         ),
         Without<ColliderDisabled>,
     >,

--- a/src/tests/determinism_2d.rs
+++ b/src/tests/determinism_2d.rs
@@ -62,7 +62,7 @@ fn cross_platform_determinism_2d() {
     let hash = compute_hash(app.world(), query);
 
     // Update this value if simulation behavior changes.
-    let expected = 0x7c2bfb7b;
+    let expected = 0xdd0ee602;
 
     assert!(
         hash == expected,

--- a/src/tests/determinism_2d.rs
+++ b/src/tests/determinism_2d.rs
@@ -62,7 +62,7 @@ fn cross_platform_determinism_2d() {
     let hash = compute_hash(app.world(), query);
 
     // Update this value if simulation behavior changes.
-    let expected = 0xeabb3d88;
+    let expected = 0x7c2bfb7b;
 
     assert!(
         hash == expected,


### PR DESCRIPTION
# Objective

Contact pair removal currently has some issues.

1. Contact pair removal is done using the `EdgeIndex` directly, but removing an edge can move the indices around (due to `swap_remove`), which can sometimes result in incorrect pair removal if many pairs are removed at once.
2. Changing `CollisionLayers` doesn't update existing contact pairs.
3. When a collider is removed or disabled, `CollisionEnded` is sent even for non-touching contact pairs.

## Solution

Fix the things!

For problem 2, I just made the narrow phase always check if the `CollisionLayers` match for now. Ideally, we'd handle this with fine-grained change detection instead.

`CollisionLayers` is now also a required component for colliders. This avoids extra branching and is perhaps more semantically accurate; colliders can only belong to collision layers if they have the component for it.

---

## Migration Guide

`CollisionLayers` is now a required component for colliders.