### PR TITLE
docs: fix typo

### DIFF
--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -76,7 +76,7 @@
 //!
 //! Speculative collisions are an efficient and generally robust approach
 //! to Continuous Collision Detection. They are enabled for all bodies by default,
-//! provided that the default naximum speculative margin is greater than zero.
+//! provided that the default maximum speculative margin is greater than zero.
 //!
 //! However, speculative collisions aren't entirely without issues,
 //! and there are some cases where large speculative margins can cause undesired behavior.


### PR DESCRIPTION
# Objective

- There was a small typo `naximum` instead of `maximum`

## Solution

- Change n to m
