### PR TITLE
Fix order of quaternion multiplication

### DIFF
--- a/src/dynamics/integrator/mod.rs
+++ b/src/dynamics/integrator/mod.rs
@@ -283,7 +283,8 @@ fn integrate_positions(
         }
         #[cfg(feature = "3d")]
         {
-            delta_rotation.0 *= Quaternion::from_scaled_axis(*angular_velocity * delta_secs);
+            delta_rotation.0 =
+                Quaternion::from_scaled_axis(*angular_velocity * delta_secs) * delta_rotation.0;
         }
     });
 

--- a/src/dynamics/integrator/semi_implicit_euler.rs
+++ b/src/dynamics/integrator/semi_implicit_euler.rs
@@ -98,7 +98,7 @@ pub fn integrate_position(
     #[cfg(feature = "2d")]
     {
         let delta_rot = Rotation::radians(ang_vel * delta_seconds);
-        *rot *= delta_rot;
+        *rot = delta_rot * *rot;
         *rot = rot.fast_renormalize();
     }
     #[cfg(feature = "3d")]


### PR DESCRIPTION
# Objective

@unpairedbracket noticed that we right-multiply rotation instead of left-multiplying it during position integration. This affects how the rotations compose and the order they are applied. While the observable difference tends to be small here, we should get it fixed!

## Solution

Fix the order of multiplication.