### PR TITLE
Rename entity properties in `ContactPair` and `ContactConstraint`

### DIFF
--- a/crates/avian2d/examples/determinism_2d.rs
+++ b/crates/avian2d/examples/determinism_2d.rs
@@ -190,14 +190,14 @@ pub struct PhysicsHooks<'w, 's> {
 }
 
 impl CollisionHooks for PhysicsHooks<'_, '_> {
-    fn filter_pairs(&self, entity1: Entity, entity2: Entity, _commands: &mut Commands) -> bool {
+    fn filter_pairs(&self, collider1: Entity, collider2: Entity, _commands: &mut Commands) -> bool {
         // Ignore the collision if the entities are connected by a joint.
         // TODO: This should be an optimized built-in feature for joints.
         self.joints
             .iter()
             .find(|joint| {
-                (joint.entity1 == entity1 && joint.entity2 == entity2)
-                    || (joint.entity1 == entity2 && joint.entity2 == entity1)
+                (joint.entity1 == collider1 && joint.entity2 == collider2)
+                    || (joint.entity1 == collider2 && joint.entity2 == collider1)
             })
             .is_some()
     }

--- a/crates/avian2d/examples/kinematic_character_2d/plugin.rs
+++ b/crates/avian2d/examples/kinematic_character_2d/plugin.rs
@@ -281,7 +281,7 @@ fn kinematic_controller_collisions(
     for contacts in collisions.iter() {
         // Get the rigid body entities of the colliders (colliders could be children)
         let Ok([&ColliderOf { body: rb1 }, &ColliderOf { body: rb2 }]) =
-            collider_rbs.get_many([contacts.entity1, contacts.entity2])
+            collider_rbs.get_many([contacts.collider1, contacts.collider2])
         else {
             continue;
         };

--- a/crates/avian2d/examples/one_way_platform_2d.rs
+++ b/crates/avian2d/examples/one_way_platform_2d.rs
@@ -259,23 +259,23 @@ impl CollisionHooks for PlatformerCollisionHooks<'_, '_> {
         // Choose the appropriate normal for pass-through depending on which is which.
         let (platform_entity, one_way_platform, platform_transform, other_entity, relevant_normal) =
             if let Ok((one_way_platform, platform_transform)) =
-                self.one_way_platforms_query.get(contacts.entity1)
+                self.one_way_platforms_query.get(contacts.collider1)
             {
                 (
-                    contacts.entity1,
+                    contacts.collider1,
                     one_way_platform,
                     platform_transform,
-                    contacts.entity2,
+                    contacts.collider2,
                     RelevantNormal::Normal1,
                 )
             } else if let Ok((one_way_platform, platform_transform)) =
-                self.one_way_platforms_query.get(contacts.entity2)
+                self.one_way_platforms_query.get(contacts.collider2)
             {
                 (
-                    contacts.entity2,
+                    contacts.collider2,
                     one_way_platform,
                     platform_transform,
-                    contacts.entity1,
+                    contacts.collider1,
                     RelevantNormal::Normal2,
                 )
             } else {

--- a/crates/avian3d/examples/conveyor_belt.rs
+++ b/crates/avian3d/examples/conveyor_belt.rs
@@ -44,8 +44,8 @@ impl CollisionHooks for ConveyorHooks<'_, '_> {
         // This also affects the sign used for the conveyor belt's speed to apply it in the correct direction.
         let (Ok((conveyor_belt, global_transform)), sign) = self
             .conveyor_query
-            .get(contacts.entity1)
-            .map_or((self.conveyor_query.get(contacts.entity2), 1.0), |q| {
+            .get(contacts.collider1)
+            .map_or((self.conveyor_query.get(contacts.collider2), 1.0), |q| {
                 (Ok(q), -1.0)
             })
         else {

--- a/crates/avian3d/examples/kinematic_character_3d/plugin.rs
+++ b/crates/avian3d/examples/kinematic_character_3d/plugin.rs
@@ -297,7 +297,7 @@ fn kinematic_controller_collisions(
     for contacts in collisions.iter() {
         // Get the rigid body entities of the colliders (colliders could be children)
         let Ok([&ColliderOf { body: rb1 }, &ColliderOf { body: rb2 }]) =
-            collider_rbs.get_many([contacts.entity1, contacts.entity2])
+            collider_rbs.get_many([contacts.collider1, contacts.collider2])
         else {
             continue;
         };

--- a/src/collision/broad_phase.rs
+++ b/src/collision/broad_phase.rs
@@ -341,8 +341,8 @@ fn sweep_and_prune<H: CollisionHooks>(
             let mut contacts = ContactPair::new(*entity1, *entity2);
 
             // Initialize flags and other data for the contact pair.
-            contacts.body_entity1 = Some(collider_of1.body);
-            contacts.body_entity2 = Some(collider_of2.body);
+            contacts.body1 = Some(collider_of1.body);
+            contacts.body2 = Some(collider_of2.body);
             contacts.flags.set(
                 ContactPairFlags::SENSOR,
                 flags1.union(*flags2).contains(AabbIntervalFlags::IS_SENSOR),

--- a/src/collision/contact_types/contact_graph.rs
+++ b/src/collision/contact_types/contact_graph.rs
@@ -247,7 +247,7 @@ impl ContactGraph {
     /// or wake up the entities involved. Only use this method if you know what you are doing.
     #[inline]
     pub fn add_pair(&mut self, contacts: ContactPair) {
-        let pair_key = PairKey::new(contacts.entity1.index(), contacts.entity2.index());
+        let pair_key = PairKey::new(contacts.collider1.index(), contacts.collider2.index());
         self.add_pair_with_key(contacts, pair_key);
     }
 
@@ -275,13 +275,13 @@ impl ContactGraph {
         // Get the indices of the entities in the graph.
         let index1 = self
             .entity_to_node
-            .get_or_insert_with(contacts.entity1, || {
-                self.internal.add_node(contacts.entity1)
+            .get_or_insert_with(contacts.collider1, || {
+                self.internal.add_node(contacts.collider1)
             });
         let index2 = self
             .entity_to_node
-            .get_or_insert_with(contacts.entity2, || {
-                self.internal.add_node(contacts.entity2)
+            .get_or_insert_with(contacts.collider2, || {
+                self.internal.add_node(contacts.collider2)
             });
 
         // Add the edge to the graph.
@@ -298,7 +298,7 @@ impl ContactGraph {
     /// or wake up the entities involved. Only use this method if you know what you are doing.
     #[inline]
     pub fn insert_pair(&mut self, contacts: ContactPair) {
-        let pair_key = PairKey::new(contacts.entity1.index(), contacts.entity2.index());
+        let pair_key = PairKey::new(contacts.collider1.index(), contacts.collider2.index());
         self.insert_pair_with_key(contacts, pair_key);
     }
 
@@ -323,13 +323,13 @@ impl ContactGraph {
         // Get the indices of the entities in the graph.
         let index1 = self
             .entity_to_node
-            .get_or_insert_with(contacts.entity1, || {
-                self.internal.add_node(contacts.entity1)
+            .get_or_insert_with(contacts.collider1, || {
+                self.internal.add_node(contacts.collider1)
             });
         let index2 = self
             .entity_to_node
-            .get_or_insert_with(contacts.entity2, || {
-                self.internal.add_node(contacts.entity2)
+            .get_or_insert_with(contacts.collider2, || {
+                self.internal.add_node(contacts.collider2)
             });
 
         // Update the edge in the graph.
@@ -383,7 +383,7 @@ impl ContactGraph {
 
         // Remove the entity from the graph.
         self.internal.remove_node_with(index, |contacts| {
-            let pair_key = PairKey::new(contacts.entity1.index(), contacts.entity2.index());
+            let pair_key = PairKey::new(contacts.collider1.index(), contacts.collider2.index());
 
             pair_callback(contacts);
 

--- a/src/collision/contact_types/mod.rs
+++ b/src/collision/contact_types/mod.rs
@@ -23,13 +23,13 @@ use bevy::prelude::*;
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct ContactPair {
     /// The first collider entity in the contact.
-    pub entity1: Entity,
+    pub collider1: Entity,
     /// The second collider entity in the contact.
-    pub entity2: Entity,
+    pub collider2: Entity,
     /// The entity of the first body involved in the contact.
-    pub body_entity1: Option<Entity>,
+    pub body1: Option<Entity>,
     /// The entity of the second body involved in the contact.
-    pub body_entity2: Option<Entity>,
+    pub body2: Option<Entity>,
     /// A list of contact manifolds between two colliders.
     /// Each manifold contains one or more contact points, but each contact
     /// in a given manifold shares the same contact normal.
@@ -67,12 +67,12 @@ bitflags::bitflags! {
 impl ContactPair {
     /// Creates a new [`ContactPair`] with the given entities.
     #[inline]
-    pub fn new(entity1: Entity, entity2: Entity) -> Self {
+    pub fn new(collider1: Entity, collider2: Entity) -> Self {
         Self {
-            entity1,
-            entity2,
-            body_entity1: None,
-            body_entity2: None,
+            collider1,
+            collider2,
+            body1: None,
+            body2: None,
             manifolds: Vec::new(),
             flags: ContactPairFlags::empty(),
         }

--- a/src/collision/contact_types/system_param.rs
+++ b/src/collision/contact_types/system_param.rs
@@ -112,10 +112,10 @@ impl Collisions<'_> {
     pub fn entities_colliding_with(&self, entity: Entity) -> impl Iterator<Item = Entity> + '_ {
         // TODO: Can we do this more efficiently?
         self.collisions_with(entity).map(move |contacts| {
-            if contacts.entity1 == entity {
-                contacts.entity2
+            if contacts.collider1 == entity {
+                contacts.collider2
             } else {
-                contacts.entity1
+                contacts.collider1
             }
         })
     }

--- a/src/collision/hooks.rs
+++ b/src/collision/hooks.rs
@@ -52,10 +52,10 @@ use bevy::{ecs::system::ReadOnlySystemParam, prelude::*};
 ///
 /// // Implement the `CollisionHooks` trait.
 /// impl CollisionHooks for MyHooks<'_, '_> {
-///     fn filter_pairs(&self, entity1: Entity, entity2: Entity, _commands: &mut Commands) -> bool {
+///     fn filter_pairs(&self, collider1: Entity, collider2: Entity, _commands: &mut Commands) -> bool {
 ///         // Only allow collisions between entities in the same interaction group.
 ///         // This could be a basic solution for "multiple physics worlds" that don't interact.
-///         let Ok([group1, group2]) = self.interaction_query.get_many([entity1, entity2]) else {
+///         let Ok([group1, group2]) = self.interaction_query.get_many([collider1, collider2]) else {
 ///            return true;
 ///         };
 ///         group1.0 == group2.0
@@ -64,7 +64,7 @@ use bevy::{ecs::system::ReadOnlySystemParam, prelude::*};
 ///     fn modify_contacts(&self, contacts: &mut ContactPair, _commands: &mut Commands) -> bool {
 ///         // Allow entities to pass through the bottom and sides of one-way platforms.
 ///         // See the `one_way_platform_2d` example for a full implementation.
-///         let (entity1, entity2) = (contacts.entity1, contacts.entity2);
+///         let (entity1, entity2) = (contacts.collider1, contacts.collider2);
 ///         !is_hitting_top_of_platform(entity1, entity2, &self.platform_query, &contacts)
 ///     }
 /// }
@@ -146,7 +146,7 @@ use bevy::{ecs::system::ReadOnlySystemParam, prelude::*};
 #[expect(unused_variables)]
 pub trait CollisionHooks: ReadOnlySystemParam + Send + Sync {
     /// A contact pair filtering hook that determines whether contacts should be computed
-    /// between `entity1` and `entity2`. If `false` is returned, contacts will not be computed.
+    /// between `collider1` and `collider2`. If `false` is returned, contacts will not be computed.
     ///
     /// This is called in the broad phase, before the [`ContactPair`] has been computed.
     ///
@@ -159,7 +159,7 @@ pub trait CollisionHooks: ReadOnlySystemParam + Send + Sync {
     /// - Only called if at least one entity in the contact pair is not [`RigidBody::Static`] and not [`Sleeping`].
     /// - Access to the [`ContactGraph`] resource is not allowed in this method.
     ///   Trying to access it will result in a panic.
-    fn filter_pairs(&self, entity1: Entity, entity2: Entity, commands: &mut Commands) -> bool {
+    fn filter_pairs(&self, collider1: Entity, collider2: Entity, commands: &mut Commands) -> bool {
         true
     }
 

--- a/src/collision/narrow_phase/mod.rs
+++ b/src/collision/narrow_phase/mod.rs
@@ -340,14 +340,17 @@ fn remove_collider_on<E: Event, C: Component>(
             .flags
             .contains(ContactPairFlags::CONTACT_EVENTS)
         {
-            event_writer.write(CollisionEnded(contact_pair.entity1, contact_pair.entity2));
+            event_writer.write(CollisionEnded(
+                contact_pair.collider1,
+                contact_pair.collider2,
+            ));
         }
 
         // Remove the entity from the `CollidingEntities` of the other entity.
-        let other_entity = if contact_pair.entity1 == entity {
-            contact_pair.entity2
+        let other_entity = if contact_pair.collider1 == entity {
+            contact_pair.collider2
         } else {
-            contact_pair.entity1
+            contact_pair.collider1
         };
         if let Ok(mut colliding_entities) = query.get_mut(other_entity) {
             colliding_entities.remove(&entity);

--- a/src/debug_render/mod.rs
+++ b/src/debug_render/mod.rs
@@ -308,10 +308,10 @@ fn debug_render_contacts(
     }
 
     for contacts in collisions.iter() {
-        let Ok((position1, rotation1)) = colliders.get(contacts.entity1) else {
+        let Ok((position1, rotation1)) = colliders.get(contacts.collider1) else {
             continue;
         };
-        let Ok((position2, rotation2)) = colliders.get(contacts.entity2) else {
+        let Ok((position2, rotation2)) = colliders.get(contacts.collider2) else {
             continue;
         };
 

--- a/src/dynamics/sleeping/mod.rs
+++ b/src/dynamics/sleeping/mod.rs
@@ -151,10 +151,10 @@ pub fn mark_sleeping_bodies(
 
     for (entity, rb, mut lin_vel, mut ang_vel, mut time_sleeping) in &mut query {
         let colliding_entities = contact_graph.collisions_with(entity).map(|c| {
-            if entity == c.entity1 {
-                c.entity2
+            if entity == c.collider1 {
+                c.collider2
             } else {
-                c.entity1
+                c.collider1
             }
         });
 

--- a/src/dynamics/solver/contact/mod.rs
+++ b/src/dynamics/solver/contact/mod.rs
@@ -60,13 +60,13 @@ pub struct ContactConstraintPoint {
 #[derive(Clone, Debug, PartialEq, Reflect)]
 pub struct ContactConstraint {
     /// The first rigid body entity in the contact.
-    pub entity1: Entity,
+    pub body1: Entity,
     /// The second rigid body entity in the contact.
-    pub entity2: Entity,
+    pub body2: Entity,
     /// The first collider entity in the contact.
-    pub collider_entity1: Entity,
+    pub collider1: Entity,
     /// The second collider entity in the contact.
-    pub collider_entity2: Entity,
+    pub collider2: Entity,
     /// The combined coefficient of dynamic [friction](Friction) of the bodies.
     pub friction: Scalar,
     /// The combined coefficient of [restitution](Restitution) of the bodies.
@@ -324,9 +324,9 @@ impl ContactConstraint {
 
 impl MapEntities for ContactConstraint {
     fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
-        self.entity1 = entity_mapper.get_mapped(self.entity1);
-        self.entity2 = entity_mapper.get_mapped(self.entity2);
-        self.collider_entity1 = entity_mapper.get_mapped(self.collider_entity1);
-        self.collider_entity2 = entity_mapper.get_mapped(self.collider_entity2);
+        self.body1 = entity_mapper.get_mapped(self.body1);
+        self.body2 = entity_mapper.get_mapped(self.body2);
+        self.collider1 = entity_mapper.get_mapped(self.collider1);
+        self.collider2 = entity_mapper.get_mapped(self.collider2);
     }
 }

--- a/src/dynamics/solver/mod.rs
+++ b/src/dynamics/solver/mod.rs
@@ -398,8 +398,7 @@ fn warm_start(
     for constraint in constraints.iter_mut() {
         debug_assert!(!constraint.points.is_empty());
 
-        let Ok([mut body1, mut body2]) =
-            bodies.get_many_mut([constraint.entity1, constraint.entity2])
+        let Ok([mut body1, mut body2]) = bodies.get_many_mut([constraint.body1, constraint.body2])
         else {
             continue;
         };
@@ -448,8 +447,7 @@ fn solve_contacts<const USE_BIAS: bool>(
     let max_overlap_solve_speed = solver_config.max_overlap_solve_speed * length_unit.0;
 
     for constraint in &mut constraints.0 {
-        let Ok([mut body1, mut body2]) =
-            bodies.get_many_mut([constraint.entity1, constraint.entity2])
+        let Ok([mut body1, mut body2]) = bodies.get_many_mut([constraint.body1, constraint.body2])
         else {
             continue;
         };
@@ -498,8 +496,7 @@ fn solve_restitution(
             continue;
         }
 
-        let Ok([mut body1, mut body2]) =
-            bodies.get_many_mut([constraint.entity1, constraint.entity2])
+        let Ok([mut body1, mut body2]) = bodies.get_many_mut([constraint.body1, constraint.body2])
         else {
             continue;
         };
@@ -530,12 +527,11 @@ fn store_contact_impulses(
     let start = crate::utils::Instant::now();
 
     for constraint in constraints.iter() {
-        let Some(contact_pair) =
-            contact_graph.get_mut(constraint.collider_entity1, constraint.collider_entity2)
+        let Some(contact_pair) = contact_graph.get_mut(constraint.collider1, constraint.collider2)
         else {
             unreachable!(
                 "Contact pair between {} and {} not found in contact graph.",
-                constraint.collider_entity1, constraint.collider_entity2
+                constraint.collider1, constraint.collider2
             );
         };
 


### PR DESCRIPTION
# Objective

Follow-up to #718.

`ContactPair` has `entity1`, `entity2`, `body_entity1`, and `body_entity2`, while `ContactConstraint` has `entity1`, `entity2`, `collider_entity1`, and `collider_entity2`. The `entity` specifiers are kind of unnecessary, and it'd be nice if the names were more consistent and `entity1` and `entity2` were more explicit about whether they are the collider or body entities.

## Solution

Rename the properties such that both `ContactPair` and `ContactConstraint` have `collider1`, `collider2`, `body1`, and `body2`.

---

## Migration Guide

- `ContactPair`: The `entity1` and `entity2` properties are now `collider1` and `collider2`, and `body_entity1` and `body_entity2` are now `body1` and `body2`.
- `ContactConstraint`: The `entity1` and `entity2` properties are now `body1` and `body2`, and `collider_entity1` and `collider_entity2` are now `collider1` and `collider2`.