### PR TITLE
Stable contact identifiers

### DIFF
--- a/src/collision/contact_types/mod.rs
+++ b/src/collision/contact_types/mod.rs
@@ -8,7 +8,10 @@ pub use contact_graph::ContactGraph;
 pub use feature_id::PackedFeatureId;
 pub use system_param::Collisions;
 
-use crate::prelude::*;
+use crate::{
+    data_structures::graph::{EdgeId, EdgeWeight},
+    prelude::*,
+};
 use bevy::prelude::*;
 
 /// A contact pair between two colliders.
@@ -22,6 +25,9 @@ use bevy::prelude::*;
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct ContactPair {
+    // TODO: Add a `ContactId` newtype.
+    /// The stable identifier of the contact pair.
+    pub id: u32,
     /// The first collider entity in the contact.
     pub entity1: Entity,
     /// The second collider entity in the contact.
@@ -64,11 +70,24 @@ bitflags::bitflags! {
     }
 }
 
+impl EdgeWeight for ContactPair {
+    fn edge_id(&self) -> EdgeId {
+        EdgeId(self.id)
+    }
+
+    fn set_edge_id(&mut self, id: EdgeId) {
+        self.id = id.0;
+    }
+}
+
 impl ContactPair {
     /// Creates a new [`ContactPair`] with the given entities.
     #[inline]
     pub fn new(entity1: Entity, entity2: Entity) -> Self {
         Self {
+            // We use `u32::MAX` as a placeholder ID for the contact pair.
+            // It gets set to a valid ID when the contact pair is added to the `ContactGraph`.
+            id: u32::MAX,
             entity1,
             entity2,
             body_entity1: None,

--- a/src/collision/mod.rs
+++ b/src/collision/mod.rs
@@ -95,7 +95,8 @@ pub mod prelude {
         CollisionEnded, CollisionEventsEnabled, CollisionStarted, OnCollisionEnd, OnCollisionStart,
     };
     pub use super::contact_types::{
-        Collisions, ContactGraph, ContactManifold, ContactPair, ContactPairFlags, ContactPoint,
+        Collisions, ContactGraph, ContactId, ContactManifold, ContactPair, ContactPairFlags,
+        ContactPoint,
     };
     pub use super::hooks::{ActiveCollisionHooks, CollisionHooks};
     pub use super::narrow_phase::{NarrowPhaseConfig, NarrowPhasePlugin, NarrowPhaseSet};

--- a/src/data_structures/graph.rs
+++ b/src/data_structures/graph.rs
@@ -440,7 +440,7 @@ impl<N, E: EdgeWeight> UnGraph<N, E> {
     /// Removes an edge and returns its edge weight, or `None` if it didn't exist.
     ///
     /// Invalidates the edge `e` and its edge weight, and the index of the last edge weight
-    /// (that edge weight will adopt the removed edge weight'S index).
+    /// (that edge weight will adopt the removed edge weight's index).
     ///
     /// Computes in **O(e')** time, where **e'** is the size of four particular edge lists, for
     /// the vertices of `e` and the vertices of another affected edge.

--- a/src/dynamics/solver/contact/mod.rs
+++ b/src/dynamics/solver/contact/mod.rs
@@ -6,7 +6,7 @@ mod tangent_part;
 pub use normal_part::ContactNormalPart;
 pub use tangent_part::ContactTangentPart;
 
-use crate::prelude::*;
+use crate::{data_structures::graph::EdgeId, prelude::*};
 use bevy::{
     ecs::entity::{Entity, EntityMapper, MapEntities},
     reflect::Reflect,
@@ -59,14 +59,15 @@ pub struct ContactConstraintPoint {
 /// The contact points are stored in `points`, and they all share the same `normal`.
 #[derive(Clone, Debug, PartialEq, Reflect)]
 pub struct ContactConstraint {
+    // TODO: `ContactId` newtype for `EdgeId`.
+    /// The stable identifier of the [`ContactPair`] in the [`ContactGraph`].
+    pub contact_id: EdgeId,
+    /// The index of the [`ContactManifold`] in the [`ContactPair`] stored for the two bodies.
+    pub manifold_index: usize,
     /// The first rigid body entity in the contact.
     pub entity1: Entity,
     /// The second rigid body entity in the contact.
     pub entity2: Entity,
-    /// The first collider entity in the contact.
-    pub collider_entity1: Entity,
-    /// The second collider entity in the contact.
-    pub collider_entity2: Entity,
     /// The combined coefficient of dynamic [friction](Friction) of the bodies.
     pub friction: Scalar,
     /// The combined coefficient of [restitution](Restitution) of the bodies.
@@ -89,8 +90,6 @@ pub struct ContactConstraint {
     pub normal: Vector,
     /// The contact points in the manifold. Each point shares the same `normal`.
     pub points: Vec<ContactConstraintPoint>,
-    /// The index of the [`ContactManifold`] in the [`ContactPair`] stored for the two bodies.
-    pub manifold_index: usize,
 }
 
 impl ContactConstraint {
@@ -319,7 +318,5 @@ impl MapEntities for ContactConstraint {
     fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
         self.entity1 = entity_mapper.get_mapped(self.entity1);
         self.entity2 = entity_mapper.get_mapped(self.entity2);
-        self.collider_entity1 = entity_mapper.get_mapped(self.collider_entity1);
-        self.collider_entity2 = entity_mapper.get_mapped(self.collider_entity2);
     }
 }

--- a/src/dynamics/solver/mod.rs
+++ b/src/dynamics/solver/mod.rs
@@ -530,12 +530,15 @@ fn store_contact_impulses(
     let start = crate::utils::Instant::now();
 
     for constraint in constraints.iter() {
-        let Some(contact_pair) =
-            contact_graph.get_mut(constraint.collider_entity1, constraint.collider_entity2)
+        // TODO: If the constraint indices matched the contact pair indices,
+        //       we could use the index instead of the ID to avoid an extra lookup.
+        let Some(contact_pair) = contact_graph
+            .internal
+            .edge_weight_mut(constraint.contact_id)
         else {
             unreachable!(
-                "Contact pair between {} and {} not found in contact graph.",
-                constraint.collider_entity1, constraint.collider_entity2
+                "Contact pair {:?} not found in contact graph.",
+                constraint.contact_id,
             );
         };
 


### PR DESCRIPTION
# Objective

Currently, contact pairs have no stable indentifiers. Contact pairs (i.e. graph edges) are removed with `swap_remove`, which can invalidate edge indices.

This causes a few problems:

1. When processing contact status changes, we need to first collect removed contact pairs to a separate buffer and perform the actual removal afterwards. Otherwise, the indices of the rest of the status changes might get invalidated while processing them. For the actual pair removal, we also need to use entity pairs and look up the edges manually, which is more costly than indexing edges directly.
2. When writing back constraint impulses to contact data, we need to fetch contact pairs based on the entities, because contact pair removal may have invalidated the original edge indices. This can get expensive with thousands of active contacts.

For both of these cases, we would benefit from stable identifiers that can be used to efficiently fetch or remove contact pairs from the contact graph without invalidating other existing identifiers.

## Solution

Rework the `UnGraph` data structure and `ContactGraph` to support stable identifiers for graph edge connectivity data.

`UnGraph` now stores a separate `Vec` for edges and edge weights. An `Edge` only contains edge connectivity data and the index of the weight associated with it, or `None` if the edge is vacant. The order of edges is stable, and a free list is used to track which edges are vacant, but edge weights are still allowed to be moved around by edge removal.

```rust
// Before
pub struct UnGraph<N, E> {
    nodes: Vec<Node<N>>,
    edges: Vec<Edge<E>>,
}

// After
pub struct UnGraph<N, E: EdgeWeight> {
    nodes: Vec<Node<N>>,
    edges: Vec<Edge>,
    edge_count: usize,
    free_edge: EdgeId,
    edge_weights: Vec<E>,
}
```

This is a sort of mix of petgraph's [`UnGraph`](https://docs.rs/petgraph/latest/petgraph/graph/type.UnGraph.html) and [`StableUnGraph`](https://docs.rs/petgraph/latest/petgraph/stable_graph/type.StableUnGraph.html). For contacts, we need stable edge indices and fast iteration over edge weights, but `StableUnGraph` only provides the former, as it also stores edge weights for vacant edges. By allowing edge weights to be swap-removed and storing vacant edges for connectivity data to keep their order stable, we (hopefully) get the best of both worlds.

The `ContactGraph` uses this new graph representation, and stores a stable `ContactId` for each `ContactPair` and `ContactConstraint`. This lets us fix the pair removal problem (1) and improve the performance of writing back impulses from constraints to contacts (2).

I also otherwise cleaned up `UnGraph` and removed some unused code from it.

### Comparison With Box2D

A lot of Avian's narrow phase design (e.g. using bit sets for status changes) is inspired by Box2D v3. The core idea for this PR also came from Box2D.

- `b2ContactArray` stores `b2Contact`s, which only contain cold data such as the contact index, the previous and next contact edge, island connectivity information, and more. This is similar to `Edge` in our `UnGraph`, and has a stable contact ID.
- `b2ContactSimArray` stores `b2ContactSim`s, which contain the actual contact pair data, and the ID of the corresponding `b2Contact`. This is similar to the `ContactPair` edge weights in our `UnGraph`, and does *not* have stable indices, as the items are swap-removed when removing contact pairs.
- A `contactIdPool` is used to manage IDs and add items to the correct slots in the `b2ContactArray`. Our `UnGraph` doesn't store a separate ID pool; instead, it just uses a free list and marks edges as vacant or occupied.

While Box2D keeps these structures separate, we have most of the complexity and logic contained within the `UnGraph` behind a convenient and flexible API.

### Results

Before, "Store Impulses" had a fairly substantial cost in contact-heavy scenarios.

![Before](https://github.com/user-attachments/assets/b7962bd5-df58-4aaf-b43f-9b9c9eff9f86)

Now, it takes less than half the time:

![After](https://github.com/user-attachments/assets/945d768b-9c3b-4a67-9837-58508932d033)

(note that these profiles were done on a branch with huge solver optimizations; on the main branch, the solver is much more expensive here)

Contact pair removal should also be much more efficient, but that is harder to profile directly. In addition to the performance wins, the new stable identifiers clean up some logic quite nicely.