### PR TITLE
Fix `DistanceLimit::compute_correction()` signs

### DIFF
--- a/src/dynamics/solver/joints/mod.rs
+++ b/src/dynamics/solver/joints/mod.rs
@@ -165,7 +165,7 @@ impl DistanceLimit {
         // Equation 25
         if distance < self.min {
             // Separation distance lower limit
-            (-separation / distance, (distance - self.min))
+            (separation / distance, (self.min - distance))
         } else if distance > self.max {
             // Separation distance upper limit
             (-separation / distance, (distance - self.max))


### PR DESCRIPTION
`DistanceLimit::compute_correction()` would return the same direction for exceeding either `min` or `max`, while the sign was attached to the correction distance. This caused a latter < epsilon check to fail. In this PR I've negated the direction and distance for `min` case, which seems to have fixed the issue. :)