### PR TITLE
Make CI faster

### DIFF
--- a/.cargo/config_ci.toml
+++ b/.cargo/config_ci.toml
@@ -1,0 +1,12 @@
+# This config is used for the CI workflow.
+
+# Enable a small amount of optimization in the dev profile.
+[profile.dev]
+opt-level = 1
+
+# Enable a large amount of optimization in the dev profile for dependencies.
+[profile.dev.package."*"]
+opt-level = 3
+
+[target.x86_64-pc-windows-msvc]
+linker = "rust-lld.exe"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
                 os: [windows-latest, macos-latest, ubuntu-latest]
         env:
             LD_LIBRARY_PATH: "$(rustc --print target-libdir)"
+            RUSTFLAGS: --deny warnings -C debuginfo=line-tables-only -Zthreads=0
         runs-on: ${{ matrix.os }}
         timeout-minutes: 60
         steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,11 +91,11 @@ jobs:
                 save-if: ${{ github.ref == 'refs/heads/main' }}
                 cache-directories: ${{ steps.ld-windows.outputs.libdir }}
                 cache-all-crates: true
+            - name: Run cargo test
+              run: cargo nextest run --locked --no-default-features --lib --bins --examples --no-fail-fast --features enhanced-determinism,parallel,collider-from-mesh,serialize,debug-plugin,avian2d/2d,avian3d/3d,avian2d/f64,avian3d/f64,default-collider,parry-f64,bevy_scene,bevy_picking,diagnostic_ui,bevy/dynamic_linking
             - name: Run doc tests
               run: cargo test --locked --doc --no-default-features --features enhanced-determinism,parallel,collider-from-mesh,serialize,debug-plugin,avian2d/2d,avian3d/3d,avian2d/f64,avian3d/f64,default-collider,parry-f64,bevy_scene,bevy_picking,diagnostic_ui,bevy/dynamic_linking
   
-            - name: Run cargo test
-              run: cargo nextest run --locked --no-default-features --lib --bins --examples --no-fail-fast --features enhanced-determinism,parallel,collider-from-mesh,serialize,debug-plugin,avian2d/2d,avian3d/3d,avian2d/f64,avian3d/f64,default-collider,parry-f64,bevy_scene,bevy_picking,diagnostic_ui,bevy/dynamic_linking
            
     lints:
         name: Lints

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,6 @@ jobs:
             matrix:
                 os: [windows-latest, macos-latest, ubuntu-latest]
         env:
-            LD_LIBRARY_PATH: "$(rustc --print target-libdir)"
             RUSTFLAGS: --deny warnings -C debuginfo=line-tables-only -Zthreads=0
         runs-on: ${{ matrix.os }}
         timeout-minutes: 60
@@ -66,6 +65,13 @@ jobs:
               with:
                 save-if: ${{ github.ref == 'refs/heads/main' }}
                 cache-all-crates: true
+            - name: set LD_LIBRARY_PATH on unix
+              run: LD_LIBRARY_PATH=$(rustc --print target-libdir)
+              if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest' }}
+            - name: set LD_LIBRARY_PATH on windows
+              run: $env:PATH += ";" + (rustc --print target-libdir)
+              shell: pwsh
+              if: ${{ matrix.os == 'windows-latest' }}
             - name: Run cargo test
               run: cargo nextest run --locked --no-default-features --lib --bins --examples --no-fail-fast --features enhanced-determinism,parallel,collider-from-mesh,serialize,debug-plugin,avian2d/2d,avian3d/3d,avian2d/f64,avian3d/f64,default-collider,parry-f64,bevy_scene,bevy_picking,diagnostic_ui,bevy/dynamic_linking
             - name: Run doc tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,22 +61,42 @@ jobs:
               run: cargo binstall cargo-binutils --force
             - name: Activate CI cargo config
               run: mv .cargo/config_ci.toml .cargo/config.toml
-            - uses: Swatinem/rust-cache@v2
-              with:
-                save-if: ${{ github.ref == 'refs/heads/main' }}
-                cache-all-crates: true
             - name: set LD_LIBRARY_PATH on unix
-              run: LD_LIBRARY_PATH=$(rustc --print target-libdir)
+              id: ld-unix
+              run: |
+                echo "LD_LIBRARY_PATH=$(rustc --print target-libdir)" >> "$GITHUB_ENV"
+                echo "libdir=$(rustc --print target-libdir)" >> "$GITHUB_OUTPUT"
               if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest' }}
-            - name: set LD_LIBRARY_PATH on windows
-              run: $env:PATH += ";" + (rustc --print target-libdir)
+            - name: set LD_LIBRARY_PATH on Windows
+              id: ld-windows
+              run: |
+                $libDir = (rustc --print target-libdir)
+                Add-Content -Path $env:GITHUB_ENV -Value "RUST_LIB_DIR=$libDir"
+                Add-Content -Path $env:GITHUB_PATH -Value "$libDir"
+                "libdir=$libDir" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
               shell: pwsh
               if: ${{ matrix.os == 'windows-latest' }}
