### PR TITLE
Rework `Position` and `Rotation` initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,9 +67,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
@@ -136,9 +136,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "approx"
@@ -1464,15 +1464,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
+checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -1528,9 +1528,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.25"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "jobserver",
  "libc",
@@ -1554,9 +1554,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfg_aliases"
@@ -1604,18 +1604,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.39"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.39"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -1623,9 +1623,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "codespan-reporting"
@@ -2107,9 +2107,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2233,7 +2233,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -2424,9 +2424,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -2453,9 +2453,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hexasphere"
@@ -2638,9 +2638,9 @@ checksum = "9fa0e2a1fcbe2f6be6c42e342259976206b383122fc152e872795338b5a3f3a7"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libloading"
@@ -2649,7 +2649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.0",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -2666,7 +2666,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
- "redox_syscall 0.5.12",
+ "redox_syscall 0.5.13",
 ]
 
 [[package]]
@@ -2733,9 +2733,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memmap2"
@@ -2769,9 +2769,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -3290,7 +3290,7 @@ checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.12",
+ "redox_syscall 0.5.13",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -3534,9 +3534,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "portable-atomic-util"
@@ -3573,9 +3573,9 @@ checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
+checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -3638,9 +3638,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "radsort"
@@ -3734,9 +3734,9 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.29.2"
+version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f96bfbb7df43d34a2b7b8582fcbcb676ba02a763265cb90bc8aabfd62b57d64"
+checksum = "04ca636dac446b5664bd16c069c00a9621806895b8bb02c2dc68542b23b8f25d"
 dependencies = [
  "bytemuck",
  "font-types",
@@ -3759,9 +3759,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -4042,12 +4042,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "slotmap"
@@ -4060,9 +4057,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
 ]
@@ -4165,9 +4162,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4246,12 +4243,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -4281,15 +4277,15 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.9"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.26"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -4309,9 +4305,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4320,9 +4316,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -4397,9 +4393,9 @@ checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
 
 [[package]]
 name = "twox-hash"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7b17f197b3050ba473acf9181f7b1d3b66d1cf7356c6cc57886662276e65908"
+checksum = "8b907da542cbced5261bd3256de1b3a1bf340a3d37f93425a07362a1d687de56"
 
 [[package]]
 name = "typeid"
@@ -4520,9 +4516,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -4914,9 +4910,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.0"
+version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
 dependencies = [
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
@@ -5154,9 +5150,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]

--- a/src/collision/collider/mod.rs
+++ b/src/collision/collider/mod.rs
@@ -430,7 +430,7 @@ pub struct Sensor;
 
 /// The Axis-Aligned Bounding Box of a [collider](Collider) in world space.
 ///
-/// Note that the AABB will be [`ColliderAabb::INVALID`] until the first physics update.
+/// This is updated automatically.
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]

--- a/src/dynamics/rigid_body/mod.rs
+++ b/src/dynamics/rigid_body/mod.rs
@@ -19,8 +19,11 @@ pub use world_query::*;
 pub(crate) use forces::FloatZero;
 pub(crate) use forces::Torque;
 
-use crate::prelude::*;
-use bevy::prelude::*;
+use crate::{position::init_physics_transform, prelude::*};
+use bevy::{
+    ecs::{component::HookContext, world::DeferredWorld},
+    prelude::*,
+};
 use derive_more::From;
 
 /// A non-deformable body used for the simulation of most physics objects.
@@ -263,6 +266,8 @@ use derive_more::From;
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, Component, Default, PartialEq)]
 #[require(
+    Position::PLACEHOLDER,
+    Rotation::PLACEHOLDER,
     LinearVelocity,
     AngularVelocity,
     // TODO: Make these force components optional.
@@ -277,6 +282,7 @@ use derive_more::From;
     PreSolveDeltaPosition,
     PreSolveDeltaRotation,
 )]
