### PR TITLE
Fix doc comment for `Rotation::from_sin_cos`

### DIFF
--- a/src/position.rs
+++ b/src/position.rs
@@ -247,7 +247,7 @@ impl Rotation {
     ///
     /// # Panics
     ///
-    /// Panics if `sin * sin + cos * cos != 1.0` when the `glam_assert` feature is enabled.
+    /// Panics if `sin * sin + cos * cos != 1.0` when `debug_assertions` are enabled.
     #[inline]
     pub fn from_sin_cos(sin: Scalar, cos: Scalar) -> Self {
         let rotation = Self { sin, cos };


### PR DESCRIPTION
# Objective

The doc comment for `Rotation::from_sin_cos` mentions a non-existent `glam_assert` feature (it's in Glam, not Avian).

## Solution

Fix it.