### PR TITLE
Rename most `rigid_body` names to `body`

### DIFF
--- a/crates/avian2d/examples/dynamic_character_2d/plugin.rs
+++ b/crates/avian2d/examples/dynamic_character_2d/plugin.rs
@@ -57,7 +57,7 @@ pub struct MaxSlopeAngle(Scalar);
 #[derive(Bundle)]
 pub struct CharacterControllerBundle {
     character_controller: CharacterController,
-    rigid_body: RigidBody,
+    body: RigidBody,
     collider: Collider,
     ground_caster: ShapeCaster,
     locked_axes: LockedAxes,
@@ -103,7 +103,7 @@ impl CharacterControllerBundle {
 
         Self {
             character_controller: CharacterController,
-            rigid_body: RigidBody::Dynamic,
+            body: RigidBody::Dynamic,
             collider,
             ground_caster: ShapeCaster::new(caster_shape, Vector::ZERO, 0.0, Dir2::NEG_Y)
                 .with_max_distance(10.0),

--- a/crates/avian2d/examples/kinematic_character_2d/plugin.rs
+++ b/crates/avian2d/examples/kinematic_character_2d/plugin.rs
@@ -74,7 +74,7 @@ pub struct MaxSlopeAngle(Scalar);
 #[derive(Bundle)]
 pub struct CharacterControllerBundle {
     character_controller: CharacterController,
-    rigid_body: RigidBody,
+    body: RigidBody,
     collider: Collider,
     ground_caster: ShapeCaster,
     gravity: ControllerGravity,
@@ -120,7 +120,7 @@ impl CharacterControllerBundle {
 
         Self {
             character_controller: CharacterController,
-            rigid_body: RigidBody::Kinematic,
+            body: RigidBody::Kinematic,
             collider,
             ground_caster: ShapeCaster::new(caster_shape, Vector::ZERO, 0.0, Dir2::NEG_Y)
                 .with_max_distance(10.0),
@@ -280,7 +280,7 @@ fn kinematic_controller_collisions(
     // Iterate through collisions and move the kinematic body to resolve penetration
     for contacts in collisions.iter() {
         // Get the rigid body entities of the colliders (colliders could be children)
-        let Ok([&ColliderOf { rigid_body: rb1 }, &ColliderOf { rigid_body: rb2 }]) =
+        let Ok([&ColliderOf { body: rb1 }, &ColliderOf { body: rb2 }]) =
             collider_rbs.get_many([contacts.entity1, contacts.entity2])
         else {
             continue;

--- a/crates/avian3d/examples/dynamic_character_3d/plugin.rs
+++ b/crates/avian3d/examples/dynamic_character_3d/plugin.rs
@@ -57,7 +57,7 @@ pub struct MaxSlopeAngle(Scalar);
 #[derive(Bundle)]
 pub struct CharacterControllerBundle {
     character_controller: CharacterController,
-    rigid_body: RigidBody,
+    body: RigidBody,
     collider: Collider,
     ground_caster: ShapeCaster,
     locked_axes: LockedAxes,
@@ -103,7 +103,7 @@ impl CharacterControllerBundle {
 
         Self {
             character_controller: CharacterController,
-            rigid_body: RigidBody::Dynamic,
+            body: RigidBody::Dynamic,
             collider,
             ground_caster: ShapeCaster::new(
                 caster_shape,

--- a/crates/avian3d/examples/kinematic_character_3d/plugin.rs
+++ b/crates/avian3d/examples/kinematic_character_3d/plugin.rs
@@ -75,7 +75,7 @@ pub struct MaxSlopeAngle(Scalar);
 #[derive(Bundle)]
 pub struct CharacterControllerBundle {
     character_controller: CharacterController,
-    rigid_body: RigidBody,
+    body: RigidBody,
     collider: Collider,
     ground_caster: ShapeCaster,
     gravity: ControllerGravity,
@@ -121,7 +121,7 @@ impl CharacterControllerBundle {
 
         Self {
             character_controller: CharacterController,
-            rigid_body: RigidBody::Kinematic,
+            body: RigidBody::Kinematic,
             collider,
             ground_caster: ShapeCaster::new(
                 caster_shape,
@@ -296,7 +296,7 @@ fn kinematic_controller_collisions(
     // Iterate through collisions and move the kinematic body to resolve penetration
     for contacts in collisions.iter() {
         // Get the rigid body entities of the colliders (colliders could be children)
-        let Ok([&ColliderOf { rigid_body: rb1 }, &ColliderOf { rigid_body: rb2 }]) =
+        let Ok([&ColliderOf { body: rb1 }, &ColliderOf { body: rb2 }]) =
             collider_rbs.get_many([contacts.entity1, contacts.entity2])
         else {
             continue;

--- a/src/collision/broad_phase.rs
+++ b/src/collision/broad_phase.rs
@@ -164,14 +164,14 @@ fn update_aabb_intervals(
                 *aabb = *new_aabb;
                 *collider_of = new_collider_of.map_or(
                     ColliderOf {
-                        rigid_body: *collider_entity,
+                        body: *collider_entity,
                     },
                     |p| *p,
                 );
                 *layers = *new_layers;
 
                 let is_static = new_collider_of.is_some_and(|collider_of| {
-                    rbs.get(collider_of.rigid_body)
+                    rbs.get(collider_of.body)
                         .is_ok_and(RigidBody::is_static)
                 });
 
@@ -242,7 +242,7 @@ fn add_new_aabb_intervals(
             );
             (
                 entity,
-                collider_of.map_or(ColliderOf { rigid_body: entity }, |p| *p),
+                collider_of.map_or(ColliderOf { body: entity }, |p| *p),
                 *aabb,
                 *layers,
                 flags,
@@ -342,8 +342,8 @@ fn sweep_and_prune<H: CollisionHooks>(
             let mut contacts = ContactPair::new(*entity1, *entity2);
 
             // Initialize flags and other data for the contact pair.
-            contacts.body_entity1 = Some(collider_of1.rigid_body);
-            contacts.body_entity2 = Some(collider_of2.rigid_body);
+            contacts.body_entity1 = Some(collider_of1.body);
+            contacts.body_entity2 = Some(collider_of2.body);
             contacts.flags.set(
                 ContactPairFlags::SENSOR,
                 flags1.union(*flags2).contains(AabbIntervalFlags::IS_SENSOR),

--- a/src/collision/broad_phase.rs
+++ b/src/collision/broad_phase.rs
@@ -171,8 +171,7 @@ fn update_aabb_intervals(
                 *layers = *new_layers;
 
                 let is_static = new_collider_of.is_some_and(|collider_of| {
-                    rbs.get(collider_of.body)
-                        .is_ok_and(RigidBody::is_static)
+                    rbs.get(collider_of.body).is_ok_and(RigidBody::is_static)
                 });
 
                 flags.set(AabbIntervalFlags::IS_INACTIVE, is_static || is_sleeping);

--- a/src/collision/collider/collider_transform/plugin.rs
+++ b/src/collision/collider/collider_transform/plugin.rs
@@ -97,7 +97,7 @@ pub(crate) fn update_child_collider_position(
     rb_query: Query<(&Position, &Rotation), (With<RigidBody>, With<Children>)>,
 ) {
     for (collider_transform, mut position, mut rotation, collider_of) in &mut collider_query {
-        let Ok((rb_pos, rb_rot)) = rb_query.get(collider_of.rigid_body) else {
+        let Ok((rb_pos, rb_rot)) = rb_query.get(collider_of.body) else {
             continue;
         };
 

--- a/src/collision/collider/world_query.rs
+++ b/src/collision/collider/world_query.rs
@@ -11,7 +11,7 @@ use bevy::{ecs::query::QueryData, prelude::*};
 #[derive(QueryData)]
 pub struct ColliderQuery<C: AnyCollider> {
     pub entity: Entity,
-    pub rigid_body: Option<&'static ColliderOf>,
+    pub of: Option<&'static ColliderOf>,
     pub position: Ref<'static, Position>,
     pub rotation: Ref<'static, Rotation>,
     pub accumulated_translation: Option<Ref<'static, AccumulatedTranslation>>,
@@ -30,6 +30,14 @@ pub struct ColliderQuery<C: AnyCollider> {
 }
 
 impl<C: AnyCollider> ColliderQueryItem<'_, C> {
+    /// Returns the entity of the rigid body that the collider is attached to.
+    ///
+    /// If the collider is not attached to a rigid body, this will return `None`.
+    #[inline(always)]
+    pub fn body(&self) -> Option<Entity> {
+        self.of.map(|ColliderOf { body }| *body)
+    }
+
     /// Returns the current position of the body. This is a sum of the [`Position`] and
     /// [`AccumulatedTranslation`] components.
     pub fn current_position(&self) -> Vector {

--- a/src/collision/collision_events.rs
+++ b/src/collision/collision_events.rs
@@ -205,7 +205,7 @@ pub struct OnCollisionStart {
     /// The entity of the rigid body that started colliding with the [`Trigger::target`].
     ///
     /// If the collider is not attached to a rigid body, this will be `None`.
-    pub rigid_body: Option<Entity>,
+    pub body: Option<Entity>,
 }
 
 /// A [collision event](super#collision-events) that is triggered for [observers](Observer)
@@ -269,7 +269,7 @@ pub struct OnCollisionEnd {
     /// The entity of the rigid body that stopped colliding with the [`Trigger::target`].
     ///
     /// If the collider is not attached to a rigid body, this will be `None`.
-    pub rigid_body: Option<Entity>,
+    pub body: Option<Entity>,
 }
 
 /// A marker component that enables [collision events](self) for an entity.

--- a/src/collision/narrow_phase/mod.rs
+++ b/src/collision/narrow_phase/mod.rs
@@ -284,49 +284,25 @@ fn trigger_collision_events(
     for event in state.started.read() {
         if let Ok(collider_of) = state.query.get(event.0) {
             let collider = event.1;
-            let rigid_body = collider_of.map(|c| c.rigid_body);
-            started_pairs.push((
-                event.0,
-                OnCollisionStart {
-                    collider,
-                    rigid_body,
-                },
-            ));
+            let body = collider_of.map(|c| c.body);
+            started_pairs.push((event.0, OnCollisionStart { collider, body }));
         }
         if let Ok(collider_of) = state.query.get(event.1) {
             let collider = event.0;
-            let rigid_body = collider_of.map(|c| c.rigid_body);
-            started_pairs.push((
-                event.1,
-                OnCollisionStart {
-                    collider,
-                    rigid_body,
-                },
-            ));
+            let body = collider_of.map(|c| c.body);
+            started_pairs.push((event.1, OnCollisionStart { collider, body }));
         }
     }
     for event in state.ended.read() {
         if let Ok(collider_of) = state.query.get(event.0) {
             let collider = event.1;
-            let rigid_body = collider_of.map(|c| c.rigid_body);
-            ended_pairs.push((
-                event.0,
-                OnCollisionEnd {
-                    collider,
-                    rigid_body,
-                },
-            ));
+            let body = collider_of.map(|c| c.body);
+            ended_pairs.push((event.0, OnCollisionEnd { collider, body }));
         }
         if let Ok(collider_of) = state.query.get(event.1) {
             let collider = event.0;
-            let rigid_body = collider_of.map(|c| c.rigid_body);
-            ended_pairs.push((
-                event.1,
-                OnCollisionEnd {
-                    collider,
-                    rigid_body,
-                },
-            ));
+            let body = collider_of.map(|c| c.body);
+            ended_pairs.push((event.1, OnCollisionEnd { collider, body }));
         }
     }
 

--- a/src/collision/narrow_phase/system_param.rs
+++ b/src/collision/narrow_phase/system_param.rs
@@ -361,14 +361,12 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                 } else {
                     // The AABBs overlap. Compute contacts.
 
-                    let body1_bundle =
-                        collider1.rigid_body.and_then(|&ColliderOf { rigid_body }| {
-                            self.body_query.get(rigid_body).ok()
-                        });
-                    let body2_bundle =
-                        collider2.rigid_body.and_then(|&ColliderOf { rigid_body }| {
-                            self.body_query.get(rigid_body).ok()
-                        });
+                    let body1_bundle = collider1
+                        .body()
+                        .and_then(|body| self.body_query.get(body).ok());
+                    let body2_bundle = collider2
+                        .body()
+                        .and_then(|body| self.body_query.get(body).ok());
 
                     // The rigid body's friction, restitution, collision margin, and speculative margin
                     // will be used if the collider doesn't have them specified.

--- a/src/debug_render/mod.rs
+++ b/src/debug_render/mod.rs
@@ -212,7 +212,7 @@ fn debug_render_aabbs(
     #[cfg(feature = "2d")]
     for (entity, aabb, collider_rb, render_config) in &aabbs {
         if let Some(mut color) = render_config.map_or(config.aabb_color, |c| c.aabb_color) {
-            let collider_rb = collider_rb.map_or(entity, |c| c.rigid_body);
+            let collider_rb = collider_rb.map_or(entity, |c| c.body);
 
             // If the body is sleeping, multiply the color by the sleeping color multiplier
             if sleeping.contains(collider_rb) {
@@ -235,7 +235,7 @@ fn debug_render_aabbs(
     #[cfg(feature = "3d")]
     for (entity, aabb, collider_rb, render_config) in &aabbs {
         if let Some(mut color) = render_config.map_or(config.aabb_color, |c| c.aabb_color) {
-            let collider_rb = collider_rb.map_or(entity, |c| c.rigid_body);
+            let collider_rb = collider_rb.map_or(entity, |c| c.body);
 
             // If the body is sleeping, multiply the color by the sleeping color multiplier
             if sleeping.contains(collider_rb) {
@@ -277,7 +277,7 @@ fn debug_render_colliders(
     let config = store.config::<PhysicsGizmos>().1;
     for (entity, collider, position, rotation, collider_rb, render_config) in &mut colliders {
         if let Some(mut color) = render_config.map_or(config.collider_color, |c| c.collider_color) {
-            let collider_rb = collider_rb.map_or(entity, |c| c.rigid_body);
+            let collider_rb = collider_rb.map_or(entity, |c| c.body);
 
             // If the body is sleeping, multiply the color by the sleeping color multiplier
             if sleeping.contains(collider_rb) {

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -561,7 +561,7 @@ fn solve_swept_ccd(
         for (
             collider2,
             &ColliderOf {
-                rigid_body: entity2,
+                body: entity2,
             },
         ) in colliders.iter_many(intersecting_entities)
         {

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -558,12 +558,7 @@ fn solve_swept_ccd(
 
         // Iterate through colliders intersecting the AABB of the CCD body.
         let intersecting_entities = contact_graph.entities_colliding_with(entity);
-        for (
-            collider2,
-            &ColliderOf {
-                body: entity2,
-            },
-        ) in colliders.iter_many(intersecting_entities)
+        for (collider2, &ColliderOf { body: entity2 }) in colliders.iter_many(intersecting_entities)
         {
             debug_assert_ne!(entity, entity2, "collider AABB cannot intersect itself");
 

--- a/src/dynamics/rigid_body/mass_properties/mod.rs
+++ b/src/dynamics/rigid_body/mass_properties/mod.rs
@@ -391,8 +391,8 @@ fn queue_mass_recomputation_on_collider_mass_change(
         )>,
     >,
 ) {
-    for &ColliderOf { rigid_body } in &mut query {
-        if let Ok(mut entity_commands) = commands.get_entity(rigid_body) {
+    for &ColliderOf { body } in &mut query {
+        if let Ok(mut entity_commands) = commands.get_entity(body) {
             entity_commands.insert(RecomputeMassProperties);
         }
     }

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -165,9 +165,7 @@ pub fn init_transforms<C: Component>(
         return;
     }
 
-    for (entity, transform, global_transform, pos, rot, previous_rot, parent, has_rigid_body) in
-        &query
-    {
+    for (entity, transform, global_transform, pos, rot, previous_rot, parent, has_body) in &query {
         let parent_transforms = parent.and_then(|&ChildOf(parent)| parents.get(parent).ok());
         let parent_pos = parent_transforms.and_then(|(pos, _, _)| pos);
         let parent_rot = parent_transforms.and_then(|(_, rot, _)| rot);
@@ -309,7 +307,7 @@ pub fn init_transforms<C: Component>(
         // or computed based on the GlobalTransform.
         // If the entity isn't a rigid body, adding PreSolveAccumulatedTranslation and PreviousRotation
         // is unnecessary.
-        match (has_rigid_body, new_transform) {
+        match (has_body, new_transform) {
             (true, None) => {
                 cmds.try_insert((
                     Position(new_position),


### PR DESCRIPTION
# Objective

We have a lot of properties called `rigid_body`. In a lot of cases, really the relevant part is that it is just a physics "body", and the `rigid_` qualifier is largely unnecessary. Typically, it's enough to just use `body` for properties, and it can result in cleaner names.

## Solution

Rename `rigid_body` to just `body` for `OnCollisionStart`, `OnCollisionEnd`, `ColliderOf`, and many internal variables and types.

Despite using `body` for a lot of property names, I think we should still probably keep the `Rigid` prefix for types such as `RigidBody`.

---

## Migration Guide

`ColliderQuery::rigid_body` has been renamed to `of` (for `ColliderOf`) and there is a new `body` helper to get the contained entity directly.