+#[component(on_add = RigidBody::on_add)]
 #[cfg_attr(feature = "3d", require(GlobalAngularInertia))]
 pub enum RigidBody {
     /// Dynamic bodies are bodies that are affected by forces, velocity and collisions.
@@ -314,6 +320,11 @@ impl RigidBody {
     /// Checks if the rigid body is kinematic.
     pub fn is_kinematic(&self) -> bool {
         *self == Self::Kinematic
+    }
+
+    fn on_add(mut world: DeferredWorld, ctx: HookContext) {
+        // Initialize the global physics transform for the rigid body.
+        init_physics_transform(&mut world, &ctx);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -524,7 +524,7 @@ pub mod prelude {
         dynamics::{self, ccd::SpeculativeMargin, prelude::*},
         interpolation::*,
         position::{Position, Rotation},
-        prepare::{init_transforms, PrepareConfig, PreparePlugin},
+        prepare::{PrepareConfig, PreparePlugin},
         schedule::*,
         spatial_query::{self, *},
         sync::SyncPlugin,

--- a/src/position.rs
+++ b/src/position.rs
@@ -170,7 +170,6 @@ pub(crate) type RotationValue = Quaternion;
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, Component, PartialEq)]
 #[cfg(feature = "2d")]
-#[require(Transform)]
 pub struct Rotation {
     /// The cosine of the rotation angle in radians.
     ///
@@ -731,7 +730,6 @@ impl Ease for Rotation {
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, Component, Default, PartialEq)]
-#[require(Transform)]
 pub struct Rotation(pub Quaternion);
 
 #[cfg(feature = "3d")]

--- a/src/position.rs
+++ b/src/position.rs
@@ -3,7 +3,11 @@
 #![allow(clippy::unnecessary_cast)]
 
 use crate::prelude::*;
-use bevy::{math::DQuat, prelude::*};
+use bevy::{
+    ecs::{component::HookContext, world::DeferredWorld},
+    math::DQuat,
+    prelude::*,
+};
 use derive_more::From;
 
 #[cfg(feature = "2d")]
@@ -41,9 +45,15 @@ use crate::math::Matrix;
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, Component, Default, PartialEq)]
+#[require(Transform)]
 pub struct Position(pub Vector);
 
 impl Position {
+    /// A placeholder position. This is an invalid position and should *not*
+    /// be used to an actually position entities in the world, but can be used
+    /// to indicate that a position has not yet been initialized.
+    pub const PLACEHOLDER: Self = Self(Vector::MAX);
+
     /// Creates a [`Position`] component with the given global `position`.
     pub fn new(position: Vector) -> Self {
         Self(position)
@@ -161,6 +171,7 @@ pub(crate) type RotationValue = Quaternion;
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, Component, PartialEq)]
 #[cfg(feature = "2d")]