-            - name: Run cargo test
-              run: cargo nextest run --locked --no-default-features --lib --bins --examples --no-fail-fast --features enhanced-determinism,parallel,collider-from-mesh,serialize,debug-plugin,avian2d/2d,avian3d/3d,avian2d/f64,avian3d/f64,default-collider,parry-f64,bevy_scene,bevy_picking,diagnostic_ui,bevy/dynamic_linking
+            - name: Restore Rust cache on Unix
+              uses: Swatinem/rust-cache@v2
+              if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest' }}
+              with:
+                save-if: ${{ github.ref == 'refs/heads/main' }}
+                cache-directories: ${{ steps.ld-unix.outputs.libdir }}
+                cache-all-crates: true
+            - name: Restore Rust cache on Windows
+              uses: Swatinem/rust-cache@v2
+              if: ${{ matrix.os == 'windows-latest' }}
+              with:
+                save-if: ${{ github.ref == 'refs/heads/main' }}
+                cache-directories: ${{ steps.ld-windows.outputs.libdir }}
+                cache-all-crates: true
             - name: Run doc tests
               run: cargo test --locked --doc --no-default-features --features enhanced-determinism,parallel,collider-from-mesh,serialize,debug-plugin,avian2d/2d,avian3d/3d,avian2d/f64,avian3d/f64,default-collider,parry-f64,bevy_scene,bevy_picking,diagnostic_ui,bevy/dynamic_linking
-
+  
+            - name: Run cargo test
+              run: cargo nextest run --locked --no-default-features --lib --bins --examples --no-fail-fast --features enhanced-determinism,parallel,collider-from-mesh,serialize,debug-plugin,avian2d/2d,avian3d/3d,avian2d/f64,avian3d/f64,default-collider,parry-f64,bevy_scene,bevy_picking,diagnostic_ui,bevy/dynamic_linking
+           
     lints:
         name: Lints
         runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,22 +45,30 @@ jobs:
         strategy:
             matrix:
                 os: [windows-latest, macos-latest, ubuntu-latest]
+        env:
+            LD_LIBRARY_PATH: "$(rustc --print target-libdir)"
         runs-on: ${{ matrix.os }}
         timeout-minutes: 60
         steps:
             - uses: actions/checkout@v4
-            - uses: dtolnay/rust-toolchain@stable
+            - uses: dtolnay/rust-toolchain@nightly
+              with:
+                components: llvm-tools-preview
             - uses: cargo-bins/cargo-binstall@main
             - name: Install nextest
-              run: cargo binstall cargo-nextest --secure --force
+              run: cargo binstall cargo-nextest --force
+            - name: Install LLD
+              run: cargo binstall cargo-binutils --force
+            - name: Activate CI cargo config
+              run: mv .cargo/config_ci.toml .cargo/config.toml
             - uses: Swatinem/rust-cache@v2
               with:
                 save-if: ${{ github.ref == 'refs/heads/main' }}
                 cache-all-crates: true
             - name: Run cargo test
-              run: cargo nextest run --locked --no-default-features --lib --bins --examples --no-fail-fast --features enhanced-determinism,parallel,collider-from-mesh,serialize,debug-plugin,avian2d/2d,avian3d/3d,avian2d/f64,avian3d/f64,default-collider,parry-f64,bevy_scene,bevy_picking,diagnostic_ui
+              run: cargo nextest run --locked --no-default-features --lib --bins --examples --no-fail-fast --features enhanced-determinism,parallel,collider-from-mesh,serialize,debug-plugin,avian2d/2d,avian3d/3d,avian2d/f64,avian3d/f64,default-collider,parry-f64,bevy_scene,bevy_picking,diagnostic_ui,bevy/dynamic_linking
             - name: Run doc tests
-              run: cargo test --locked --doc --no-default-features --features enhanced-determinism,parallel,collider-from-mesh,serialize,debug-plugin,avian2d/2d,avian3d/3d,avian2d/f64,avian3d/f64,default-collider,parry-f64,bevy_scene,bevy_picking,diagnostic_ui
+              run: cargo test --locked --doc --no-default-features --features enhanced-determinism,parallel,collider-from-mesh,serialize,debug-plugin,avian2d/2d,avian3d/3d,avian2d/f64,avian3d/f64,default-collider,parry-f64,bevy_scene,bevy_picking,diagnostic_ui,bevy/dynamic_linking
 
     lints:
         name: Lints

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,10 @@ jobs:
             - name: set LD_LIBRARY_PATH on unix
               id: ld-unix
               run: |
+                # Linux
                 echo "LD_LIBRARY_PATH=$(rustc --print target-libdir)" >> "$GITHUB_ENV"
+                # macOS
+                echo "DYLD_LIBRARY_PATH=$(rustc --print target-libdir)" >> "$GITHUB_ENV"
                 echo "libdir=$(rustc --print target-libdir)" >> "$GITHUB_OUTPUT"
               if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest' }}
             - name: set LD_LIBRARY_PATH on Windows
@@ -74,7 +77,6 @@ jobs:
                 Add-Content -Path $env:GITHUB_ENV -Value "RUST_LIB_DIR=$libDir"
                 Add-Content -Path $env:GITHUB_PATH -Value "$libDir"
                 "libdir=$libDir" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-
               shell: pwsh
               if: ${{ matrix.os == 'windows-latest' }}
             - name: Restore Rust cache on Unix


### PR DESCRIPTION
For the tests:
- Use dynamic linking
- Cache the dynamic libraries
- Use LLD on Windows (our bottleneck)
- Run nightly
- Activate parallel rustc frontend

I did not change the linker to `mold` on linux nor did I activate `cranelift` there because Windows is the bottleneck by *far* and those are not reliably available there.