### PR TITLE
Fix wrong shape order in `shape_intersections_callback`

### DIFF
--- a/src/spatial_query/pipeline.rs
+++ b/src/spatial_query/pipeline.rs
@@ -778,8 +778,8 @@ impl SpatialQueryPipeline {
 
                     if dispatcher.intersection_test(
                         &isometry,
-                        proxy.collider.shape_scaled().as_ref(),
                         shape.shape_scaled().as_ref(),
+                        proxy.collider.shape_scaled().as_ref(),
                     ) == Ok(true)
                     {
                         return callback(proxy.entity);


### PR DESCRIPTION
# Objective

Fixes #720.

#696 accidentally regressed `SpatialQueryPipeline::shape_intersections_callback`, mixing up the order of the input shapes.

## Solution

Fix the order!