+#[require(Transform)]
 pub struct Rotation {
     /// The cosine of the rotation angle in radians.
     ///
@@ -181,6 +192,14 @@ impl Default for Rotation {
 
 #[cfg(feature = "2d")]
 impl Rotation {
+    /// A placeholder rotation. This is an invalid rotation and should *not*
+    /// be used to an actually rotate entities in the world, but can be used
+    /// to indicate that a rotation has not yet been initialized.
+    pub const PLACEHOLDER: Self = Self {
+        cos: Scalar::MAX,
+        sin: Scalar::MAX,
+    };
+
     /// No rotation.
     pub const IDENTITY: Self = Self { cos: 1.0, sin: 0.0 };
 
@@ -713,10 +732,21 @@ impl Ease for Rotation {
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, Component, Default, PartialEq)]
+#[require(Transform)]
 pub struct Rotation(pub Quaternion);
 
 #[cfg(feature = "3d")]
 impl Rotation {
+    /// A placeholder rotation. This is an invalid rotation and should *not*
+    /// be used to an actually rotate entities in the world, but can be used
+    /// to indicate that a rotation has not yet been initialized.
+    pub const PLACEHOLDER: Self = Self(Quaternion::from_xyzw(
+        Scalar::MAX,
+        Scalar::MAX,
+        Scalar::MAX,
+        Scalar::MAX,
+    ));
+
     /// No rotation.
     pub const IDENTITY: Self = Self(Quaternion::IDENTITY);
 
@@ -1011,5 +1041,160 @@ impl From<DQuat> for Rotation {
             quat.z as Scalar,
             quat.w as Scalar,
         ))
+    }
+}
+
+pub(crate) fn init_physics_transform(world: &mut DeferredWorld, ctx: &HookContext) {
+    let entity_ref = world.entity(ctx.entity);
+
+    // Get the global `Position` and `Rotation`.
+    let (mut position, is_pos_placeholder) = entity_ref
+        .get::<Position>()
+        .map_or((default(), true), |p| (*p, *p == Position::PLACEHOLDER));
+    let (mut rotation, is_rot_placeholder) = entity_ref
+        .get::<Rotation>()
+        .map_or((default(), true), |r| (*r, *r == Rotation::PLACEHOLDER));
+
+    if is_pos_placeholder {
+        position.0 = Vector::ZERO;
+    }
+    if is_rot_placeholder {
+        rotation = Rotation::IDENTITY;
+    }
+
+    // If either `Position` or `Rotation` was set manually, we want to set `Transform` to match later.
+    let is_not_placeholder = !is_pos_placeholder || !is_rot_placeholder;
+
+    let prepare_config = world
+        .get_resource::<PrepareConfig>()
+        .cloned()
+        .unwrap_or_default();
+
+    // If either `Position` or `Rotation` was not a placeholder,
+    // we need to update the `Transform` to match the current values.
+    if is_not_placeholder && prepare_config.position_to_transform {
+        // Get the parent's global transform if it exists.
+        if let Some(Some(parent_transform)) = world
+            .get::<ChildOf>(ctx.entity)
+            .map(|parent| world.get::<GlobalTransform>(parent.0))
+        {
+            #[cfg(feature = "2d")]
+            let Some(transform) = world.get::<Transform>(ctx.entity).copied() else {
+                return;
+            };
+
+            // The new local transform of the child body, computed from the its global transform
+            // and its parents global transform.
+            #[cfg(feature = "2d")]
+            let new_transform =
+                {
+                    let (parent_translation, parent_scale) =
+                        (parent_transform.translation(), parent_transform.scale());
+                    GlobalTransform::from(
+                        Transform::from_translation(position.f32().extend(
+                            parent_translation.z + transform.translation.z * parent_scale.z,
+                        ))
+                        .with_rotation(Quaternion::from(rotation).f32()),
+                    )
+                    .reparented_to(parent_transform)
+                };
+            #[cfg(feature = "3d")]
+            let new_transform = GlobalTransform::from(
+                Transform::from_translation(position.f32()).with_rotation(rotation.f32()),
+            )
+            .reparented_to(parent_transform);
+
+            // Update the `Transform` of the entity with the new local transform.
+            if let Some(mut transform) = world.get_mut::<Transform>(ctx.entity) {
+                *transform = new_transform;
+            }
+        } else if let Some(mut transform) = world.get_mut::<Transform>(ctx.entity) {
+            // If the entity has no parent, we can set the transform directly.
+            #[cfg(feature = "2d")]
+            {
+                transform.translation = position.f32().extend(transform.translation.z);
+                transform.rotation = Quaternion::from(rotation).f32();
+            }
+            #[cfg(feature = "3d")]
+            {
+                transform.translation = position.f32();
+                transform.rotation = rotation.f32();
+            }
+        }
+    }
+
+    if !prepare_config.transform_to_position {
+        if is_pos_placeholder {
+            if let Some(mut position) = world.get_mut::<Position>(ctx.entity) {
+                position.0 = Vector::ZERO;
+            }
+        }
+        if is_rot_placeholder {
+            if let Some(mut rotation) = world.get_mut::<Rotation>(ctx.entity) {
+                *rotation = Rotation::IDENTITY;
+            }
+        }
+    } else if is_pos_placeholder || is_rot_placeholder {
+        // If either `Position` or `Rotation` is a placeholder, we need to compute the global transform
+        // from the hierarchy and set the `Position` and/or `Rotation` to the computed values.
+
+        let mut global_transform = GlobalTransform::default();
+
+        if let Some(transform) = world.get::<Transform>(ctx.entity) {
+            global_transform = GlobalTransform::from(*transform);
+
+            // Compute the global transform by traversing up the hierarchy.
+            let mut curr_parent = world.get::<ChildOf>(ctx.entity);
+            while let Some(parent) = curr_parent {
+                if let Some(parent_transform) = world.get::<Transform>(parent.0) {
+                    global_transform = *parent_transform * global_transform;
+                }
+                curr_parent = world.get::<ChildOf>(parent.0);
+            }
+
+            // Set the computed `position` and `rotation` based on the global transform.
+            let (_, global_rotation, global_translation) =
+                global_transform.to_scale_rotation_translation();
+            #[cfg(feature = "2d")]
+            {
+                position.0 = global_translation.truncate().adjust_precision();
+                rotation = Rotation::from(global_rotation.adjust_precision());
+            }
+            #[cfg(feature = "3d")]
+            {
+                position.0 = global_translation.adjust_precision();
+                rotation.0 = global_rotation.adjust_precision();
+            }
+        } else {
+            // No transform was set. Set the computed `position` and `rotation` to default values.
+            if is_pos_placeholder {
+                position.0 = Vector::ZERO;
+            }
+            if is_rot_placeholder {
+                rotation = Rotation::IDENTITY;
+            }
+        }
+
+        // Now we update the actual component values based on the computed global transform.
+        let mut entity_mut = world.entity_mut(ctx.entity);
+
+        // Set the global transform.
+        if let Some(mut global_transform_mut) = entity_mut.get_mut::<GlobalTransform>() {
+            *global_transform_mut = global_transform;
+        }
+        // Set the position unless it was already set.
+        if let Some(mut pos) = entity_mut
+            .get_mut::<Position>()
+            .filter(|pos| **pos == Position::PLACEHOLDER)
+        {
+            *pos = position;
+        }
+        // Set the rotation to the global transform unless it was already set.
+        if let Some(mut rot) = entity_mut
+            .get_mut::<Rotation>()
+            .filter(|rot| **rot == Rotation::PLACEHOLDER)
+        {
+            *rot = rotation;
+        }
     }
 }

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -72,7 +72,19 @@ pub enum PrepareSet {
 impl Plugin for PreparePlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<SyncConfig>()
-            .register_type::<SyncConfig>();
+            .init_resource::<PrepareConfig>();
+
+        app.register_type::<(SyncConfig, PrepareConfig)>();
+
+        if app
+            .world()
+            .resource::<PrepareConfig>()
+            .position_to_transform
+        {
+            app.register_required_components::<Position, Transform>();
+            app.register_required_components::<Rotation, Transform>();
+        }
+
         app.configure_sets(
             self.schedule,
             (
@@ -84,9 +96,6 @@ impl Plugin for PreparePlugin {
                 .chain()
                 .in_set(PhysicsSet::Prepare),
         );
-
-        app.init_resource::<PrepareConfig>()
-            .register_type::<PrepareConfig>();
     }
 }
 

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -8,7 +8,6 @@ use crate::{prelude::*, sync::SyncConfig};
 use bevy::{
     ecs::{intern::Interned, query::QueryFilter, schedule::ScheduleLabel},
     prelude::*,
-    transform::systems::{mark_dirty_trees, propagate_parent_transforms, sync_simple_transforms},
 };
 
 /// Runs systems at the start of each physics frame. Initializes [rigid bodies](RigidBody)
@@ -88,24 +87,6 @@ impl Plugin for PreparePlugin {
 
         app.init_resource::<PrepareConfig>()
             .register_type::<PrepareConfig>();
-
-        // Note: Collider logic is handled by the `ColliderBackendPlugin`
-        app.add_systems(
-            self.schedule,
-            // Run transform propagation if new bodies have been added
-            (
-                mark_dirty_trees,
-                propagate_parent_transforms,
-                sync_simple_transforms,
-            )
-                .chain()
-                .run_if(match_any::<Added<RigidBody>>)
-                .in_set(PrepareSet::PropagateTransforms),
-        )
-        .add_systems(
-            self.schedule,
-            init_transforms::<RigidBody>.in_set(PrepareSet::InitTransforms),
-        );
     }
 }
 
