### PR TITLE
Fix new `mismatched_lifetime_syntaxes` lints

### DIFF
--- a/src/collision/collider/parry/primitives2d.rs
+++ b/src/collision/collider/parry/primitives2d.rs
@@ -118,7 +118,7 @@ impl Shape for EllipseColliderShape {
         parry::shape::ShapeType::Custom
     }
 
-    fn as_typed_shape(&self) -> parry::shape::TypedShape {
+    fn as_typed_shape(&self) -> parry::shape::TypedShape<'_> {
         parry::shape::TypedShape::Custom(self)
     }
 
@@ -400,7 +400,7 @@ impl Shape for RegularPolygonColliderShape {
         parry::shape::ShapeType::Custom
     }
 
-    fn as_typed_shape(&self) -> parry::shape::TypedShape {
+    fn as_typed_shape(&self) -> parry::shape::TypedShape<'_> {
         parry::shape::TypedShape::Custom(self)
     }
 

--- a/src/data_structures/bit_vec.rs
+++ b/src/data_structures/bit_vec.rs
@@ -108,7 +108,7 @@ impl BitVec {
 
     /// Returns an iterator over the blocks of the [`BitVec`].
     #[inline]
-    pub fn blocks(&self) -> Blocks {
+    pub fn blocks(&self) -> Blocks<'_> {
         Blocks {
             iter: self.blocks.iter(),
         }

--- a/src/data_structures/graph.rs
+++ b/src/data_structures/graph.rs
@@ -436,7 +436,7 @@ impl<N, E> UnGraph<N, E> {
     /// Produces an empty iterator if the node doesn't exist.
     ///
     /// The iterator element type is `NodeIndex`.
-    pub fn neighbors(&self, a: NodeIndex) -> Neighbors<E> {
+    pub fn neighbors(&self, a: NodeIndex) -> Neighbors<'_, E> {
         Neighbors {
             skip_start: a,
             edges: &self.edges,
@@ -452,7 +452,7 @@ impl<N, E> UnGraph<N, E> {
     /// Produces an empty iterator if the node doesn't exist.
     ///
     /// The iterator element type is `EdgeReference<E>`.
-    pub fn edges(&self, a: NodeIndex) -> Edges<E> {
+    pub fn edges(&self, a: NodeIndex) -> Edges<'_, E> {
         Edges {
             skip_start: a,
             edges: &self.edges,
@@ -469,7 +469,7 @@ impl<N, E> UnGraph<N, E> {
     /// Produces an empty iterator if the node doesn't exist.
     ///
     /// The iterator element type is `EdgeReference<E>`.
-    pub fn edges_mut(&mut self, a: NodeIndex) -> EdgesMut<N, E> {
+    pub fn edges_mut(&mut self, a: NodeIndex) -> EdgesMut<'_, N, E> {
         let incoming_edge = self.first_edge(a, EdgeDirection::Incoming);
         let outgoing_edge = self.first_edge(a, EdgeDirection::Outgoing);
 
@@ -518,7 +518,7 @@ impl<N, E> UnGraph<N, E> {
     }
 
     /// Returns an iterator yielding immutable access to edge weights for edges from or to `a`.
-    pub fn edge_weights(&self, a: NodeIndex) -> EdgeWeights<E> {
+    pub fn edge_weights(&self, a: NodeIndex) -> EdgeWeights<'_, E> {
         EdgeWeights {
             skip_start: a,
             edges: &self.edges,
@@ -531,7 +531,7 @@ impl<N, E> UnGraph<N, E> {
     }
 
     /// Returns an iterator yielding mutable access to edge weights for edges from or to `a`.
-    pub fn edge_weights_mut(&mut self, a: NodeIndex) -> EdgeWeightsMut<N, E> {
+    pub fn edge_weights_mut(&mut self, a: NodeIndex) -> EdgeWeightsMut<'_, N, E> {
         let incoming_edge = self.first_edge(a, EdgeDirection::Incoming);
         let outgoing_edge = self.first_edge(a, EdgeDirection::Outgoing);
 
@@ -546,7 +546,7 @@ impl<N, E> UnGraph<N, E> {
     ///
     /// The order in which weights are yielded matches the order of their
     /// edge indices.
-    pub fn all_edge_weights(&self) -> AllEdgeWeights<E> {
+    pub fn all_edge_weights(&self) -> AllEdgeWeights<'_, E> {
         AllEdgeWeights {
             edges: self.edges.iter(),
         }
@@ -556,7 +556,7 @@ impl<N, E> UnGraph<N, E> {
     ///
     /// The order in which weights are yielded matches the order of their
     /// edge indices.
-    pub fn all_edge_weights_mut(&mut self) -> AllEdgeWeightsMut<E> {
+    pub fn all_edge_weights_mut(&mut self) -> AllEdgeWeightsMut<'_, E> {
         AllEdgeWeightsMut {
             edges: self.edges.iter_mut(),
         }

--- a/src/diagnostics/ui.rs
+++ b/src/diagnostics/ui.rs
@@ -292,7 +292,7 @@ trait CommandsExt {
 }
 
 impl CommandsExt for RelatedSpawnerCommands<'_, ChildOf> {
-    fn diagnostic_group(&mut self, name: &str) -> EntityCommands {
+    fn diagnostic_group(&mut self, name: &str) -> EntityCommands<'_> {
         self.spawn((
             DiagnosticGroup,
             Name::new(name.to_string()),
@@ -305,7 +305,7 @@ impl CommandsExt for RelatedSpawnerCommands<'_, ChildOf> {
         ))
     }
 
-    fn diagnostic_row(&mut self) -> EntityCommands {
+    fn diagnostic_row(&mut self) -> EntityCommands<'_> {
         self.spawn((
             DiagnosticRow,
             Node {

--- a/src/diagnostics/ui.rs
+++ b/src/diagnostics/ui.rs
@@ -267,9 +267,9 @@ fn build_diagnostic_texts(cmd: &mut RelatedSpawnerCommands<ChildOf>) {
 
 /// An extension trait for building physics diagnostics UI.
 trait CommandsExt {
-    fn diagnostic_group(&mut self, name: &str) -> EntityCommands;
+    fn diagnostic_group(&mut self, name: &str) -> EntityCommands<'_>;
 
-    fn diagnostic_row(&mut self) -> EntityCommands;
+    fn diagnostic_row(&mut self) -> EntityCommands<'_>;
 
     fn counter_text(&mut self, text: &str, diagnostic_path: &'static DiagnosticPath);
 

--- a/src/spatial_query/ray_caster.rs
+++ b/src/spatial_query/ray_caster.rs
@@ -418,7 +418,7 @@ impl RayHits {
     /// Returns an iterator over the hits in arbitrary order.
     ///
     /// If you want to get them sorted by distance, use `iter_sorted`.
-    pub fn iter(&self) -> core::slice::Iter<RayHitData> {
+    pub fn iter(&self) -> core::slice::Iter<'_, RayHitData> {
         self.as_slice().iter()
     }
 

--- a/src/spatial_query/shape_caster.rs
+++ b/src/spatial_query/shape_caster.rs
@@ -558,7 +558,7 @@ impl ShapeHits {
     }
 
     /// Returns an iterator over the hits in the order of distance.
-    pub fn iter(&self) -> core::slice::Iter<ShapeHitData> {
+    pub fn iter(&self) -> core::slice::Iter<'_, ShapeHitData> {
         self.as_slice().iter()
     }
 }


### PR DESCRIPTION
# Objective

Rust introduced a new `mismatched_lifetime_syntaxes` lint that breaks CI.

## Solution

Fix the warnings!