### PR TITLE
Replaced Avian transform syncs with 0.16 Bevy versions

### DIFF
--- a/src/collision/collider/collider_transform/plugin.rs
+++ b/src/collision/collider/collider_transform/plugin.rs
@@ -7,6 +7,7 @@ use crate::{
 use bevy::{
     ecs::{intern::Interned, schedule::ScheduleLabel},
     prelude::*,
+    transform::systems::{mark_dirty_trees, propagate_parent_transforms, sync_simple_transforms},
 };
 
 /// A plugin for propagating and updating transforms for colliders.
@@ -51,8 +52,9 @@ impl Plugin for ColliderTransformPlugin {
         app.add_systems(
             self.schedule,
             (
-                crate::sync::sync_simple_transforms_physics,
-                crate::sync::propagate_transforms_physics,
+                mark_dirty_trees,
+                propagate_parent_transforms,
+                sync_simple_transforms,
             )
                 .chain()
                 .run_if(match_any::<(Added<ColliderMarker>, Without<RigidBody>)>)

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -8,6 +8,7 @@ use crate::{prelude::*, sync::SyncConfig};
 use bevy::{
     ecs::{intern::Interned, query::QueryFilter, schedule::ScheduleLabel},
     prelude::*,
+    transform::systems::{mark_dirty_trees, propagate_parent_transforms, sync_simple_transforms},
 };
 
 /// Runs systems at the start of each physics frame. Initializes [rigid bodies](RigidBody)
@@ -93,8 +94,9 @@ impl Plugin for PreparePlugin {
             self.schedule,
             // Run transform propagation if new bodies have been added
             (
-                crate::sync::sync_simple_transforms_physics,
-                crate::sync::propagate_transforms_physics,
+                mark_dirty_trees,
+                propagate_parent_transforms,
+                sync_simple_transforms,
             )
                 .chain()
                 .run_if(match_any::<Added<RigidBody>>)

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -4,10 +4,11 @@
 //! See [`SyncPlugin`].
 
 use crate::prelude::*;
-use ancestor_marker::{AncestorMarker, AncestorMarkerPlugin};
+use ancestor_marker::AncestorMarkerPlugin;
 use bevy::{
     ecs::{intern::Interned, schedule::ScheduleLabel},
     prelude::*,
+    transform::systems::{mark_dirty_trees, propagate_parent_transforms, sync_simple_transforms},
 };
 
 // TODO: Where should this be?
@@ -82,8 +83,9 @@ impl Plugin for SyncPlugin {
         app.add_systems(
             self.schedule,
             (
-                sync_simple_transforms_physics,
-                propagate_transforms_physics,
+                mark_dirty_trees,
+                propagate_parent_transforms,
+                sync_simple_transforms,
                 init_previous_global_transform,
                 transform_to_position,
                 // Update `PreviousGlobalTransform` for the physics step's `GlobalTransform` change detection
@@ -100,8 +102,9 @@ impl Plugin for SyncPlugin {
         app.add_systems(
             self.schedule,
             (
-                sync_simple_transforms_physics,
-                propagate_transforms_physics,
+                mark_dirty_trees,
+                propagate_parent_transforms,
+                sync_simple_transforms,
                 transform_to_position,
             )
                 .chain()
@@ -121,8 +124,9 @@ impl Plugin for SyncPlugin {
         app.add_systems(
             self.schedule,
             (
-                sync_simple_transforms_physics,
-                propagate_transforms_physics,
+                mark_dirty_trees,
+                propagate_parent_transforms,
+                sync_simple_transforms,
                 update_previous_global_transforms,
             )
                 .chain()
@@ -343,298 +347,5 @@ pub fn update_previous_global_transforms(
 ) {
     for (transform, mut previous_transform) in &mut bodies {
         previous_transform.0 = *transform;
-    }
-}
-
-// Below are copies of Bevy's transform propagation systems, but optimized to only traverse trees with rigid bodies.
-// Propagation is unnecessary for everything else, because the physics engine should only modify the positions
-// of rigid bodies and their descendants. Bevy runs its own propagation near the end of the frame.
-
-/// Updates the [`GlobalTransform`] component of physics entities that don't have other physics entities in the hierarchy.
-#[allow(clippy::type_complexity)]
-pub fn sync_simple_transforms_physics(
-    mut query: ParamSet<(
-        Query<
-            (&Transform, &mut GlobalTransform),
-            (
-                Or<(Changed<Transform>, Added<GlobalTransform>)>,
-                Without<ChildOf>,
-                Or<(
-                    Without<AncestorMarker<RigidBody>>,
-                    Without<AncestorMarker<ColliderMarker>>,
-                )>,
-                Or<(With<RigidBody>, With<ColliderMarker>)>,
-            ),
-        >,
-        Query<
-            (Ref<Transform>, &mut GlobalTransform),
-            (
-                Without<ChildOf>,
-                Or<(
-                    Without<AncestorMarker<RigidBody>>,
-                    Without<AncestorMarker<ColliderMarker>>,
-                )>,
-                Or<(With<RigidBody>, With<ColliderMarker>)>,
-            ),
-        >,
-    )>,
-    mut orphaned: RemovedComponents<ChildOf>,
-) {
-    // Update changed entities.
-    query
-        .p0()
-        .par_iter_mut()
-        .for_each(|(transform, mut global_transform)| {
-            *global_transform = GlobalTransform::from(*transform);
-        });
-    // Update orphaned entities.
-    let mut query = query.p1();
-    let mut iter = query.iter_many_mut(orphaned.read());
-    while let Some((transform, mut global_transform)) = iter.fetch_next() {
-        if !transform.is_changed() && !global_transform.is_added() {
-            *global_transform = GlobalTransform::from(*transform);
-        }
-    }
-}
-
-// Below is a diagram of an example hierarchy.
-//
-//   A
-//  / \
-// N   A
-//    / \
-//   P   N
-//  / \
-// N   N
-//
-// P = a physics entity
-// A = a physics entity ancestor
-// N = not a physics entity ancestor
-//
-// We can stop propagation, if:
-//
-// 1. we encounter an N that doesn't have any P as an ancestor.
-// 2. we encounter a P with no children.
-
-// TODO: A general `PhysicsMarker` for both rigid bodies and colliders could be nice.
-
-type TransformQueryData = (
-    Ref<'static, Transform>,
-    &'static mut GlobalTransform,
-    Option<&'static Children>,
-    Has<RigidBody>,
-    Has<ColliderMarker>,
-);
-
-type ParentQueryData = (
-    Entity,
-    Ref<'static, ChildOf>,
-    Has<RigidBody>,
-    Has<ColliderMarker>,
-);
-
-type PhysicsObjectOrAncestorFilter = Or<(
-    Or<(With<RigidBody>, With<AncestorMarker<RigidBody>>)>,
-    Or<(With<ColliderMarker>, With<AncestorMarker<ColliderMarker>>)>,
-)>;
-
-/// Update [`GlobalTransform`] component of physics entities based on entity hierarchy and
-/// [`Transform`] component.
-#[allow(clippy::type_complexity)]
-pub fn propagate_transforms_physics(
-    mut root_query: Query<
-        (
-            Entity,
-            &Children,
-            Ref<Transform>,
-            &mut GlobalTransform,
-            Has<RigidBody>,
-            Has<ColliderMarker>,
-        ),
-        (
-            Without<ChildOf>,
-            Or<(
-                With<AncestorMarker<RigidBody>>,
-                With<AncestorMarker<ColliderMarker>>,
-            )>,
-        ),
-    >,
-    mut orphaned: RemovedComponents<ChildOf>,
-    transform_query: Query<TransformQueryData, With<ChildOf>>,
-    // This is used if the entity has no physics entity ancestor.
-    parent_query_1: Query<ParentQueryData>,
-    // This is used if the entity is a physics entity with children *or* if any ancestor is a physics entity.
-    parent_query_2: Query<ParentQueryData, PhysicsObjectOrAncestorFilter>,
-    mut orphaned_entities: Local<Vec<Entity>>,
-) {
-    orphaned_entities.clear();
-    orphaned_entities.extend(orphaned.read());
-    orphaned_entities.sort_unstable();
-    root_query.par_iter_mut().for_each(
-        |(entity, children, transform, mut global_transform, is_root_rb, is_root_collider)| {
-            let changed = transform.is_changed() || global_transform.is_added() || orphaned_entities.binary_search(&entity).is_ok();
-            if changed {
-                *global_transform = GlobalTransform::from(*transform);
-            }
-
-            let handle = |(child, actual_child_of, is_parent_rb, is_parent_collider): (Entity, Ref<ChildOf>, bool, bool)| {
-                assert_eq!(
-                    actual_child_of.parent(), entity,
-                    "Malformed hierarchy. This probably means that your hierarchy has been improperly maintained, or contains a cycle"
-                );
-                // SAFETY:
-                // - `child` must have consistent parentage, or the above assertion would panic.
-                // Since `child` is parented to a root entity, the entire hierarchy leading to it is consistent.
-                // - We may operate as if all descendants are consistent, since `propagate_recursive` will panic before
-                //   continuing to propagate if it encounters an entity with inconsistent parentage.
-                // - Since each root entity is unique and the hierarchy is consistent and forest-like,
-                //   other root entities' `propagate_recursive` calls will not conflict with this one.
-                // - Since this is the only place where `transform_query` gets used, there will be no conflicting fetches elsewhere.
-                #[allow(unsafe_code)]
-                unsafe {
-                    propagate_transforms_physics_recursive(
-                        &global_transform,
-                        &transform_query,
-                        &parent_query_1,
-                        &parent_query_2,
-                        child,
-                        changed || actual_child_of.is_changed(),
-                        is_parent_rb || is_parent_collider,
-                    );
-                }
-            };
-
-            if is_root_rb || is_root_collider {
-                parent_query_1.iter_many(children).for_each(handle);
-            } else {
-                parent_query_2.iter_many(children).for_each(handle);
-            }
-        },
-    );
-}
-
-/// Recursively propagates the transforms for `entity` and all of its descendants.
-///
-/// # Panics
-///
-/// If `entity`'s descendants have a malformed hierarchy, this function will panic occur before propagating
-/// the transforms of any malformed entities and their descendants.
-///
-/// # Safety
-///
-/// - While this function is running, `transform_query` must not have any fetches for `entity`,
-///   nor any of its descendants.
-/// - The caller must ensure that the hierarchy leading to `entity`
-///   is well-formed and must remain as a tree or a forest. Each entity must have at most one parent.
-#[allow(clippy::type_complexity)]
-unsafe fn propagate_transforms_physics_recursive(
-    parent: &GlobalTransform,
-    transform_query: &Query<TransformQueryData, With<ChildOf>>,
-    // This is used if the entity has no physics entity ancestor.
-    parent_query_1: &Query<ParentQueryData>,
-    // This is used if the entity is a physics entity with children *or* if any ancestor is a physics entity.
-    parent_query_2: &Query<ParentQueryData, PhysicsObjectOrAncestorFilter>,
-    entity: Entity,
-    mut changed: bool,
-    mut any_ancestor_is_physics_entity: bool,
-) {
-    let (global_matrix, children) = {
-        let Ok((transform, mut global_transform, children, is_rb, is_collider)) =
-            // SAFETY: This call cannot create aliased mutable references.
-            //   - The top level iteration parallelizes on the roots of the hierarchy.
-            //   - The caller ensures that each child has one and only one unique parent throughout the entire
-            //     hierarchy.
-            //
-            // For example, consider the following malformed hierarchy:
-            //
-            //     A
-            //   /   \
-            //  B     C
-            //   \   /
-            //     D
-            //
-            // D has two parents, B and C. If the propagation passes through C, but the ChildOf component on D points to B,
-            // the above check will panic as the origin parent does match the recorded parent.
-            //
-            // Also consider the following case, where A and B are roots:
-            //
-            //  A       B
-            //   \     /
-            //    C   D
-            //     \ /
-            //      E
-            //
-            // Even if these A and B start two separate tasks running in parallel, one of them will panic before attempting
-            // to mutably access E.
-            (unsafe { transform_query.get_unchecked(entity) }) else {
-                return;
-            };
-
-        if any_ancestor_is_physics_entity || is_rb || is_collider {
-            any_ancestor_is_physics_entity = true;
-
-            changed |= transform.is_changed() || global_transform.is_added();
-            if changed {
-                *global_transform = parent.mul_transform(*transform);
-            }
-        }
-
-        (*global_transform, children)
-    };
-
-    let Some(children) = children else { return };
-
-    // If the entity has a physics entity ancestor, propagate down regardless of the child type.
-    // Otherwise, only propagate to entities that are physics entities or physics entity ancestors.
-    if any_ancestor_is_physics_entity {
-        for (child, actual_child_of, is_parent_rb, is_parent_collider) in
-            parent_query_1.iter_many(children)
-        {
-            assert_eq!(
-                actual_child_of.parent(), entity,
-                "Malformed hierarchy. This probably means that your hierarchy has been improperly maintained, or contains a cycle"
-            );
-            // SAFETY: The caller guarantees that `transform_query` will not be fetched
-            // for any descendants of `entity`, so it is safe to call `propagate_transforms_physics_recursive` for each child.
-            //
-            // The above assertion ensures that each child has one and only one unique parent throughout the
-            // entire hierarchy.
-            unsafe {
-                propagate_transforms_physics_recursive(
-                    &global_matrix,
-                    transform_query,
-                    parent_query_1,
-                    parent_query_2,
-                    child,
-                    changed || actual_child_of.is_changed(),
-                    any_ancestor_is_physics_entity || is_parent_rb || is_parent_collider,
-                );
-            }
-        }
-    } else {
-        for (child, actual_child_of, is_parent_rb, is_parent_collider) in
-            parent_query_2.iter_many(children)
-        {
-            assert_eq!(
-                actual_child_of.parent(), entity,
-                "Malformed hierarchy. This probably means that your hierarchy has been improperly maintained, or contains a cycle"
-            );
-            // SAFETY: The caller guarantees that `transform_query` will not be fetched
-            // for any descendants of `entity`, so it is safe to call `propagate_transforms_physics_recursive` for each child.
-            //
-            // The above assertion ensures that each child has one and only one unique parent throughout the
-            // entire hierarchy.
-            unsafe {
-                propagate_transforms_physics_recursive(
-                    &global_matrix,
-                    transform_query,
-                    parent_query_1,
-                    parent_query_2,
-                    child,
-                    changed || actual_child_of.is_changed(),
-                    any_ancestor_is_physics_entity || is_parent_rb || is_parent_collider,
-                );
-            }
-        }
     }
 }


### PR DESCRIPTION
# Objective

- Replacing the Avian transform propagation functions with the ones from the Bevy engine to leverage [0.16's faster transform propagation](https://bevyengine.org/news/bevy-0-16/#faster-transform-propagation).

## Solution
Replaced every instance of these systems

```
sync_simple_transforms_physics,
propagate_transforms_physics,
```
with these directly from Bevy

```
mark_dirty_trees,
propagate_parent_transforms,
sync_simple_transforms,
```
And also removed code related to sync_simple_transforms_physics and propagate_transforms_physics that are now no longer used.

I was running into a problem on my computer where having many hierarchies was causing my FPS to vary wildly, but switching to the Bevy propagation resolved it. 

Before (averaging ~20 fps with drops into the single digits)
![image](https://github.com/user-attachments/assets/b087f839-1e45-4126-987d-b12dd1cbacb5)
After (averaging a more steady ~100fps)
![image](https://github.com/user-attachments/assets/ed22ac1f-b67e-4189-b81c-c024fe271161)

Using this resolved the issue in my game. I also ran a bunch of the examples to compare and can't tell a difference before and after even on the determinism ones.

---

## Changelog

> replaced the Avian transform propagation functions with the ones from the Bevy engine 



## Example Used

This is the example I was using above

```rust
use bevy::{
    diagnostic::{DiagnosticsStore, FrameTimeDiagnosticsPlugin},
    prelude::*,
};

use avian3d::prelude::*;

fn main() {
    App::new()
        .add_plugins((
            DefaultPlugins,
            PhysicsPlugins::default(),
            FrameTimeDiagnosticsPlugin::default(),
        ))
        .add_systems(Startup, setup)
        .add_systems(Update, text_update_system)
        .run();
}

#[derive(Component)]
struct FpsText;

fn setup(
    mut commands: Commands,
    mut meshes: ResMut<Assets<Mesh>>,
    mut materials: ResMut<Assets<StandardMaterial>>,
    mut time: ResMut<Time<Physics>>,
) {
    commands.spawn((
        Camera3d::default(),
        Transform::from_xyz(3.0, 1.0, 3.0).looking_at(Vec3::new(0.0, -0.5, 0.0), Vec3::Y),
    ));

    let cube = meshes.add(Cuboid::new(0.5, 0.5, 0.5));

    const GOLDEN_ANGLE: f32 = 137.507_77;

    let mut hsla = Hsla::hsl(0.0, 1.0, 0.5);
    let count = 20;
    let nest_count = 100;

    for x in -count..count {
        for z in -count..count {
            let mut current_entity = commands
                .spawn((
                    Transform::from_translation(Vec3::new(x as f32, 0.0, z as f32)),
                    Visibility::Visible,
                ))
                .id();

            for _ in 0..nest_count {
                current_entity = commands
                    .spawn((Transform::default(), Visibility::Visible))
                    .insert(ChildOf(current_entity))
                    .id();
            }

            commands.spawn((
                Mesh3d(cube.clone()),
                MeshMaterial3d(materials.add(Color::from(hsla))),
                Transform::default(),
                Collider::cuboid(0.5, 0.5, 0.5),
                RigidBody::Dynamic,
                ChildOf(current_entity),
            ));
            hsla = hsla.rotate_hue(GOLDEN_ANGLE);
        }
    }

    time.pause();

    commands
        .spawn((
            Text::new("FPS: "),
            TextFont {
                font_size: 42.0,
                ..default()
            },
        ))
        .with_child((
            TextSpan::default(),
            TextFont {
                font_size: 33.0,
                ..default()
            },
            FpsText,
        ));
}

fn text_update_system(
    diagnostics: Res<DiagnosticsStore>,
    mut query: Query<&mut TextSpan, With<FpsText>>,
) {
    for mut span in &mut query {
        if let Some(fps) = diagnostics.get(&FrameTimeDiagnosticsPlugin::FPS) {
            if let Some(value) = fps.smoothed() {
                **span = format!("{value:.2}");
            }
        }
    }
}
```