### PR TITLE
Fix `PreviousGlobalTransform` initialization

### DIFF
--- a/src/tests/determinism_2d.rs
+++ b/src/tests/determinism_2d.rs
@@ -62,7 +62,7 @@ fn cross_platform_determinism_2d() {
     let hash = compute_hash(app.world(), query);
 
     // Update this value if simulation behavior changes.
-    let expected = 0x2b3eeafc;
+    let expected = 0x10b3db5;
 
     assert!(
         hash == expected,


### PR DESCRIPTION
# Objective

`PreviousGlobalTransform` is currently initialized too late, causing `Transform` updates between the spawn and first physics step to be ignored.

## Solution

Make `PreviousGlobalTransform` a required component (if the `SyncPlugin` is enabled) so that it's initialized at spawn.