### PR TITLE
Optimize gyroscopic motion

### DIFF
--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -165,6 +165,10 @@ name = "revolute_joint_3d"
 required-features = ["3d", "default-collider"]
 
 [[example]]
+name = "gyroscopic_motion"
+required-features = ["3d", "default-collider"]
+
+[[example]]
 name = "picking"
 required-features = ["3d", "default-collider", "bevy_picking"]
 

--- a/crates/avian3d/examples/gyroscopic_motion.rs
+++ b/crates/avian3d/examples/gyroscopic_motion.rs
@@ -1,0 +1,131 @@
+//! Gyroscopic motion is the tendency of a rotating object to maintain its axis of rotation
+//! unless acted upon by an external torque. It manifests as objects with non-uniform angular
+//! inertia tensors seemingly wobbling as they spin in the air or on the ground, and is
+//! responsible for many rotational phenomena.
+//!
+//! One interesting example of gyroscopic motion is the Dzhanibekov effect, also known as the
+//! "tennis racket theorem". When a rigid body with three distinct principal moments of inertia
+//! is rotated about one of its principal axes, it can exhibit a sudden flip or change in
+//! rotation about the other two axes. This example demonstrates this effect using a
+//! tennis racket and a T-handle.
+//!
+//! Avian handles gyroscopic motion automatically. No special setup is required.
+
+use avian3d::{math::*, prelude::*};
+use bevy::prelude::*;
+use examples_common_3d::ExampleCommonPlugin;
+
+fn main() {
+    App::new()
+        .add_plugins((
+            DefaultPlugins,
+            ExampleCommonPlugin,
+            PhysicsPlugins::default(),
+        ))
+        .insert_resource(Gravity::ZERO)
+        .add_systems(Startup, setup)
+        .add_systems(FixedUpdate, log_racket_angular_momentum)
+        .run();
+}
+
+/// A marker component for the "T-handle" used to demonstrate the Dzhanibekov effect.
+#[derive(Component)]
+struct THandle;
+
+/// A marker component for the "tennis racket", also used to demonstrate the Dzhanibekov effect.
+#[derive(Component)]
+struct Racket;
+
+fn setup(
+    mut commands: Commands,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+    mut meshes: ResMut<Assets<Mesh>>,
+) {
+    let material = materials.add(Color::WHITE);
+
+    // Spawn the T-handle.
+    let large_cylinder = Cylinder::new(0.4, 5.0);
+    let small_cylinder = Cylinder::new(0.25, 1.25);
+    commands.spawn((
+        Name::new("T-handle"),
+        THandle,
+        RigidBody::Dynamic,
+        AngularVelocity(Vector::Z * 10.0),
+        Transform::from_xyz(-4.0, 0.0, 0.0).with_rotation(Quat::from_rotation_y(FRAC_PI_2)),
+        Collider::from(large_cylinder),
+        Mesh3d(meshes.add(large_cylinder)),
+        MeshMaterial3d(material.clone()),
+        children![(
+            Transform::from_xyz(1.0, 0.0, 0.0).with_rotation(Quat::from_rotation_z(FRAC_PI_2)),
+            Collider::from(small_cylinder),
+            Mesh3d(meshes.add(small_cylinder)),
+            MeshMaterial3d(material.clone()),
+        )],
+    ));
+
+    // Spawn the tennis racket.
+    let racket_handle_circular = Cylinder::new(0.25, 1.5);
+    let racket_face_circular = Cylinder::new(1.5, 0.2);
+    commands.spawn((
+        Name::new("Tennis Racket"),
+        Racket,
+        RigidBody::Dynamic,
+        Transform::from_xyz(4.0, 0.0, 0.0).with_rotation(Quat::from_rotation_y(0.001)),
+        AngularVelocity(Vector::X * 10.0),
+        Visibility::default(),
+        children![
+            (
+                Name::new("Racket Handle"),
+                Transform::from_xyz(0.0, 0.0, 1.5).with_rotation(Quat::from_rotation_x(FRAC_PI_2)),
+                Collider::from(racket_handle_circular),
+                Mesh3d(meshes.add(racket_handle_circular)),
+                MeshMaterial3d(material.clone()),
+            ),
+            (
+                Name::new("Racket Face"),
+                Transform::from_xyz(0.0, 0.0, -1.5).with_scale(Vec3::new(1.0, 1.0, 1.5)),
+                Collider::from(racket_face_circular),
+                Mesh3d(meshes.add(racket_face_circular)),
+                MeshMaterial3d(material.clone()),
+            )
+        ],
+    ));
+
+    // Directional light
+    commands.spawn((
+        DirectionalLight {
+            illuminance: 3000.0,
+            shadows_enabled: true,
+            ..default()
+        },
+        Transform::default().looking_at(Vec3::new(-1.0, -2.5, -1.5), Vec3::Y),
+    ));
+
+    // Camera
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_translation(Vec3::new(10.0, 5.0, 10.0)).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
+}
+
+/// Logs the angular momentum of the racket to see how it changes over time.
+fn log_racket_angular_momentum(
+    query: Query<(&AngularVelocity, &GlobalTransform, &ComputedAngularInertia), With<Racket>>,
+) {
+    for (angular_velocity, global_transform, inertia) in &query {
+        // Compute the up-to-date inertia tensor in world space.
+        let world_inertia = inertia.rotated(global_transform.rotation());
+
+        // Compute the angular momentum.
+        let angular_momentum = world_inertia.tensor() * angular_velocity.0;
+
+        // Gyroscopic torque should conserve angular momentum and kinetic energy,
+        // assuming no external torques are applied.
+        //
+        // However, due to the semi-implicit Euler integration scheme and the discrete nature
+        // of the simulation, energy may still gradually decrease over time. This is expected
+        // and typically acceptable for game physics. The more important problem to avoid is
+        // more energy being introduced into the system, as that can lead to instability.
+        info!("Racket angular momentum: {:.1}", angular_momentum.length());
+    }
+}

