### PR TITLE
Add convex_polyline for creating Collider

### DIFF
--- a/src/collision/collider/constructor.rs
+++ b/src/collision/collider/constructor.rs
@@ -391,6 +391,9 @@ pub enum ColliderConstructor {
     /// Constructs a collider with [`Collider::convex_hull`].
     #[cfg(feature = "3d")]
     ConvexHull { points: Vec<Vector> },
+    /// Constructs a collider with [`Collider::convex_polyline`].
+    #[cfg(feature = "2d")]
+    ConvexPolyline { points: Vec<Vector> },
     /// Constructs a collider with [`Collider::heightfield`].
     #[cfg(feature = "2d")]
     Heightfield { heights: Vec<Scalar>, scale: Vector },

--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -942,7 +942,7 @@ impl Collider {
         SharedShape::convex_hull(&points).map(Into::into)
     }
 
-    /// Creates a collider with a [convex polygon](https://en.wikipedia.org/wiki/Convex_polygon) shape **without** computing 
+    /// Creates a collider with a [convex polygon](https://en.wikipedia.org/wiki/Convex_polygon) shape **without** computing
     /// the [convex hull](https://en.wikipedia.org/wiki/Convex_hull) of the given points: convexity of the input is
     /// assumed and not checked.
     #[cfg(feature = "2d")]

--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -943,7 +943,7 @@ impl Collider {
     }
 
     /// Creates a collider with a [convex polygon](https://en.wikipedia.org/wiki/Convex_polygon) shape **without** computing 
-    /// the the [convex hull](https://en.wikipedia.org/wiki/Convex_hull) of the given points: convexity of the input is
+    /// the [convex hull](https://en.wikipedia.org/wiki/Convex_hull) of the given points: convexity of the input is
     /// assumed and not checked.
     #[cfg(feature = "2d")]
     pub fn convex_polyline(points: Vec<Vector>) -> Option<Self> {

--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -942,6 +942,15 @@ impl Collider {
         SharedShape::convex_hull(&points).map(Into::into)
     }
 
+    /// Creates a collider with a [convex polygon](https://en.wikipedia.org/wiki/Convex_polygon) shape **without** computing 
+    /// the the [convex hull](https://en.wikipedia.org/wiki/Convex_hull) of the given points: convexity of the input is
+    /// assumed and not checked.
+    #[cfg(feature = "2d")]
+    pub fn convex_polyline(points: Vec<Vector>) -> Option<Self> {
+        let points = points.iter().map(|v| (*v).into()).collect::<Vec<_>>();
+        SharedShape::convex_polyline(points).map(Into::into)
+    }
+
     /// Creates a collider with a heightfield shape.
     ///
     /// A 2D heightfield is a segment along the `X` axis, subdivided at regular intervals.
@@ -1236,6 +1245,8 @@ impl Collider {
             ColliderConstructor::ConvexHull { points } => Self::convex_hull(points),
             #[cfg(feature = "3d")]
             ColliderConstructor::ConvexHull { points } => Self::convex_hull(points),
+            #[cfg(feature = "2d")]
+            ColliderConstructor::ConvexPolyline { points } => Self::convex_polyline(points),
             #[cfg(feature = "2d")]
             ColliderConstructor::Heightfield { heights, scale } => {
                 Some(Self::heightfield(heights, scale))


### PR DESCRIPTION
# Objective

Add a method called convex_polyline to Collider. convex_polyline should be the same as convex_hull but without computing convex hull of the points.


