### PR TITLE
Add support for `Voxels` shape

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,7 +402,7 @@ dependencies = [
  "bevy_utils",
  "blake3",
  "derive_more",
- "downcast-rs 2.0.1",
+ "downcast-rs",
  "either",
  "petgraph",
  "ron",
@@ -429,7 +429,7 @@ dependencies = [
  "cfg-if",
  "console_error_panic_hook",
  "ctrlc",
- "downcast-rs 2.0.1",
+ "downcast-rs",
  "log",
  "thiserror 2.0.12",
  "variadics_please",
@@ -460,7 +460,7 @@ dependencies = [
  "crossbeam-channel",
  "derive_more",
  "disqualified",
- "downcast-rs 2.0.1",
+ "downcast-rs",
  "either",
  "futures-io",
  "futures-lite",
@@ -996,7 +996,7 @@ dependencies = [
  "bevy_utils",
  "derive_more",
  "disqualified",
- "downcast-rs 2.0.1",
+ "downcast-rs",
  "erased-serde",
  "foldhash",
  "glam",
@@ -1052,7 +1052,7 @@ dependencies = [
  "bytemuck",
  "codespan-reporting",
  "derive_more",
- "downcast-rs 2.0.1",
+ "downcast-rs",
  "encase",
  "fixedbitset",
  "futures-lite",
@@ -1371,7 +1371,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "shlex",
  "syn",
 ]
@@ -1750,7 +1750,7 @@ dependencies = [
  "fontdb",
  "log",
  "rangemap",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "rustybuzz",
  "self_cell",
  "smol_str",
@@ -1935,12 +1935,6 @@ checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
 dependencies = [
  "litrs",
 ]
-
-[[package]]
-name = "downcast-rs"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "downcast-rs"
@@ -2792,7 +2786,7 @@ dependencies = [
  "indexmap",
  "log",
  "pp-rs",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "spirv",
  "strum",
  "termcolor",
@@ -2814,7 +2808,7 @@ dependencies = [
  "once_cell",
  "regex",
  "regex-syntax 0.8.5",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "thiserror 1.0.69",
  "tracing",
  "unicode-ident",
@@ -3261,6 +3255,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2c1f9f56e534ac6a9b8a4600bdf0f530fb393b5f393e7b4d03489c3cf0c3f01"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3297,116 +3300,112 @@ dependencies = [
 
 [[package]]
 name = "parry2d"
-version = "0.17.6"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87edd53b1639e011e4765eecfceb0fa2c486da696dcdcfbc9a38bfc3574fb7e0"
+checksum = "fcc75102c1fac2294401262c78e5a42abe7168244c9436df2fec8fe0c27395c7"
 dependencies = [
  "approx",
  "arrayvec",
  "bitflags 2.9.1",
- "downcast-rs 1.2.1",
+ "downcast-rs",
  "either",
  "ena",
+ "hashbrown",
  "indexmap",
  "log",
  "nalgebra",
  "num-derive",
  "num-traits",
- "ordered-float",
+ "ordered-float 5.0.0",
  "rayon",
- "rustc-hash 2.1.1",
  "serde",
  "simba",
  "slab",
- "smallvec",
  "spade",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "parry2d-f64"
-version = "0.17.6"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42dadff562001ff51eed809d7c75ac6f185d8cffc575d7b45a8bdc6ea6f1bf30"
+checksum = "6c1bf4d25366c83ff7c3f6d4e7a718b44dae8582c07867fc22fadc787726ffc2"
 dependencies = [
  "approx",
  "arrayvec",
  "bitflags 2.9.1",
- "downcast-rs 1.2.1",
+ "downcast-rs",
  "either",
  "ena",
+ "hashbrown",
  "indexmap",
  "log",
  "nalgebra",
  "num-derive",
  "num-traits",
- "ordered-float",
+ "ordered-float 5.0.0",
  "rayon",
- "rustc-hash 2.1.1",
  "serde",
  "simba",
  "slab",
- "smallvec",
  "spade",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "parry3d"
-version = "0.17.6"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeb9659a05b1783fb2e9bc94f48225ae5b40817eb45b62569c0e4dd767a6e51"
+checksum = "e7f8d0a3b2f4c0e250d4599b69e490535521c3497e2b88b0b5d2ada251bc83a8"
 dependencies = [
  "approx",
  "arrayvec",
  "bitflags 2.9.1",
- "downcast-rs 1.2.1",
+ "downcast-rs",
  "either",
  "ena",
+ "hashbrown",
  "indexmap",
  "log",
  "nalgebra",
  "num-derive",
  "num-traits",
- "ordered-float",
+ "ordered-float 5.0.0",
  "rayon",
  "rstar",
- "rustc-hash 2.1.1",
  "serde",
  "simba",
  "slab",
- "smallvec",
  "spade",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "parry3d-f64"
-version = "0.17.6"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4484c8ad93ff03c0e57aa1a4f3ff5406ab6301a1eb838ef6dea90e94f00a6c7"
+checksum = "95ba84fdf1b5b1579829399cee5e1e78d52ad0e376a17e8bd56768568080821d"
 dependencies = [
  "approx",
  "arrayvec",
  "bitflags 2.9.1",
- "downcast-rs 1.2.1",
+ "downcast-rs",
  "either",
  "ena",
+ "hashbrown",
  "indexmap",
  "log",
  "nalgebra",
  "num-derive",
  "num-traits",
- "ordered-float",
+ "ordered-float 5.0.0",
  "rayon",
  "rstar",
- "rustc-hash 2.1.1",
  "serde",
  "simba",
  "slab",
- "smallvec",
  "spade",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -3858,12 +3857,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
-
-[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4085,6 +4078,7 @@ dependencies = [
  "hashbrown",
  "num-traits",
  "robust",
+ "serde",
  "smallvec",
 ]
 
@@ -4668,7 +4662,7 @@ dependencies = [
  "parking_lot",
  "profiling",
  "raw-window-handle",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "smallvec",
  "thiserror 2.0.12",
  "wgpu-hal",
@@ -4705,13 +4699,13 @@ dependencies = [
  "ndk-sys 0.5.0+25.2.9519653",
  "objc",
  "once_cell",
- "ordered-float",
+ "ordered-float 4.6.0",
  "parking_lot",
  "profiling",
  "range-alloc",
  "raw-window-handle",
  "renderdoc-sys",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "smallvec",
  "thiserror 2.0.12",
  "wasm-bindgen",

--- a/crates/avian2d/Cargo.toml
+++ b/crates/avian2d/Cargo.toml
@@ -82,8 +82,8 @@ bevy_heavy = { version = "0.2" }
 bevy_transform_interpolation = { version = "0.2" }
 libm = { version = "0.2", optional = true }
 approx = "0.5"
-parry2d = { version = "0.17", optional = true }
-parry2d-f64 = { version = "0.17", optional = true }
+parry2d = { version = "0.21", optional = true }
+parry2d-f64 = { version = "0.21", optional = true }
 nalgebra = { version = "0.33", features = ["convert-glam029"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 derive_more = "1"

--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -84,8 +84,8 @@ bevy_heavy = { version = "0.2" }
 bevy_transform_interpolation = { version = "0.2" }
 libm = { version = "0.2", optional = true }
 approx = "0.5"
-parry3d = { version = "0.17", optional = true }
-parry3d-f64 = { version = "0.17", optional = true }
+parry3d = { version = "0.21", optional = true }
+parry3d-f64 = { version = "0.21", optional = true }
 nalgebra = { version = "0.33", features = ["convert-glam029"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 derive_more = "1"

--- a/src/collision/collider/constructor.rs
+++ b/src/collision/collider/constructor.rs
@@ -398,6 +398,27 @@ pub enum ColliderConstructor {
     /// Constructs a collider with [`Collider::convex_polyline`].
     #[cfg(feature = "2d")]
     ConvexPolyline { points: Vec<Vector> },
+    /// Constructs a collider with [`Collider::voxels`].
+    Voxels {
+        voxel_size: Vector,
+        grid_coordinates: Vec<IVector>,
+    },
+    /// Constructs a collider with [`Collider::voxelized_polyline`].
+    #[cfg(feature = "2d")]
+    VoxelizedPolyline {
+        vertices: Vec<Vector>,
+        indices: Vec<[u32; 2]>,
+        voxel_size: Scalar,
+        fill_mode: FillMode,
+    },
+    /// Constructs a collider with [`Collider::voxelized_trimesh`].
+    #[cfg(feature = "3d")]
+    VoxelizedTrimesh {
+        vertices: Vec<Vector>,
+        indices: Vec<[u32; 3]>,
+        voxel_size: Scalar,
+        fill_mode: FillMode,
+    },
     /// Constructs a collider with [`Collider::heightfield`].
     #[cfg(feature = "2d")]
     Heightfield { heights: Vec<Scalar>, scale: Vector },
@@ -431,6 +452,12 @@ pub enum ColliderConstructor {
     /// Constructs a collider with [`Collider::convex_hull_from_mesh`].
     #[cfg(feature = "collider-from-mesh")]
     ConvexHullFromMesh,
+    /// Constructs a collider with [`Collider::voxelized_trimesh_from_mesh`].
+    #[cfg(feature = "collider-from-mesh")]
+    VoxelizedTrimeshFromMesh {
+        voxel_size: Scalar,
+        fill_mode: FillMode,
+    },
     /// Constructs a collider with [`Collider::compound`].
     Compound(Vec<(Position, Rotation, ColliderConstructor)>),
 }
@@ -446,6 +473,7 @@ impl ColliderConstructor {
                 | Self::ConvexDecompositionFromMesh
                 | Self::ConvexDecompositionFromMeshWithConfig(_)
                 | Self::ConvexHullFromMesh
+                | Self::VoxelizedTrimeshFromMesh { .. }
         )
     }
 

--- a/src/debug_render/gizmos.rs
+++ b/src/debug_render/gizmos.rs
@@ -275,6 +275,19 @@ impl PhysicsGizmoExt for Gizmos<'_, '_, PhysicsGizmos> {
                 let d = basis2 * -10_000.0;
                 self.draw_polyline(&[a, b, c, d], &[[0, 1], [2, 3]], position, rotation, color);
             }
+            TypedShape::Voxels(v) => {
+                #[cfg(feature = "2d")]
+                let (vertices, indices) = v.to_polyline();
+                #[cfg(feature = "3d")]
+                let (vertices, indices) = v.to_outline();
+                self.draw_polyline(
+                    &nalgebra_to_glam(&vertices),
+                    &indices,
+                    position,
+                    rotation,
+                    color,
+                );
+            }
             TypedShape::HeightField(s) => {
                 #[cfg(feature = "2d")]
                 for segment in s.segments() {

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -30,6 +30,14 @@ pub(crate) use bevy_math::Vec2 as VectorF32;
 #[cfg(feature = "3d")]
 pub(crate) use bevy_math::Vec3 as VectorF32;
 
+/// The `i32` vector type chosen based on the dimension.
+#[cfg(feature = "2d")]
+pub(crate) use bevy_math::IVec2 as IVector;
+
+/// The `i32` vector type chosen based on the dimension.
+#[cfg(feature = "3d")]
+pub(crate) use bevy_math::IVec3 as IVector;
+
 /// The ray type chosen based on the dimension.
 #[cfg(feature = "2d")]
 pub(crate) type Ray = Ray2d;


### PR DESCRIPTION
# Objective

Parry added support for a cool new `Voxels` shape for efficient voxelized geometry without ghost collision problems caused by internal edges. We should add support for this too!

## Solution

- Update to Parry 0.21
- Add `Collider::voxels`
- Add `Collider::voxels_from_points`
- Add `Collider::voxelized_polyline` (2D)
- Add `Collider::voxelized_trimesh` (3D)
- Add `Collider::voxelized_trimesh_from_mesh` (3D)
- Add `Collider::voxelized_convex_decomposition`
- Add `Collider::voxelized_convex_decomposition_with_config`
- Add `Collider::voxelized_convex_decomposition_from_mesh` (3D)
- Add `ColliderConstructor::Voxels`
- Add `ColliderConstructor::VoxelizedPolyline`
- Add `ColliderConstructor::VoxelizedTrimesh`
- Add `ColliderConstructor::VoxelizedTrimeshFromMesh`

The update to Parry 0.21 also made `SharedShape::trimesh` and `SharedShape::trimesh_with_flags` fallible. To support this, `Collider::trimesh` and `Collider::trimesh_with_config` now panic for degenerate input, but there are also `Collider::try_trimesh` and `Collider::try_trimesh_with_config` versions that return a `Result`.

---

## Migration Guide

`Collider::trimesh` and `Collider::trimesh_with_config` can now panic for degenerate input. Use `Collider::try_trimesh` and `Collider::try_trimesh_with_config` to instead get a `Result` and handle error cases manually.