--- a/src/dynamics/integrator/mod.rs
+++ b/src/dynamics/integrator/mod.rs
@@ -182,6 +182,8 @@ fn integrate_velocities(
         let SolverBody {
             linear_velocity,
             angular_velocity,
+            #[cfg(feature = "3d")]
+            delta_rotation,
             ..
         } = body.solver_body.into_inner();
 
@@ -205,6 +207,8 @@ fn integrate_velocities(
             let external_force = body.force.force();
             let external_torque = body.torque.torque() + body.force.torque();
             let gravity = gravity.0 * body.gravity_scale.map_or(1.0, |scale| scale.0);
+            #[cfg(feature = "3d")]
+            let rotation = *delta_rotation * *body.rot;
 
             semi_implicit_euler::integrate_velocity(
                 linear_velocity,
@@ -216,7 +220,7 @@ fn integrate_velocities(
                 #[cfg(feature = "3d")]
                 body.global_angular_inertia,
                 #[cfg(feature = "3d")]
-                *body.rot,
+                rotation,
                 locked_axes,
                 gravity,
                 delta_secs,

--- a/src/dynamics/integrator/semi_implicit_euler.rs
+++ b/src/dynamics/integrator/semi_implicit_euler.rs
@@ -66,22 +66,8 @@ pub fn integrate_velocity(
     {
         // In 3D, we should also handle gyroscopic motion, which accounts for
         // non-spherical shapes that may wobble as they spin in the air.
-        //
-        // Gyroscopic motion happens when the inertia tensor is not uniform, causing
-        // the angular momentum to point in a different direction than the angular velocity.
-        //
-        // The gyroscopic torque is τ = ω x Iω.
-        //
-        // However, the basic semi-implicit approach can blow up, as semi-implicit Euler
-        // extrapolates velocity and the gyroscopic torque is quadratic in the angular velocity.
-        // Thus, we use implicit Euler, which is much more accurate and stable, although slightly more expensive.
-        let delta_ang_vel_gyro = solve_gyroscopic_torque(
-            *ang_vel,
-            rotation.0,
-            angular_inertia.tensor(),
-            delta_seconds,
-        );
-        *ang_vel += locked_axes.apply_to_angular_velocity(delta_ang_vel_gyro);
+        solve_gyroscopic_torque(ang_vel, rotation.0, angular_inertia, delta_seconds);
+        *ang_vel = locked_axes.apply_to_angular_velocity(*ang_vel);
     }
 }
 
@@ -169,39 +155,78 @@ pub fn angular_acceleration(
     effective_angular_inertia.inverse() * torque
 }
 
-/// Computes the angular correction caused by gyroscopic motion,
-/// which may cause objects with non-uniform angular inertia to wobble
-/// while spinning.
+/// Applies the effects of gyroscopic motion to the given angular velocity.
+///
+/// Gyroscopic motion is the tendency of a rotating object to maintain its axis of rotation
+/// unless acted upon by an external torque. It manifests as objects with non-uniform angular
+/// inertia tensors seemingly wobbling as they spin in the air or on the ground.
+///
+/// Gyroscopic motion is important for realistic spinning behavior, and for simulating
+/// gyroscopic phenomena such as the Dzhanibekov effect.
 #[cfg(feature = "3d")]
+#[inline]
 pub fn solve_gyroscopic_torque(
-    ang_vel: Vector,
+    ang_vel: &mut Vector,
     rotation: Quaternion,
-    local_inertia: Matrix,
-    delta_seconds: Scalar,
-) -> Vector {
-    // Based on the "Gyroscopic Motion" section of Erin Catto's GDC 2015 slides on Numerical Methods.
-    // https://box2d.org/files/ErinCatto_NumericalMethods_GDC2015.pdf
+    local_inertia: &ComputedAngularInertia,
+    delta_secs: Scalar,
+) {
+    // References:
+    // - The "Gyroscopic Motion" section of Erin Catto's GDC 2015 slides on Numerical Methods.
+    //   https://box2d.org/files/ErinCatto_NumericalMethods_GDC2015.pdf
+    // - Jolt Physics - MotionProperties::ApplyGyroscopicForceInternal
+    //   https://github.com/jrouwe/JoltPhysics/blob/d497df2b9b0fa9aaf41295e1406079c23148232d/Jolt/Physics/Body/MotionProperties.inl#L102
+    //
+    // Erin Catto's GDC presentation suggests using implicit Euler for gyroscopic torque,
+    // as semi-implicit Euler can easily blow up with larger time steps due to extrapolating velocity.
+    // The extrapolation diverges quickly because gyroscopic torque is quadratic in the angular velocity.
+    //
+    // However, implicit Euler is measurably more expensive than semi-implicit Euler.
+    // We instead take inspiration from Jolt, and use semi-implicit Euler integration,
+    // clamping the magnitude of the angular momentum to remain the same.
+    // This is efficient, prevents energy from being introduced into the system,
+    // and produces reasonably accurate results for game purposes.
 
-    // Convert angular velocity to body coordinates so that we can use the local angular inertia
-    let local_ang_vel = rotation.inverse() * ang_vel;
+    // Convert angular velocity to body space so that we can use the local angular inertia.
+    let local_ang_vel = rotation.inverse() * *ang_vel;
 
-    // Compute body-space angular momentum
-    let angular_momentum = local_inertia * local_ang_vel;
+    // Compute body-space angular momentum.
+    let local_momentum = local_inertia.tensor() * local_ang_vel;
 
-    // Compute Jacobian
-    let jacobian = local_inertia
-        + delta_seconds
-            * (skew_symmetric_mat3(local_ang_vel) * local_inertia
-                - skew_symmetric_mat3(angular_momentum));
+    // The gyroscopic torque is given by:
+    //
+    // T = -ω x I ω = -ω x L
+    //
+    // where ω is the angular velocity, I is the angular inertia tensor,
+    // and L is the angular momentum.
+    //
+    // The change in angular momentum is given by:
+    //
+    // ΔL = T Δt = -ω x L Δt
+    //
+    // Thus, we can compute the new angular momentum as:
+    //
+    // L' = L + ΔL = L - Δt (ω x L)
+    let mut new_local_momentum = local_momentum - delta_secs * local_ang_vel.cross(local_momentum);
 
-    // Residual vector
-    let f = delta_seconds * local_ang_vel.cross(angular_momentum);
+    // Make sure the magnitude of the angular momentum remains the same to avoid introducing
+    // energy into the system due to the extrapolation done by semi-implicit Euler integration.
+    let new_local_momentum_length_squared = new_local_momentum.length_squared();
+    if new_local_momentum_length_squared == 0.0 {
+        *ang_vel = Vector::ZERO;
+        return;
+    }
+    new_local_momentum *=
+        ops::sqrt(local_momentum.length_squared() / new_local_momentum_length_squared);
 
-    // Do one Newton-Raphson iteration
-    let delta_ang_vel = -jacobian.inverse_or_zero() * f;
-
-    // Convert back to world coordinates
-    rotation * delta_ang_vel
+    // Convert back to world-space angular velocity.
+    let local_inverse_inertia = local_inertia.inverse();
+    let inv_inertia_diagonal = Vector::new(
+        local_inverse_inertia.x_axis.x,
+        local_inverse_inertia.y_axis.y,
+        local_inverse_inertia.z_axis.z,
+    );
+    *ang_vel = rotation * (inv_inertia_diagonal * new_local_momentum);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Objective

#420 changed Avian to use implicit Euler integration for solving gyroscopic torque. This was done for stability, as the semi-implicit version was prone to blowing up, because it extrapolated angular velocity and brought energy into the system.

However, that implementation of gyroscopic torque is fairly expensive, often being more than half of the total cost of velocity integration.  It would be nice to make this have less overhead.

Additionally, #735 broke gyroscopic motion, which needs to be fixed.

## Solution

Switch gyroscopic torque back to an approach that is closer to semi-implicit Euler integration, but clamp the magnitude of the angular momentum to remain the same. This prevents energy from being introduced to the system and seems to be sufficiently accurate for game physics. This idea was inspired by Jolt's [`ApplyGyroscopicForceInternal`](https://github.com/jrouwe/JoltPhysics/blob/d497df2b9b0fa9aaf41295e1406079c23148232d/Jolt/Physics/Body/MotionProperties.inl#L102).

## Results

This is a 3D test scene with a bunch of cube stacks. The inertia tensors of the cubes are uniform, so they shouldn't really experience any gyroscopic effects.

- **Left**: Before any optimizations.
- **Right**: With the faster gyroscopic torque solver.

![Performance comparison](https://github.com/user-attachments/assets/8d6bb41a-ad45-406b-9a7d-a2f1f55076c6)

## Bonus: `gyroscopic_motion` Example

I added a new `gyroscopic_motion` example to demonstrate the Dzhanibekov effect and test the conservation of angular momentum.

https://github.com/user-attachments/assets/9ef9e335-feb9-4685-8f12-2f34ba442937