### PR TITLE
Update to Bevy 0.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ cargo run --example cubes --no-default-features --features "3d f64 parry-f64"
 
 | Bevy    | Avian |
 | ------- | ----- |
-| 0.16 RC | main  |
+| 0.16    | main  |
 | 0.15    | 0.2   |
 | 0.14    | 0.1   |
 

--- a/crates/avian2d/Cargo.toml
+++ b/crates/avian2d/Cargo.toml
@@ -73,11 +73,11 @@ bench = false
 
 [dependencies]
 avian_derive = { path = "../avian_derive", version = "0.2" }
-bevy = { version = "0.16.0-rc", default-features = false, features = [
+bevy = { version = "0.16", default-features = false, features = [
     "std",
     "bevy_log",
 ] }
-bevy_math = { version = "0.16.0-rc" }
+bevy_math = { version = "0.16" }
 bevy_heavy = { git = "https://github.com/Jondolf/bevy_heavy" }
 bevy_transform_interpolation = { git = "https://github.com/Jondolf/bevy_transform_interpolation" }
 libm = { version = "0.2", optional = true }
@@ -94,7 +94,7 @@ thread_local = { version = "1.1", optional = true }
 [dev-dependencies]
 examples_common_2d = { path = "../examples_common_2d" }
 benches_common_2d = { path = "../benches_common_2d" }
-bevy_math = { version = "0.16.0-rc", features = ["approx"] }
+bevy_math = { version = "0.16", features = ["approx"] }
 bevy_heavy = { git = "https://github.com/Jondolf/bevy_heavy", features = [
     "approx",
 ] }

--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -75,11 +75,11 @@ bench = false
 
 [dependencies]
 avian_derive = { path = "../avian_derive", version = "0.2" }
-bevy = { version = "0.16.0-rc", default-features = false, features = [
+bevy = { version = "0.16", default-features = false, features = [
     "std",
     "bevy_log",
 ] }
-bevy_math = { version = "0.16.0-rc" }
+bevy_math = { version = "0.16" }
 bevy_heavy = { git = "https://github.com/Jondolf/bevy_heavy" }
 bevy_transform_interpolation = { git = "https://github.com/Jondolf/bevy_transform_interpolation" }
 libm = { version = "0.2", optional = true }
@@ -95,11 +95,11 @@ thread_local = { version = "1.1", optional = true }
 [dev-dependencies]
 examples_common_3d = { path = "../examples_common_3d" }
 benches_common_3d = { path = "../benches_common_3d" }
-bevy = { version = "0.16.0-rc", default-features = false, features = [
+bevy = { version = "0.16", default-features = false, features = [
     "bevy_gltf",
     "animation",
 ] }
-bevy_math = { version = "0.16.0-rc", features = ["approx"] }
+bevy_math = { version = "0.16", features = ["approx"] }
 bevy_heavy = { git = "https://github.com/Jondolf/bevy_heavy", features = [
     "approx",
 ] }

--- a/crates/benches_common_2d/Cargo.toml
+++ b/crates/benches_common_2d/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = { version = "0.16.0-rc", default-features = false }
+bevy = { version = "0.16", default-features = false }
 avian2d = { path = "../avian2d", default-features = false }
 criterion = "0.5"
 

--- a/crates/benches_common_3d/Cargo.toml
+++ b/crates/benches_common_3d/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = { version = "0.16.0-rc", default-features = false }
+bevy = { version = "0.16", default-features = false }
 avian3d = { path = "../avian3d", default-features = false }
 criterion = "0.5"
 

--- a/crates/examples_common_2d/Cargo.toml
+++ b/crates/examples_common_2d/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 use-debug-plugin = []
 
 [dependencies]
-bevy = { version = "0.16.0-rc", default-features = false, features = [
+bevy = { version = "0.16", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_state",
     "bevy_text",

--- a/crates/examples_common_3d/Cargo.toml
+++ b/crates/examples_common_3d/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 use-debug-plugin = []
 
 [dependencies]
-bevy = { version = "0.16.0-rc", default-features = false, features = [
+bevy = { version = "0.16", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_state",
     "bevy_text",

--- a/src/diagnostics/ui.rs
+++ b/src/diagnostics/ui.rs
@@ -427,9 +427,10 @@ fn update_timers(
         };
 
         // Linearly interpolating between green and red, with `lower_bound` and `upper_bound`.
-        let t = (average as f32 - color_config.lower_bound)
-            / (color_config.upper_bound - color_config.lower_bound);
-        text_color.0 = Animatable::interpolate(&green, &red, t.min(1.0)).into();
+        let t = ((average as f32 - color_config.lower_bound)
+            / (color_config.upper_bound - color_config.lower_bound))
+            .min(1.0);
+        text_color.0 = (green * (1.0 - t) + red * t).into();
 
         // Make sure the node is visible.
         node.display = Display::Flex;


### PR DESCRIPTION
# Objective

Fixes #708.
Alternative to #674 and #710.

#710 updates Avian to Bevy 0.16, but doesn't update the README. Both #674 and #710 also fix an error about missing `bevy_animation` by enabling the `animation` feature (only in 2D, so 3D is still broken) rather than removing the root problem, the unnecessary use of `Animatable` in `src/diagnostics/ui.rs`.

## Solution

Update to Bevy 0.16 and replace the use of `Animatable` with manual interpolation code.