### PR TITLE
Cache colliders created from meshes via constructors

### DIFF
--- a/src/collision/collider/cache.rs
+++ b/src/collision/collider/cache.rs
@@ -10,7 +10,7 @@ pub struct ColliderCachePlugin;
 impl Plugin for ColliderCachePlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<ColliderCache>();
-        app.add_systems(PostUpdate, clear_unused_colliders);
+        app.add_systems(PreUpdate, clear_unused_colliders);
     }
 }
 

--- a/src/collision/collider/cache.rs
+++ b/src/collision/collider/cache.rs
@@ -1,0 +1,30 @@
+use bevy::{platform::collections::HashMap, prelude::*};
+
+use super::{Collider, ColliderConstructor};
+
+/// A plugin for caching colliders created from meshes.
+pub struct ColliderCachePlugin;
+
+impl Plugin for ColliderCachePlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<ColliderCache>();
+    }
+}
+
+#[derive(Debug, Resource, Default)]
+pub(crate) struct ColliderCache(HashMap<Handle<Mesh>, Collider>);
+
+impl ColliderCache {
+    pub(crate) fn get_or_insert(
+        &mut self,
+        mesh_handle: &Handle<Mesh>,
+        mesh: &Mesh,
+        constructor: ColliderConstructor,
+    ) -> Option<Collider> {
+        if !self.0.contains_key(mesh_handle) {
+            let collider = Collider::try_from_constructor(constructor, Some(mesh))?;
+            self.0.insert(mesh_handle.clone_weak(), collider);
+        }
+        self.0.get(mesh_handle).cloned()
+    }
+}

--- a/src/collision/collider/cache.rs
+++ b/src/collision/collider/cache.rs
@@ -15,7 +15,7 @@ impl Plugin for ColliderCachePlugin {
 }
 
 #[derive(Debug, Resource, Default)]
-pub(crate) struct ColliderCache(HashMap<AssetId<Mesh>, Collider>);
+pub(crate) struct ColliderCache(HashMap<(AssetId<Mesh>, ColliderConstructor), Collider>);
 
 impl ColliderCache {
     pub(crate) fn get_or_insert(

--- a/src/collision/collider/cache.rs
+++ b/src/collision/collider/cache.rs
@@ -2,12 +2,15 @@ use bevy::{platform::collections::HashMap, prelude::*};
 
 use super::{Collider, ColliderConstructor};
 
-/// A plugin for caching colliders created from meshes.
+/// A plugin for caching colliders created from meshes via [`ColliderConstructor`] or [`ColliderConstructorHierarchy`](super::ColliderConstructorHierarchy).
+/// With this plugin enabled, colliders created from meshes through such constructors will be created only once and reused.
+/// This is especially useful when performing convex decomposition, as this is a very expensive operation.
 pub struct ColliderCachePlugin;
 
 impl Plugin for ColliderCachePlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<ColliderCache>();
+        app.add_systems(PostUpdate, garbage_collect_collider_cache);
     }
 }
 
@@ -27,4 +30,15 @@ impl ColliderCache {
         }
         self.0.get(mesh_handle).cloned()
     }
+}
+
+fn garbage_collect_collider_cache(
+    mut collider_cache: ResMut<ColliderCache>,
+    asset_server: Res<AssetServer>,
+) {
+    collider_cache
+        .0
+        // Not using `is_loaded_with_dependencies` because when dropping a handle,
+        // the entire hierarchy of handles is dropped.
+        .retain(|mesh_handle, _| asset_server.is_loaded(mesh_handle));
 }

--- a/src/collision/collider/cache.rs
+++ b/src/collision/collider/cache.rs
@@ -15,7 +15,7 @@ impl Plugin for ColliderCachePlugin {
 }
 
 #[derive(Debug, Resource, Default)]
