### PR TITLE
Fix AABB interval initialization in broad phase

### DIFF
--- a/src/collision/broad_phase.rs
+++ b/src/collision/broad_phase.rs
@@ -8,7 +8,7 @@ use core::marker::PhantomData;
 use crate::{data_structures::pair_key::PairKey, prelude::*};
 use bevy::{
     ecs::{
-        entity::{EntityHashSet, EntityMapper, MapEntities},
+        entity::{EntityMapper, MapEntities},
         entity_disabling::Disabled,
         system::{lifetimeless::Read, StaticSystemParam, SystemParamItem},
     },
@@ -67,6 +67,38 @@ where
 
         physics_schedule
             .add_systems(collect_collision_pairs::<H>.in_set(BroadPhaseSet::CollectCollisions));
+
+        app.add_observer(
+            |trigger: Trigger<OnRemove, (Disabled, ColliderDisabled)>,
+             query: Query<AabbIntervalQueryData, Without<ColliderDisabled>>,
+             rbs: Query<&RigidBody>,
+             mut intervals: ResMut<AabbIntervals>| {
+                let entity = trigger.target();
+
+                // Re-enable the collider.
+                if let Ok((entity, collider_of, aabb, layers, is_sensor, events_enabled, hooks)) =
+                    query.get(entity)
+                {
+                    let flags = init_aabb_interval_flags(
+                        collider_of,
+                        &rbs,
+                        is_sensor,
+                        events_enabled,
+                        hooks,
+                    );
+                    let interval = (
+                        entity,
+                        collider_of.map_or(ColliderOf { body: entity }, |p| *p),
+                        *aabb,
+                        *layers,
+                        flags,
+                    );
+
+                    // Add the re-enabled collider to the intervals.
+                    intervals.0.push(interval);
+                }
+            },
+        );
     }
 
     fn finish(&self, app: &mut App) {
@@ -91,14 +123,14 @@ pub enum BroadPhaseSet {
 
 /// Entities with [`ColliderAabb`]s sorted along an axis by their extents.
 #[derive(Resource, Default)]
-struct AabbIntervals(
-    Vec<(
-        Entity,
-        ColliderOf,
-        ColliderAabb,
-        CollisionLayers,
-        AabbIntervalFlags,
-    )>,
+struct AabbIntervals(Vec<AabbInterval>);
+
+type AabbInterval = (
+    Entity,
+    ColliderOf,
+    ColliderAabb,
+    CollisionLayers,
+    AabbIntervalFlags,
 );
 
 bitflags::bitflags! {
@@ -209,38 +241,13 @@ type AabbIntervalQueryData = (
 #[allow(clippy::type_complexity)]
 fn add_new_aabb_intervals(
     added_aabbs: Query<AabbIntervalQueryData, (Added<ColliderAabb>, Without<ColliderDisabled>)>,
-    aabbs: Query<AabbIntervalQueryData, Without<ColliderDisabled>>,
     rbs: Query<&RigidBody>,
     mut intervals: ResMut<AabbIntervals>,
-    mut re_enabled_colliders: RemovedComponents<ColliderDisabled>,
-    mut re_enabled_entities: RemovedComponents<Disabled>,
 ) {
-    // Collect re-enabled entities without duplicates.
-    let re_enabled = re_enabled_colliders
-        .read()
-        .chain(re_enabled_entities.read())
-        .collect::<EntityHashSet>();
-    let re_enabled_aabbs = aabbs.iter_many(re_enabled);
-
-    let aabbs = added_aabbs.iter().chain(re_enabled_aabbs).map(
+    let aabbs = added_aabbs.iter().map(
         |(entity, collider_of, aabb, layers, is_sensor, events_enabled, hooks)| {
-            let mut flags = AabbIntervalFlags::empty();
-            flags.set(
-                AabbIntervalFlags::IS_INACTIVE,
-                collider_of.is_some_and(|collider_of| {
-                    rbs.get(collider_of.body).is_ok_and(RigidBody::is_static)
-                }),
-            );
-            flags.set(AabbIntervalFlags::IS_SENSOR, is_sensor);
-            flags.set(AabbIntervalFlags::CONTACT_EVENTS, events_enabled);
-            flags.set(
-                AabbIntervalFlags::CUSTOM_FILTER,
-                hooks.is_some_and(|h| h.contains(ActiveCollisionHooks::FILTER_PAIRS)),
-            );
-            flags.set(
-                AabbIntervalFlags::MODIFY_CONTACTS,
-                hooks.is_some_and(|h| h.contains(ActiveCollisionHooks::MODIFY_CONTACTS)),
-            );
+            let flags =
+                init_aabb_interval_flags(collider_of, &rbs, is_sensor, events_enabled, hooks);
             (
                 entity,
                 collider_of.map_or(ColliderOf { body: entity }, |p| *p),
@@ -251,6 +258,32 @@ fn add_new_aabb_intervals(
         },
     );
     intervals.0.extend(aabbs);
+}
+
+fn init_aabb_interval_flags(
+    collider_of: Option<&ColliderOf>,
+    rbs: &Query<&RigidBody>,
+    is_sensor: bool,
+    events_enabled: bool,
+    hooks: Option<&ActiveCollisionHooks>,
+) -> AabbIntervalFlags {
+    let mut flags = AabbIntervalFlags::empty();
+    flags.set(
+        AabbIntervalFlags::IS_INACTIVE,
+        collider_of
+            .is_some_and(|collider_of| rbs.get(collider_of.body).is_ok_and(RigidBody::is_static)),
+    );
+    flags.set(AabbIntervalFlags::IS_SENSOR, is_sensor);
+    flags.set(AabbIntervalFlags::CONTACT_EVENTS, events_enabled);
+    flags.set(
+        AabbIntervalFlags::CUSTOM_FILTER,
+        hooks.is_some_and(|h| h.contains(ActiveCollisionHooks::FILTER_PAIRS)),
+    );
+    flags.set(
+        AabbIntervalFlags::MODIFY_CONTACTS,
+        hooks.is_some_and(|h| h.contains(ActiveCollisionHooks::MODIFY_CONTACTS)),
+    );
+    flags
 }
 
 /// Finds pairs of entities with overlapping [`ColliderAabb`]s


### PR DESCRIPTION
# Objective

Fixes #739.

The broad phase uses `RemovedComponents` for detecting when `Disabled` or `ColliderDisabled` is removed. However, it can miss removals in schedules with fixed time steps. To make it more robust, we should use observers instead.

Additionally, there is a bug where child colliders of static bodies are not marked as static/inactive on the first time step.

## Solution

Use observers to fix the first problem, and rework initialization logic to fix the second.