### PR TITLE
Sort contact constraints for determinism when `parallel` feature is enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
             - uses: dtolnay/rust-toolchain@stable
             - uses: Swatinem/rust-cache@v2
             - name: Run cargo test
-              run: cargo test --no-default-features --features enhanced-determinism,collider-from-mesh,serialize,debug-plugin,avian2d/2d,avian3d/3d,avian2d/f64,avian3d/f64,default-collider,parry-f64,bevy_scene,bevy_picking,diagnostic_ui
+              run: cargo test --no-default-features --features enhanced-determinism,parallel,collider-from-mesh,serialize,debug-plugin,avian2d/2d,avian3d/3d,avian2d/f64,avian3d/f64,default-collider,parry-f64,bevy_scene,bevy_picking,diagnostic_ui
 
     lints:
         name: Lints

--- a/src/collision/narrow_phase/system_param.rs
+++ b/src/collision/narrow_phase/system_param.rs
@@ -619,6 +619,8 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                             tangent_velocity: manifold.tangent_velocity,
                             normal: manifold.normal,
                             points: Vec::with_capacity(manifold.points.len()),
+                            #[cfg(feature = "parallel")]
+                            pair_index: contact_index,
                             manifold_index,
                         };
 
@@ -731,6 +733,13 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                 self.contact_constraints
                     .extend(context_mut.contact_constraints.drain(..));
             });
+
+            // Sort the contact constraints by pair index to maintain determinism.
+            // NOTE: `sort_by_key` is faster than `sort_unstable_by_key` here,
+            //       because the constraints within chunks are already sorted.
+            // TODO: We should figure out an approach that doesn't require sorting.
+            self.contact_constraints
+                .sort_by_key(|constraint| constraint.pair_index);
         }
     }
 }

--- a/src/collision/narrow_phase/system_param.rs
+++ b/src/collision/narrow_phase/system_param.rs
@@ -316,6 +316,7 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                 #[cfg(not(feature = "parallel"))]
                 let constraints = &mut self.contact_constraints;
 
+                // TODO: Move this out of the chunk iteration? Requires refactoring `par_for_each!`.
                 #[cfg(feature = "parallel")]
                 // Get the thread-local narrow phase context.
                 let mut thread_context = self

--- a/src/dynamics/solver/contact/mod.rs
+++ b/src/dynamics/solver/contact/mod.rs
@@ -89,6 +89,13 @@ pub struct ContactConstraint {
     pub normal: Vector,
     /// The contact points in the manifold. Each point shares the same `normal`.
     pub points: Vec<ContactConstraintPoint>,
+    /// The index of the [`ContactPair`] in the [`ContactGraph`].
+    ///
+    /// This is primarily used for ordering contact constraints deterministically
+    /// when parallelism is enabled. The index may be invalidated by contact removal.
+    // TODO: We should figure out a better way to handle deterministic constraint generation.
+    #[cfg(feature = "parallel")]
+    pub pair_index: usize,
     /// The index of the [`ContactManifold`] in the [`ContactPair`] stored for the two bodies.
     pub manifold_index: usize,
 }


### PR DESCRIPTION
# Objective

Multithreaded determinism is currently broken! This is because #699 accidentally resulted in contact constraint order being non-deterministic. CI didn't catch this, because it currently doesn't use the `parallel` feature.

## Solution

When the `parallel` feature is enabled, store the pair index for each `ContactConstraint`, and just sort the constraints based on these indices.

I suspect that a better approach that doesn't require sorting exists, but for now, this works as a simple hot-fix. I also tried the simple approach of returning `Vec`s from Bevy's `par_splat_map_mut`, but that would mean that we can't reuse the constraint buffers, and have to allocate from scratch every time. Either way, there's more to try and experiment with here.

Because the constraints within chunks are still largely sorted, the sorting ends up being quite fast. In the `pyramid_2d` example, it increased the time of "Update Contacts" from about 0.42 ms to about 0.44 ms with ~3025 constraints.

I also enabled the `parallel` feature for CI to hopefully catch multithreading problems like this automatically in the future!