-pub(crate) struct ColliderCache(HashMap<(AssetId<Mesh>, ColliderConstructor), Collider>);
+pub(crate) struct ColliderCache(HashMap<AssetId<Mesh>, Collider>);
 
 impl ColliderCache {
     pub(crate) fn get_or_insert(

--- a/src/collision/collider/cache.rs
+++ b/src/collision/collider/cache.rs
@@ -47,7 +47,9 @@ fn clear_unused_colliders(
 ) {
     for event in asset_events.read() {
         if let AssetEvent::Removed { id } | AssetEvent::Unused { id } = event {
-            collider_cache.0.remove(id);
+            if collider_cache.0.contains_key(id) {
+                collider_cache.0.remove(id);
+            }
         }
     }
 }

--- a/src/collision/collider/constructor.rs
+++ b/src/collision/collider/constructor.rs
@@ -447,9 +447,9 @@ impl ColliderConstructor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bevy::ecs::query::QueryData;
     #[cfg(feature = "bevy_scene")]
     use bevy::scene::ScenePlugin;
+    use bevy::{ecs::query::QueryData, render::mesh::MeshPlugin};
 
     #[test]
     fn collider_constructor_requires_no_mesh_on_primitive() {
@@ -747,6 +747,7 @@ mod tests {
             AssetPlugin::default(),
             #[cfg(feature = "bevy_scene")]
             ScenePlugin,
+            MeshPlugin,
             PhysicsPlugins::default(),
         ))
         .init_resource::<Assets<Mesh>>();

--- a/src/collision/collider/mod.rs
+++ b/src/collision/collider/mod.rs
@@ -15,9 +15,9 @@ mod backend;
 
 pub use backend::{ColliderBackendPlugin, ColliderMarker};
 
-#[cfg(feature = "collider-from-mesh")]
+#[cfg(all(feature = "collider-from-mesh", feature = "default-collider"))]
 mod cache;
-#[cfg(feature = "collider-from-mesh")]
+#[cfg(all(feature = "collider-from-mesh", feature = "default-collider"))]
 pub use cache::ColliderCachePlugin;
 pub mod collider_hierarchy;
 pub mod collider_transform;

--- a/src/collision/collider/mod.rs
+++ b/src/collision/collider/mod.rs
@@ -15,6 +15,10 @@ mod backend;
 
 pub use backend::{ColliderBackendPlugin, ColliderMarker};
 
+#[cfg(feature = "collider-from-mesh")]
+mod cache;
+#[cfg(feature = "collider-from-mesh")]
+pub use cache::ColliderCachePlugin;
 pub mod collider_hierarchy;
 pub mod collider_transform;
 

--- a/src/collision/mod.rs
+++ b/src/collision/mod.rs
@@ -82,6 +82,8 @@ pub use diagnostics::CollisionDiagnostics;
 /// Re-exports common types related to collision detection functionality.
 pub mod prelude {
     pub use super::broad_phase::{BroadPhasePlugin, BroadPhaseSet};
+    #[cfg(feature = "collider-from-mesh")]
+    pub use super::collider::ColliderCachePlugin;
     pub use super::collider::{
         collider_hierarchy::{ColliderHierarchyPlugin, ColliderOf, RigidBodyColliders},
         collider_transform::{ColliderTransform, ColliderTransformPlugin},

--- a/src/collision/mod.rs
+++ b/src/collision/mod.rs
@@ -82,7 +82,7 @@ pub use diagnostics::CollisionDiagnostics;
 /// Re-exports common types related to collision detection functionality.
 pub mod prelude {
     pub use super::broad_phase::{BroadPhasePlugin, BroadPhaseSet};
-    #[cfg(feature = "collider-from-mesh")]
+    #[cfg(all(feature = "collider-from-mesh", feature = "default-collider"))]
     pub use super::collider::ColliderCachePlugin;
     pub use super::collider::{
         collider_hierarchy::{ColliderHierarchyPlugin, ColliderOf, RigidBodyColliders},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -566,7 +566,11 @@ use prelude::*;
 /// | [`MassPropertyPlugin`]            | Manages mass properties of dynamic [rigid bodies](RigidBody).                                                                                              |
 /// | [`ColliderBackendPlugin`]         | Handles generic collider backend logic, like initializing colliders and AABBs and updating related components.                                             |
 /// | [`ColliderHierarchyPlugin`]       | Manages [`ColliderOf`] relationships based on the entity hierarchy.                                                                                        |
-/// | [`ColliderTransformPlugin`]       | Propagates and updates transforms for colliders.                                                                                                           |
+/// | [`ColliderTransformPlugin`]       | Propagates and updates transforms for colliders.
+#[cfg_attr(
+    all(feature = "collider-from-mesh", feature = "default-collider"),
+    doc = "| [`ColliderCachePlugin`]           | Caches colliders created from meshes. Requires `collider-from-mesh` and `default-collider` features.                                                       |"
+)]
 /// | [`BroadPhasePlugin`]              | Finds pairs of entities with overlapping [AABBs](ColliderAabb) to reduce the number of potential contacts for the [narrow phase](collision::narrow_phase). |
 /// | [`NarrowPhasePlugin`]             | Manages contacts and generates contact constraints.                                                                                                        |
 /// | [`SolverSchedulePlugin`]          | Sets up the solver and substepping loop by initializing the necessary schedules, sets and resources.                                                       |
@@ -791,7 +795,7 @@ impl PluginGroup for PhysicsPlugins {
             .add(ColliderHierarchyPlugin)
             .add(ColliderTransformPlugin::new(self.schedule));
 
-        #[cfg(feature = "collider-from-mesh")]
+        #[cfg(all(feature = "collider-from-mesh", feature = "default-collider"))]
         let builder = builder.add(ColliderCachePlugin);
 
         #[cfg(all(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -791,6 +791,9 @@ impl PluginGroup for PhysicsPlugins {
             .add(ColliderHierarchyPlugin)
             .add(ColliderTransformPlugin::new(self.schedule));
 
+        #[cfg(feature = "collider-from-mesh")]
+        let builder = builder.add(ColliderCachePlugin);
+
         #[cfg(all(
             feature = "default-collider",
             any(feature = "parry-f32", feature = "parry-f64")

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -22,6 +22,8 @@ fn create_app() -> App {
         TransformPlugin,
         PhysicsPlugins::default(),
         bevy::asset::AssetPlugin::default(),
+        #[cfg(all(feature = "collider-from-mesh", feature = "default-collider"))]
+        bevy::render::mesh::MeshPlugin,
         #[cfg(feature = "bevy_scene")]
         bevy::scene::ScenePlugin,
     ))
@@ -195,6 +197,8 @@ fn no_ambiguity_errors() {
             bevy::asset::AssetPlugin::default(),
             #[cfg(feature = "bevy_scene")]
             bevy::scene::ScenePlugin,
+            #[cfg(all(feature = "collider-from-mesh", feature = "default-collider"))]
+            bevy::render::mesh::MeshPlugin,
         ))
         .init_resource::<Assets<Mesh>>()
         .edit_schedule(DeterministicSchedule, |s| {


### PR DESCRIPTION
# Objective

- Creating colliders from meshes can be expensive when not just using a trimesh
- Especially convex decomps take ages
- In end-user cases, `ColliderConstructor` and `ColliderConstructorHierarchy` are *very* popular for creating colliders from meshes
- Ideally, we would have a way to cache any and all colliders, but I think caching the ones made from a mesh with these methods would already bring us 90% of the way, from a user perspective.

## Solution

So, let's cache them! Intentionally leaving the cache `pub(crate)` and not `pub` so we can easily expand it without breaking anything for users.

---

## Changelog

- Using `ColliderConstructor` or `ColliderConstructorHierarchy` for creating colliders from meshes will now cache the collider. This is especially noticeable when creating multiple copies of a mesh with a collider from a convex decomposition, e.g. spawning ten chairs each with `ColliderConstructorHierarchy::new(ColliderConstructor::ConvexDecompositionFromMesh)`
