### PR TITLE
Add support for bevy 0.16.0 rc5

### DIFF
--- a/src/collision/collider/constructor.rs
+++ b/src/collision/collider/constructor.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use bevy::{platform_support::collections::HashMap, prelude::*};
+use bevy::{platform::collections::HashMap, prelude::*};
 
 /// A component that will automatically generate [`Collider`]s on its descendants at runtime.
 /// The type of the generated collider can be specified using [`ColliderConstructor`].

--- a/src/collision/contact_types/contact_graph.rs
+++ b/src/collision/contact_types/contact_graph.rs
@@ -5,7 +5,7 @@ use crate::data_structures::{
 };
 #[expect(unused_imports)]
 use crate::prelude::*;
-use bevy::{platform_support::collections::HashSet, prelude::*};
+use bevy::{platform::collections::HashSet, prelude::*};
 
 use super::{ContactPair, ContactPairFlags};
 

--- a/src/data_structures/sparse_secondary_map.rs
+++ b/src/data_structures/sparse_secondary_map.rs
@@ -10,7 +10,7 @@
 //! [`slotmap::SparseSecondaryMap`]: https://docs.rs/slotmap/1.0.7/slotmap/struct.SparseSecondaryMap.html
 
 use alloc::collections::TryReserveError;
-use bevy::platform_support::hash::RandomState;
+use bevy::platform::hash::RandomState;
 use core::mem::MaybeUninit;
 use std::collections::hash_map::{self, HashMap};
 use std::hash;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,7 @@
 
 use crate::prelude::*;
 
-pub(crate) use bevy::platform_support::time::Instant;
+pub(crate) use bevy::platform::time::Instant;
 
 /// Computes translation of `Position` based on center of mass rotation and translation
 pub(crate) fn get_pos_translation(


### PR DESCRIPTION
# Objective

Supports bevy 0.16.0 rc 5; I'm pretty sure it breaks comparability with the previous RC versions.

(Since Cargo.toml doesn't pin an rc version, you will probably need to run `Cargo clean && bevy run` to see changes)

I hope this is useful!

## Solution / Changelog

I had to change platform_support to platform as per https://github.com/bevyengine/bevy/pull/18813

---

## Tests

I ran the following, and it seems to have worked:

```
cargo run --example cubes --no-default-features --features "3d f64 parry-f64"
```