@@ -135,194 +116,6 @@ pub(crate) fn match_any<F: QueryFilter>(query: Query<(), F>) -> bool {
     !query.is_empty()
 }
 
-/// Initializes [`Transform`] based on [`Position`] and [`Rotation`] or vice versa
-/// when a component of the given type is inserted.
-pub fn init_transforms<C: Component>(
-    mut commands: Commands,
-    config: Res<PrepareConfig>,
-    query: Query<
-        (
-            Entity,
-            Option<&Transform>,
-            Option<&GlobalTransform>,
-            Option<&Position>,
-            Option<&Rotation>,
-            Option<&ChildOf>,
-            Has<RigidBody>,
-        ),
-        Added<C>,
-    >,
-    parents: Query<
-        (
-            Option<&Position>,
-            Option<&Rotation>,
-            Option<&GlobalTransform>,
-        ),
-        With<Children>,
-    >,
-) {
-    if !config.position_to_transform && !config.transform_to_position {
-        // Nothing to do
-        return;
-    }
-
-    for (entity, transform, global_transform, pos, rot, parent, has_body) in &query {
-        let parent_transforms = parent.and_then(|&ChildOf(parent)| parents.get(parent).ok());
-        let parent_pos = parent_transforms.and_then(|(pos, _, _)| pos);
-        let parent_rot = parent_transforms.and_then(|(_, rot, _)| rot);
-        let parent_global_trans = parent_transforms.and_then(|(_, _, trans)| trans);
-
-        let mut new_transform = if config.position_to_transform {
-            Some(transform.copied().unwrap_or_default())
-        } else {
-            None
-        };
-
-        // Compute Transform based on Position or vice versa
-        let new_position = if let Some(pos) = pos {
-            if let Some(transform) = &mut new_transform {
-                // Initialize new translation as global position
-                #[cfg(feature = "2d")]
-                let mut new_translation = pos.f32().extend(transform.translation.z);
-                #[cfg(feature = "3d")]
-                let mut new_translation = pos.f32();
-
-                // If the body is a child, subtract the parent's global translation
-                // to get the local translation
-                if parent.is_some() {
-                    if let Some(parent_pos) = parent_pos {
-                        #[cfg(feature = "2d")]
-                        {
-                            new_translation -= parent_pos.f32().extend(new_translation.z);
-                        }
-                        #[cfg(feature = "3d")]
-                        {
-                            new_translation -= parent_pos.f32();
-                        }
-                    } else if let Some(parent_transform) = parent_global_trans {
-                        new_translation -= parent_transform.translation();
-                    }
-                }
-                transform.translation = new_translation;
-            }
-            pos.0
-        } else if config.transform_to_position {
-            let mut new_position = Vector::ZERO;
-
-            if parent.is_some() {
-                let translation = transform.as_ref().map_or(default(), |t| t.translation);
-                if let Some(parent_pos) = parent_pos {
-                    #[cfg(feature = "2d")]
-                    {
-                        new_position = parent_pos.0 + translation.adjust_precision().truncate();
-                    }
-                    #[cfg(feature = "3d")]
-                    {
-                        new_position = parent_pos.0 + translation.adjust_precision();
-                    }
-                } else if let Some(parent_transform) = parent_global_trans {
-                    let new_pos = parent_transform
-                        .transform_point(transform.as_ref().map_or(default(), |t| t.translation));
-                    #[cfg(feature = "2d")]
-                    {
-                        new_position = new_pos.truncate().adjust_precision();
-                    }
-                    #[cfg(feature = "3d")]
-                    {
-                        new_position = new_pos.adjust_precision();
-                    }
-                }
-            } else {
-                #[cfg(feature = "2d")]
-                {
-                    new_position = transform
-                        .map(|t| t.translation.truncate().adjust_precision())
-                        .unwrap_or(global_transform.as_ref().map_or(Vector::ZERO, |t| {
-                            Vector::new(t.translation().x as Scalar, t.translation().y as Scalar)
-                        }));
-                }
-                #[cfg(feature = "3d")]
-                {
-                    new_position = transform
-                        .map(|t| t.translation.adjust_precision())
-                        .unwrap_or(
-                            global_transform
-                                .as_ref()
-                                .map_or(Vector::ZERO, |t| t.translation().adjust_precision()),
-                        )
-                }
-            };
-
-            new_position
-        } else {
-            default()
-        };
-
-        // Compute Transform based on Rotation or vice versa
-        let new_rotation = if let Some(rot) = rot {
-            if let Some(transform) = &mut new_transform {
-                // Initialize new rotation as global rotation
-                let mut new_rotation = Quaternion::from(*rot).f32();
-
-                // If the body is a child, subtract the parent's global rotation
-                // to get the local rotation
-                if parent.is_some() {
-                    if let Some(parent_rot) = parent_rot {
-                        new_rotation *= Quaternion::from(*parent_rot).f32().inverse();
-                    } else if let Some(parent_transform) = parent_global_trans {
-                        new_rotation *= parent_transform.compute_transform().rotation.inverse();
-                    }
-                }
-                transform.rotation = new_rotation;
-            }
-            *rot
-        } else if config.transform_to_position {
-            if parent.is_some() {
-                let parent_rot = parent_rot.copied().unwrap_or(Rotation::from(
-                    parent_global_trans.map_or(default(), |t| t.compute_transform().rotation),
-                ));
-                let rot = Rotation::from(transform.as_ref().map_or(default(), |t| t.rotation));
-                #[cfg(feature = "2d")]
-                {
-                    parent_rot * rot
-                }
-                #[cfg(feature = "3d")]
-                {
-                    Rotation(parent_rot.0 * rot.0)
-                }
-            } else {
-                transform.map(|t| Rotation::from(t.rotation)).unwrap_or(
-                    global_transform.map_or(Rotation::default(), |t| {
-                        t.compute_transform().rotation.into()
-                    }),
-                )
-            }
-        } else {
-            default()
-        };
-
-        let mut cmds = commands.entity(entity);
-
-        // Insert the position and rotation.
-        // The values are either unchanged (`Position` and `Rotation` already exist)
-        // or computed based on the GlobalTransform.
-        match (has_body, new_transform) {
-            (true, None) => {
-                cmds.try_insert((Position(new_position), new_rotation));
-            }
-            (true, Some(transform)) => {
-                cmds.try_insert((transform, Position(new_position), new_rotation));
-            }
-            (false, None) => {
-                cmds.try_insert((Position(new_position), new_rotation));
-            }
-            (false, Some(transform)) => {
-                cmds.try_insert((transform, Position(new_position), new_rotation));
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -331,8 +124,8 @@ mod tests {
     fn test_init_transforms_basics() {
         let mut app = App::new();
 
-        // Add system under test
-        app.add_systems(Update, init_transforms::<RigidBody>);
+        // Automatically add `Transform` for every rigid body for this test.
+        app.register_required_components::<RigidBody, Transform>();
 
         // Test all possible config permutations
         for (position_to_transform, transform_to_position) in

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -118,6 +118,9 @@ pub(crate) fn match_any<F: QueryFilter>(query: Query<(), F>) -> bool {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "3d")]
+    use approx::assert_relative_eq;
+
     use super::*;
 
     #[test]
@@ -344,7 +347,10 @@ mod tests {
                 assert_eq!(pos, &expected);
                 assert!(app.world().get::<Rotation>(e_4_with_trans).is_some());
                 let rot = app.world().get::<Rotation>(e_4_with_trans).unwrap();
-                assert_eq!(rot, &Rotation::from(trans_4.rotation));
+                #[cfg(feature = "2d")]
+                assert_eq!(*rot, Rotation::from(trans_4.rotation));
+                #[cfg(feature = "3d")]
+                assert_relative_eq!(rot.f32(), trans_4.rotation);
 
                 assert!(app.world().get::<Position>(e_5_with_trans).is_some());
                 let pos = app.world().get::<Position>(e_5_with_trans).unwrap();
@@ -361,7 +367,10 @@ mod tests {
                 assert_eq!(pos, &expected);
                 assert!(app.world().get::<Rotation>(e_5_with_trans).is_some());
                 let rot = app.world().get::<Rotation>(e_5_with_trans).unwrap();
+                #[cfg(feature = "2d")]
                 assert_eq!(rot, &Rotation::from(trans_5.rotation));
+                #[cfg(feature = "3d")]
+                assert_relative_eq!(rot.f32(), trans_5.rotation);
 
                 assert!(app.world().get::<Position>(e_6_without_trans).is_some());
                 let pos = app.world().get::<Position>(e_6_without_trans).unwrap();

--- a/src/tests/determinism_2d.rs
+++ b/src/tests/determinism_2d.rs
@@ -62,7 +62,7 @@ fn cross_platform_determinism_2d() {
     let hash = compute_hash(app.world(), query);
 
     // Update this value if simulation behavior changes.
-    let expected = 0xb196dad8;
+    let expected = 0x2b3eeafc;
 
     assert!(
         hash == expected,


### PR DESCRIPTION
# Objective

`Position` and `Rotation` are currently not required components for physics entities, and are only inserted at the start of the physics step. This leads to unnecessary archetype moves, but also causes problems with any logic that requires accurate physics positions before this, such as AABB updates, (future) BVH insertions, and more.

## Solution

Make `Position` and `Rotation` required components for `RigidBody` and `Collider`, and initialize them with the correct global values using lifecycle hooks.

`ColliderAabb` is now also initialized correctly since the correct physics positions are available right after spawn.

The initialization logic could definitely be cleaned up and optimized... but for now it's good enough, I want to unblock some other work with this :P

---

## Migration Guide

`Position`, `Rotation`, and `ColliderAabb` are now initialized with correct world-space values right after spawn.