### PR TITLE
Reduce `SpatialQueryPipeline` overhead

### DIFF
--- a/src/spatial_query/shape_caster.rs
+++ b/src/spatial_query/shape_caster.rs
@@ -383,16 +383,19 @@ impl ShapeCaster {
                 },
             );
 
-            if let Some(hit) = query_pipeline.qbvh.traverse_best_first(&mut visitor).map(
-                |(_, (entity_index, hit))| ShapeHitData {
-                    entity: query_pipeline.entity_from_index(entity_index),
-                    distance: hit.time_of_impact,
-                    point1: hit.witness1.into(),
-                    point2: hit.witness2.into(),
-                    normal1: hit.normal1.into(),
-                    normal2: hit.normal2.into(),
-                },
-            ) {
+            if let Some(hit) =
+                query_pipeline
+                    .qbvh
+                    .traverse_best_first(&mut visitor)
+                    .map(|(_, (index, hit))| ShapeHitData {
+                        entity: query_pipeline.proxies[index as usize].entity,
+                        distance: hit.time_of_impact,
+                        point1: hit.witness1.into(),
+                        point2: hit.witness2.into(),
+                        normal1: hit.normal1.into(),
+                        normal2: hit.normal2.into(),
+                    })
+            {
                 if (hits.vector.len() as u32) < hits.count + 1 {
                     hits.vector.push(hit);
                 } else {

--- a/src/spatial_query/system_param.rs
+++ b/src/spatial_query/system_param.rs
@@ -69,7 +69,6 @@ pub struct SpatialQuery<'w, 's> {
         ),
         Without<ColliderDisabled>,
     >,
-    pub(crate) added_colliders: Query<'w, 's, Entity, Added<Collider>>,
     /// The [`SpatialQueryPipeline`].
     pub query_pipeline: ResMut<'w, SpatialQueryPipeline>,
 }
@@ -79,8 +78,7 @@ impl SpatialQuery<'_, '_> {
     /// [`PhysicsStepSet::SpatialQuery`], but if you modify colliders or their positions before that, you can
     /// call this to make sure the data is up to date when performing spatial queries using [`SpatialQuery`].
     pub fn update_pipeline(&mut self) {
-        self.query_pipeline
-            .update(self.colliders.iter(), self.added_colliders.iter());
+        self.query_pipeline.update(self.colliders.iter());
     }
 
     /// Casts a [ray](spatial_query#raycasting) and computes the closest [hit](RayHitData) with a collider.


### PR DESCRIPTION
# Objective

The `SpatialQueryPipeline` currently has some egregious overhead for scenes with a large number of entities. It allocates an `EntityHashMap` with *all* colliders (`Arc`ed) and some other data, from scratch, *every frame*. Even worse, it allocates QBVH nodes for all entities up to the largest collider `Entity` index. For a scene with 999,999 non-physics entities and one collider, it seems to allocate a *million* QBVH nodes every frame. This produces profiles like this:

![Really bad spatial query pipeline performance](https://github.com/user-attachments/assets/802553c1-d013-4e8a-8344-e54d1e1de0b4)

Yikes!

## Solution

Just store QBVH proxies in a `Vec`, and use those vec indices rather than `Entity` indices for QBVH building. This also lets us replace a bunch of hashmap lookups with vector indexing, get rid of some `Entity` conversions, and avoid table scans for `Added<Collider>`.

This is still kind of a duct-tape fix. We should ideally have separate BVHs for dynamic or kinematic and static or sleeping bodies, along with incremental updates. It would also be good if we didn't have to store all the duplicate collider data and just queried the ECS directly, assuming the query overhead is negligible. This will be worked on in the future.

Still, this seems to be much better!

![Reduced overhead](https://github.com/user-attachments/assets/c680dd25-e4d2-4faf-9faa-002f39803c4a)