### PR TITLE
Fix gyroscopic torque

### DIFF
--- a/src/dynamics/integrator/semi_implicit_euler.rs
+++ b/src/dynamics/integrator/semi_implicit_euler.rs
@@ -224,12 +224,7 @@ pub fn solve_gyroscopic_torque(
 
     // Convert back to world-space angular velocity.
     let local_inverse_inertia = local_inertia.inverse();
-    let inv_inertia_diagonal = Vector::new(
-        local_inverse_inertia.x_axis.x,
-        local_inverse_inertia.y_axis.y,
-        local_inverse_inertia.z_axis.z,
-    );
-    *ang_vel = rotation * (inv_inertia_diagonal * new_local_momentum);
+    *ang_vel = rotation * (local_inverse_inertia * new_local_momentum);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Objective

#738 optimized gyroscopic torque. However, it also broke it! The current algorithm only uses the diagonal of the inertia tensor at the end, when it should be using the full tensor.

## Solution

Use the full tensor.

Alternatively, if we represented the inertia tensor with the principal moments of inertia and an orientation, we would just apply that additional orientation. This is what Jolt does.