### PR TITLE
Fix `body` property of collision events and reflect `CollisionEventsEnabled` properly

### DIFF
--- a/src/collision/collision_events.rs
+++ b/src/collision/collision_events.rs
@@ -279,5 +279,5 @@ pub struct OnCollisionEnd {
 #[derive(Component, Clone, Copy, Debug, Default, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Debug)]
+#[reflect(Component, Debug)]
 pub struct CollisionEventsEnabled;

--- a/src/collision/narrow_phase/mod.rs
+++ b/src/collision/narrow_phase/mod.rs
@@ -280,7 +280,7 @@ fn update_narrow_phase<C: AnyCollider, H: CollisionHooks + 'static>(
 
 #[derive(SystemParam)]
 struct TriggerCollisionEventsContext<'w, 's> {
-    query: Query<'w, 's, Option<&'static ColliderOf>, With<CollisionEventsEnabled>>,
+    query: Query<'w, 's, (Option<&'static ColliderOf>, Has<CollisionEventsEnabled>)>,
     started: EventReader<'w, 's, CollisionStarted>,
     ended: EventReader<'w, 's, CollisionEnded>,
 }
@@ -300,26 +300,36 @@ fn trigger_collision_events(
     // Collect `OnCollisionStart` and `OnCollisionEnd` events
     // for entities that have events enabled.
     for event in state.started.read() {
-        if let Ok(collider_of) = state.query.get(event.1) {
+        let Ok([(collider_of1, events_enabled1), (collider_of2, events_enabled2)]) =
+            state.query.get_many([event.0, event.1])
+        else {
+            continue;
+        };
+        if events_enabled1 {
             let collider = event.1;
-            let body = collider_of.map(|c| c.body);
+            let body = collider_of2.map(|c| c.body);
             started_pairs.push((event.0, OnCollisionStart { collider, body }));
         }
-        if let Ok(collider_of) = state.query.get(event.0) {
+        if events_enabled2 {
             let collider = event.0;
-            let body = collider_of.map(|c| c.body);
+            let body = collider_of1.map(|c| c.body);
             started_pairs.push((event.1, OnCollisionStart { collider, body }));
         }
     }
     for event in state.ended.read() {
-        if let Ok(collider_of) = state.query.get(event.1) {
+        let Ok([(collider_of1, events_enabled1), (collider_of2, events_enabled2)]) =
+            state.query.get_many([event.0, event.1])
+        else {
+            continue;
+        };
+        if events_enabled1 {
             let collider = event.1;
-            let body = collider_of.map(|c| c.body);
+            let body = collider_of2.map(|c| c.body);
             ended_pairs.push((event.0, OnCollisionEnd { collider, body }));
         }
-        if let Ok(collider_of) = state.query.get(event.0) {
+        if events_enabled2 {
             let collider = event.0;
-            let body = collider_of.map(|c| c.body);
+            let body = collider_of1.map(|c| c.body);
             ended_pairs.push((event.1, OnCollisionEnd { collider, body }));
         }
     }

--- a/src/collision/narrow_phase/mod.rs
+++ b/src/collision/narrow_phase/mod.rs
@@ -108,7 +108,12 @@ where
         #[cfg(feature = "parallel")]
         app.init_resource::<NarrowPhaseThreadLocals>();
 
-        app.register_type::<(NarrowPhaseConfig, DefaultFriction, DefaultRestitution)>();
+        app.register_type::<(
+            NarrowPhaseConfig,
+            DefaultFriction,
+            DefaultRestitution,
+            CollisionEventsEnabled,
+        )>();
 
         app.add_event::<CollisionStarted>()
             .add_event::<CollisionEnded>();

--- a/src/collision/narrow_phase/mod.rs
+++ b/src/collision/narrow_phase/mod.rs
@@ -295,24 +295,24 @@ fn trigger_collision_events(
     // Collect `OnCollisionStart` and `OnCollisionEnd` events
     // for entities that have events enabled.
     for event in state.started.read() {
-        if let Ok(collider_of) = state.query.get(event.0) {
+        if let Ok(collider_of) = state.query.get(event.1) {
             let collider = event.1;
             let body = collider_of.map(|c| c.body);
             started_pairs.push((event.0, OnCollisionStart { collider, body }));
         }
-        if let Ok(collider_of) = state.query.get(event.1) {
+        if let Ok(collider_of) = state.query.get(event.0) {
             let collider = event.0;
             let body = collider_of.map(|c| c.body);
             started_pairs.push((event.1, OnCollisionStart { collider, body }));
         }
     }
     for event in state.ended.read() {
-        if let Ok(collider_of) = state.query.get(event.0) {
+        if let Ok(collider_of) = state.query.get(event.1) {
             let collider = event.1;
             let body = collider_of.map(|c| c.body);
             ended_pairs.push((event.0, OnCollisionEnd { collider, body }));
         }
-        if let Ok(collider_of) = state.query.get(event.1) {
+        if let Ok(collider_of) = state.query.get(event.0) {
             let collider = event.0;
             let body = collider_of.map(|c| c.body);
             ended_pairs.push((event.1, OnCollisionEnd { collider, body }));


### PR DESCRIPTION
# Objective

Fixes #750

Someone (me) somehow got the entities mixed up for the `body` property of the `OnCollisionStart` and `OnCollisionEnded` events. It is documented to be the body of the entity that hit `trigger.target()`, but it is in fact the body associated with the `trigger.target()` itself. Yikes!

Additionally, the `CollisionEventsEnabled` type doesn't reflect `Component` and isn't registered. This breaks scenes.

## Solution

Fix `body` to be the body of the entity that hit `trigger.target()`, and reflect `Component` for `CollisionEventsEnabled`.

This is critical enough that I'll make a 0.3.1 patch release with it soon.