### PR TITLE
ColliderConstructor::Compound

### DIFF
--- a/src/collision/collider/constructor.rs
+++ b/src/collision/collider/constructor.rs
@@ -280,6 +280,7 @@ pub struct ColliderConstructorHierarchyConfig {
 #[cfg_attr(feature = "collider-from-mesh", derive(Default))]
 #[cfg_attr(feature = "collider-from-mesh", reflect(Default))]
 #[reflect(Debug, Component, PartialEq)]
+#[reflect(no_field_bounds)]
 #[non_exhaustive]
 #[allow(missing_docs)]
 pub enum ColliderConstructor {
@@ -427,6 +428,8 @@ pub enum ColliderConstructor {
     /// Constructs a collider with [`Collider::convex_hull_from_mesh`].
     #[cfg(feature = "collider-from-mesh")]
     ConvexHullFromMesh,
+    /// Constructs a collider with [`Collider::compound`].
+    Compound(Vec<(Position, Rotation, ColliderConstructor)>),
 }
 
 impl ColliderConstructor {
@@ -440,6 +443,20 @@ impl ColliderConstructor {
                 | Self::ConvexDecompositionFromMesh
                 | Self::ConvexDecompositionFromMeshWithConfig(_)
                 | Self::ConvexHullFromMesh
+        )
+    }
+
+    /// Construct a [`ColliderConstructor::Compound`] from arbitrary [`Position`] and [`Rotation`] representations.
+    pub fn compound<P, R>(shapes: Vec<(P, R, ColliderConstructor)>) -> Self
+    where
+        P: Into<Position>,
+        R: Into<Rotation>,
+    {
+        Self::Compound(
+            shapes
+                .into_iter()
+                .map(|(pos, rot, constructor)| (pos.into(), rot.into(), constructor))
+                .collect(),
         )
     }
 }

--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -1549,11 +1549,11 @@ mod tests {
             ),
             (
                 Position(Vector::new(5.0, 0.0, 0.0)),
-                Rotation::from(Quat::from_rotation_z(PI / 2.0)),
+                Rotation::from(Quaternion::from_rotation_z(PI / 2.0)),
                 ColliderConstructor::Compound(vec![
                     (
                         Position(Vector::new(2.0, 0.0, 0.0)),
-                        Rotation::from(Quat::from_rotation_y(PI)),
+                        Rotation::from(Quaternion::from_rotation_y(PI)),
                         ColliderConstructor::Compound(vec![(
                             Position(Vector::new(1.0, 0.0, 0.0)),
                             Rotation::default(),


### PR DESCRIPTION
# Objective

Allow for the creation of compound colliders through `ColliderConstructor`.

## Solution

Added a new enum variant to `ColliderConstructor` and a helper impl to allow constructing the variant with a wider variety of types.

---

## Changelog

> Added `ColliderConstructor::Compound`
