### PR TITLE
Use try_remove to avoid errors on AncestorMarker removal

### DIFF
--- a/src/sync/ancestor_marker.rs
+++ b/src/sync/ancestor_marker.rs
@@ -115,7 +115,7 @@ fn add_ancestor_markers<C: Component>(
 /// Remove the component from entity, unless it is already despawned.
 fn remove_component<T: Bundle>(commands: &mut Commands, entity: Entity) {
     if let Ok(mut entity_commands) = commands.get_entity(entity) {
-        entity_commands.remove::<T>();
+        entity_commands.try_remove::<T>();
     }
 }
 


### PR DESCRIPTION
# Objective

While despawning entities with hierarchies and RigidBody components, the following error would occur

```
Encountered an error in command <bevy_ecs::system::commands::entity_command::remove<avian3d::sync::ancestor_marker::AncestorMarker<avian3d::collision::collider::backend::ColliderMarker>>::{{closure}} as bevy_ecs::error::command_handling::CommandWithEntity<core::result::Result<(), bevy_ecs::world::error::EntityMutableFetchError>>>::with_entity::{{closure}}: The entity with ID 727v1 was despawned by forks/bevy/crates/bevy_scene/src/scene.rs:112:46
```

This was because the removal command gets queued instantly due to running in an observer on collider removal but the command gets deferred until after the entity no longer exists.

## Solution

changed removal of AncestorMarker to use try_remove to avoid errors

