### PR TITLE
Add support for floating origins using deltas in sync plugin

### DIFF
--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -105,6 +105,10 @@ bevy_heavy = { git = "https://github.com/Jondolf/bevy_heavy", features = [
 ] }
 approx = "0.5"
 criterion = { version = "0.5", features = ["html_reports"] }
+big_space = { git = "https://github.com/aevyrie/big_space", branch = "bevy-0.16.0", features = [
+    "debug",
+] }
+
 # TODO: Update to the latest version when it's available.
 # bevy_mod_debugdump = { version = "0.12" }
 

--- a/crates/avian3d/examples/floating_origin.rs
+++ b/crates/avian3d/examples/floating_origin.rs
@@ -1,0 +1,126 @@
+use avian3d::prelude::*;
+use bevy::prelude::*;
+use big_space::prelude::*;
+use examples_common_3d::ExampleCommonPlugin;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins((
+            BigSpacePlugin::default(),
+            FloatingOriginDebugPlugin::default(),
+            PhysicsPlugins::default(),
+            PhysicsDebugPlugin::default(),
+            ExampleCommonPlugin,
+        ))
+        .insert_resource(Gravity(Vec3::ZERO))
+        .add_systems(Startup, spawn_big_space)
+        .add_systems(Update, move_cube)
+        .add_systems(
+            PostUpdate,
+            move_camera.before(TransformSystem::TransformPropagate),
+        )
+        .run();
+}
+
+#[derive(Component)]
+struct WasdControlled;
+
+#[derive(Component)]
+struct MainCamera;
+
+fn spawn_big_space(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    commands.spawn_big_space(Grid::new(5.0, 0.0), |root| {
+        // Camera with no physics components
+        root.spawn_spatial((
+            FloatingOrigin,
+            Transform::from_xyz(0.0, 0.0, 25.0).looking_at(Vec3::new(0.0, 0.0, 0.0), Vec3::Y),
+            Camera::default(),
+            Camera3d::default(),
+            Projection::Perspective(PerspectiveProjection::default()),
+            MainCamera,
+        ));
+
+        let cube_mesh = meshes.add(Cuboid::default());
+
+        // WASD controlled cube
+        root.spawn_spatial((
+            Mesh3d(cube_mesh.clone()),
+            MeshMaterial3d(materials.add(Color::WHITE)),
+            Transform::IDENTITY,
+            RigidBody::Dynamic,
+            Collider::cuboid(1.0, 1.0, 1.0),
+            WasdControlled,
+            LinearVelocity::default(),
+            LinearDamping::default(),
+            TransformInterpolation,
+        ));
+    });
+}
+
+fn move_cube(
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+    mut query: Query<(&mut LinearVelocity, &mut LinearDamping), With<WasdControlled>>,
+) {
+    let mut velocity = Vec3::ZERO;
+    if keyboard_input.pressed(KeyCode::KeyW) {
+        velocity += Vec3::Y * 0.1;
+    }
+    if keyboard_input.pressed(KeyCode::KeyS) {
+        velocity -= Vec3::Y * 0.1;
+    }
+    if keyboard_input.pressed(KeyCode::KeyA) {
+        velocity -= Vec3::X * 0.1;
+    }
+    if keyboard_input.pressed(KeyCode::KeyD) {
+        velocity += Vec3::X * 0.1;
+    }
+
+    for (mut linear_velocity, _) in &mut query {
+        linear_velocity.0 += velocity;
+    }
+
+    let linear_damping_value = if keyboard_input.pressed(KeyCode::Space) {
+        10.0
+    } else {
+        0.0
+    };
+
+    for (_, mut linear_damping) in &mut query {
+        linear_damping.0 = linear_damping_value;
+    }
+}
+
+fn move_camera(
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+    mut query: Query<&mut Transform, With<MainCamera>>,
+    time: Res<Time>,
+) {
+    let camera_speed = 5.0;
+
+    for mut transform in &mut query {
+        let mut movement = Vec3::ZERO;
+
+        if keyboard_input.pressed(KeyCode::ArrowUp) {
+            movement += Vec3::Y;
+        }
+        if keyboard_input.pressed(KeyCode::ArrowDown) {
+            movement -= Vec3::Y;
+        }
+        if keyboard_input.pressed(KeyCode::ArrowLeft) {
+            movement -= Vec3::X;
+        }
+        if keyboard_input.pressed(KeyCode::ArrowRight) {
+            movement += Vec3::X;
+        }
+
+        if movement != Vec3::ZERO {
+            movement = movement.normalize() * camera_speed * time.delta_secs();
+            transform.translation += movement;
+        }
+    }
+}


### PR DESCRIPTION
# Objective

- Update the `SyncPlugin` to be compatible with floating origin plugins like `big_space` 

## Solution

- Use position deltas in the `SyncPlugin` to update transform translation

---

Creating this as a draft to discuss the change since I'm not sure if I broke hierarchy's in this. All the demos seem to work though so...!

Alternatively I was thinking there could be another config option in `SyncConfig` like `use_delta_transforms` that would call a different `position_to_transform_with_deltas` to trigger this functionality.