### PR TITLE
Handle entity disabling properly

### DIFF
--- a/src/collision/broad_phase.rs
+++ b/src/collision/broad_phase.rs
@@ -8,7 +8,7 @@ use core::marker::PhantomData;
 use crate::{data_structures::pair_key::PairKey, prelude::*};
 use bevy::{
     ecs::{
-        entity::{EntityMapper, MapEntities},
+        entity::{EntityHashSet, EntityMapper, MapEntities},
         entity_disabling::Disabled,
         system::{lifetimeless::Read, StaticSystemParam, SystemParamItem},
     },
@@ -203,6 +203,8 @@ type AabbIntervalQueryData = (
     Option<Read<ActiveCollisionHooks>>,
 );
 
+// TODO: This is pretty gross and inefficient. This should be done with observers or hooks
+//       once we rework the broad phase.
 /// Adds new [`ColliderAabb`]s to [`AabbIntervals`].
 #[allow(clippy::type_complexity)]
 fn add_new_aabb_intervals(
@@ -212,11 +214,13 @@ fn add_new_aabb_intervals(
     mut re_enabled_colliders: RemovedComponents<ColliderDisabled>,
     mut re_enabled_entities: RemovedComponents<Disabled>,
 ) {
-    let re_enabled_aabbs = aabbs.iter_many(
-        re_enabled_colliders
-            .read()
-            .chain(re_enabled_entities.read()),
-    );
+    // Collect re-enabled entities without duplicates.
+    let re_enabled = re_enabled_colliders
+        .read()
+        .chain(re_enabled_entities.read())
+        .collect::<EntityHashSet>();
+    let re_enabled_aabbs = aabbs.iter_many(re_enabled);
+
     let aabbs = added_aabbs.iter().chain(re_enabled_aabbs).map(
         |(entity, collider_of, aabb, rb, layers, is_sensor, events_enabled, hooks)| {
             let mut flags = AabbIntervalFlags::empty();

--- a/src/collision/narrow_phase/mod.rs
+++ b/src/collision/narrow_phase/mod.rs
@@ -16,6 +16,7 @@ use crate::{
 };
 use bevy::{
     ecs::{
+        entity_disabling::Disabled,
         intern::Interned,
         schedule::ScheduleLabel,
         system::{StaticSystemParam, SystemParamItem},
@@ -122,6 +123,7 @@ where
         );
 
         // Remove collision pairs when colliders are disabled or removed.
+        app.add_observer(remove_collider_on::<OnAdd, Disabled>);
         app.add_observer(remove_collider_on::<OnAdd, ColliderDisabled>);
         app.add_observer(remove_collider_on::<OnRemove, Collider>);
 


### PR DESCRIPTION
# Objective

Bevy 0.16 introduces entity disabling via the `Disabled` component. We need to handle this for the contact graph and broad phase.

## Solution

Remove disabled entities from the contact graph using observers, and add re-enabled collider entities to the broad phase.