### PR TITLE
Upgrade to Rust 2024 edition

### DIFF
--- a/crates/avian2d/Cargo.toml
+++ b/crates/avian2d/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "avian2d"
 version = "0.3.0"
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Joona Aalto <jondolf.dev@gmail.com>"]
 description = "An ECS-driven physics engine for the Bevy game engine"

--- a/crates/avian2d/examples/determinism_2d.rs
+++ b/crates/avian2d/examples/determinism_2d.rs
@@ -15,7 +15,7 @@
 //! <https://github.com/erincatto/box2d/blob/90c2781f64775085035655661d5fe6542bf0fbd5/samples/sample_determinism.cpp>
 
 use avian2d::{
-    math::{AdjustPrecision, Scalar, Vector, PI},
+    math::{AdjustPrecision, PI, Scalar, Vector},
     prelude::*,
 };
 use bevy::{

--- a/crates/avian2d/examples/one_way_platform_2d.rs
+++ b/crates/avian2d/examples/one_way_platform_2d.rs
@@ -10,7 +10,7 @@ use avian2d::{math::*, prelude::*};
 use bevy::{
     ecs::{
         entity::hash_set::EntityHashSet,
-        system::{lifetimeless::Read, SystemParam},
+        system::{SystemParam, lifetimeless::Read},
     },
     prelude::*,
 };

--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "avian3d"
 version = "0.3.0"
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Joona Aalto <jondolf.dev@gmail.com>"]
 description = "An ECS-driven physics engine for the Bevy game engine"

--- a/crates/avian3d/examples/cast_ray_predicate.rs
+++ b/crates/avian3d/examples/cast_ray_predicate.rs
@@ -161,10 +161,10 @@ fn raycast(
         })
     {
         // Set the color of the hit object to red.
-        if let Ok((material_handle, _)) = cubes.get(ray_hit_data.entity) {
-            if let Some(material) = materials.get_mut(material_handle) {
-                material.base_color = RED.into();
-            }
+        if let Ok((material_handle, _)) = cubes.get(ray_hit_data.entity)
+            && let Some(material) = materials.get_mut(material_handle)
+        {
+            material.base_color = RED.into();
         }
 
         // Set the length of the ray indicator to look more like a laser,

--- a/crates/avian3d/examples/conveyor_belt.rs
+++ b/crates/avian3d/examples/conveyor_belt.rs
@@ -3,7 +3,7 @@
 
 use avian3d::{math::*, prelude::*};
 use bevy::{
-    ecs::system::{lifetimeless::Read, SystemParam},
+    ecs::system::{SystemParam, lifetimeless::Read},
     prelude::*,
 };
 use examples_common_3d::ExampleCommonPlugin;

--- a/crates/avian_derive/Cargo.toml
+++ b/crates/avian_derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "avian_derive"
 version = "0.2.2"
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Joona Aalto <jondolf.dev@gmail.com>"]
 description = "Provides derive implementations for Avian Physics"

--- a/crates/avian_derive/src/lib.rs
+++ b/crates/avian_derive/src/lib.rs
@@ -4,7 +4,7 @@ use proc_macro::TokenStream;
 
 use proc_macro_error2::{abort, emit_error, proc_macro_error};
 use quote::quote;
-use syn::{parse_macro_input, spanned::Spanned, Data, DeriveInput};
+use syn::{Data, DeriveInput, parse_macro_input, spanned::Spanned};
 
 // Modified macro from the discontinued Heron
 // https://github.com/jcornaz/heron/blob/main/macros/src/lib.rs

--- a/crates/examples_common_2d/Cargo.toml
+++ b/crates/examples_common_2d/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "examples_common_2d"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [features]
 use-debug-plugin = []

--- a/crates/examples_common_3d/Cargo.toml
+++ b/crates/examples_common_3d/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "examples_common_3d"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [features]
 use-debug-plugin = []

--- a/src/collision/broad_phase.rs
+++ b/src/collision/broad_phase.rs
@@ -10,7 +10,7 @@ use bevy::{
     ecs::{
         entity::{EntityMapper, MapEntities},
         entity_disabling::Disabled,
-        system::{lifetimeless::Read, StaticSystemParam, SystemParamItem},
+        system::{StaticSystemParam, SystemParamItem, lifetimeless::Read},
     },
     prelude::*,
 };

--- a/src/collision/collider/backend.rs
+++ b/src/collision/collider/backend.rs
@@ -20,7 +20,7 @@ use bevy::{
     },
     prelude::*,
 };
-use mass_properties::{components::RecomputeMassProperties, MassPropertySystems};
+use mass_properties::{MassPropertySystems, components::RecomputeMassProperties};
 
 /// A plugin for handling generic collider backend logic.
 ///
@@ -412,9 +412,11 @@ fn init_collider_constructor_hierarchies(
                     .cloned()
                     .unwrap_or_else(default_collider)
             } else if existing_collider.is_some() {
-                warn!("Tried to add a collider to entity {pretty_name} via {collider_constructor_hierarchy:#?}, \
+                warn!(
+                    "Tried to add a collider to entity {pretty_name} via {collider_constructor_hierarchy:#?}, \
                         but that entity already holds a collider. Skipping. \
-                        If this was intentional, add the name of the collider to overwrite to `ColliderConstructorHierarchy.config`.");
+                        If this was intentional, add the name of the collider to overwrite to `ColliderConstructorHierarchy.config`."
+                );
                 continue;
             } else {
                 default_collider()
@@ -469,9 +471,9 @@ fn init_collider_constructor_hierarchies(
                 ));
             } else {
                 error!(
-                        "Tried to add a collider to entity {pretty_name} via {collider_constructor_hierarchy:#?}, \
+                    "Tried to add a collider to entity {pretty_name} via {collider_constructor_hierarchy:#?}, \
                         but the collider could not be generated. Skipping.",
-                    );
+                );
             }
         }
 

--- a/src/collision/collider/cache.rs
+++ b/src/collision/collider/cache.rs
@@ -46,10 +46,10 @@ fn clear_unused_colliders(
     mut collider_cache: ResMut<ColliderCache>,
 ) {
     for event in asset_events.read() {
-        if let AssetEvent::Removed { id } | AssetEvent::Unused { id } = event {
-            if collider_cache.0.contains_key(id) {
-                collider_cache.0.remove(id);
-            }
+        if let AssetEvent::Removed { id } | AssetEvent::Unused { id } = event
+            && collider_cache.0.contains_key(id)
+        {
+            collider_cache.0.remove(id);
         }
     }
 }

--- a/src/collision/collider/collider_hierarchy/mod.rs
+++ b/src/collision/collider/collider_hierarchy/mod.rs
@@ -147,30 +147,30 @@ impl Relationship for ColliderOf {
             }
         }
         let body = world.entity(entity).get::<Self>().unwrap().get();
-        if let Ok(mut body_mut) = world.get_entity_mut(body) {
-            if let Some(mut relationship_target) = body_mut.get_mut::<Self::RelationshipTarget>() {
-                RelationshipSourceCollection::remove(
-                    relationship_target.collection_mut_risky(),
-                    entity,
+        if let Ok(mut body_mut) = world.get_entity_mut(body)
+            && let Some(mut relationship_target) = body_mut.get_mut::<Self::RelationshipTarget>()
+        {
+            RelationshipSourceCollection::remove(
+                relationship_target.collection_mut_risky(),
+                entity,
+            );
+            if relationship_target.len() == 0
+                && let Ok(mut entity) = world.commands().get_entity(body)
+            {
+                // this "remove" operation must check emptiness because in the event that an identical
+                // relationship is inserted on top, this despawn would result in the removal of that identical
+                // relationship ... not what we want!
+                entity.queue_handled(
+                    |mut entity: EntityWorldMut| {
+                        if entity
+                            .get::<Self::RelationshipTarget>()
+                            .is_some_and(RelationshipTarget::is_empty)
+                        {
+                            entity.remove::<Self::RelationshipTarget>();
+                        }
+                    },
+                    |_, _| {},
                 );
-                if relationship_target.len() == 0 {
-                    if let Ok(mut entity) = world.commands().get_entity(body) {
-                        // this "remove" operation must check emptiness because in the event that an identical
-                        // relationship is inserted on top, this despawn would result in the removal of that identical
-                        // relationship ... not what we want!
-                        entity.queue_handled(
-                            |mut entity: EntityWorldMut| {
-                                if entity
-                                    .get::<Self::RelationshipTarget>()
-                                    .is_some_and(RelationshipTarget::is_empty)
-                                {
-                                    entity.remove::<Self::RelationshipTarget>();
-                                }
-                            },
-                            |_, _| {},
-                        );
-                    }
-                }
             }
         }
     }

--- a/src/collision/collider/collider_hierarchy/mod.rs
+++ b/src/collision/collider/collider_hierarchy/mod.rs
@@ -119,7 +119,9 @@ impl Relationship for ColliderOf {
         } else {
             warn!(
                 "{}Tried to attach collider on entity {collider} to rigid body on entity {body}, but the rigid body does not exist.",
-                caller.map(|location| format!("{location}: ")).unwrap_or_default(),
+                caller
+                    .map(|location| format!("{location}: "))
+                    .unwrap_or_default(),
             );
         }
     }

--- a/src/collision/collider/collider_transform/plugin.rs
+++ b/src/collision/collider/collider_transform/plugin.rs
@@ -232,12 +232,11 @@ unsafe fn propagate_collider_transforms_recursive(
 
         changed |=
             transform_ref.is_changed() || collider_transform.as_ref().is_some_and(|t| t.is_added());
-        if changed {
-            if let Some(mut collider_transform) = collider_transform {
-                if *collider_transform != transform {
-                    *collider_transform = transform;
-                }
-            }
+        if changed
+            && let Some(mut collider_transform) = collider_transform
+            && *collider_transform != transform
+        {
+            *collider_transform = transform;
         }
 
         children
@@ -246,7 +245,8 @@ unsafe fn propagate_collider_transforms_recursive(
     let Some(children) = children else { return };
     for (child, child_transform, is_rb, child_of) in parent_query.iter_many(children) {
         assert_eq!(
-            child_of.parent(), entity,
+            child_of.parent(),
+            entity,
             "Malformed hierarchy. This probably means that your hierarchy has been improperly maintained, or contains a cycle"
         );
 

--- a/src/collision/collider/layers.rs
+++ b/src/collision/collider/layers.rs
@@ -461,9 +461,11 @@ mod tests {
         assert!(with_bitmask.memberships.has_all(GameLayer::Enemy));
         assert!(!with_bitmask.memberships.has_all(GameLayer::Player));
 
-        assert!(with_bitmask
-            .filters
-            .has_all([GameLayer::Player, GameLayer::Ground]));
+        assert!(
+            with_bitmask
+                .filters
+                .has_all([GameLayer::Player, GameLayer::Ground])
+        );
         assert!(!with_bitmask.filters.has_all(GameLayer::Enemy));
     }
 }

--- a/src/collision/collider/mod.rs
+++ b/src/collision/collider/mod.rs
@@ -4,7 +4,7 @@ use crate::prelude::*;
 use bevy::{
     ecs::{
         component::Mutable,
-        entity::{hash_set::EntityHashSet, EntityMapper, MapEntities},
+        entity::{EntityMapper, MapEntities, hash_set::EntityHashSet},
         system::{ReadOnlySystemParam, SystemParam, SystemParamItem},
     },
     prelude::*,

--- a/src/collision/collider/parry/contact_query.rs
+++ b/src/collision/collider/parry/contact_query.rs
@@ -184,33 +184,32 @@ pub fn contact_manifolds(
     manifolds.clear();
 
     // Fall back to support map contacts for unsupported (custom) shapes.
-    if result.is_err() {
-        if let (Some(shape1), Some(shape2)) = (
+    if result.is_err()
+        && let (Some(shape1), Some(shape2)) = (
             collider1.shape_scaled().as_support_map(),
             collider2.shape_scaled().as_support_map(),
-        ) {
-            if let Some(contact) = parry::query::contact::contact_support_map_support_map(
-                &isometry12,
-                shape1,
-                shape2,
-                prediction_distance,
-            ) {
-                let normal = rotation1 * Vector::from(contact.normal1);
+        )
+        && let Some(contact) = parry::query::contact::contact_support_map_support_map(
+            &isometry12,
+            shape1,
+            shape2,
+            prediction_distance,
+        )
+    {
+        let normal = rotation1 * Vector::from(contact.normal1);
 
-                // Make sure the normal is valid
-                if !normal.is_normalized() {
-                    return;
-                }
-
-                let points = [ContactPoint::new(
-                    contact.point1.into(),
-                    contact.point2.into(),
-                    -contact.dist,
-                )];
-
-                manifolds.push(ContactManifold::new(points, normal, 0));
-            }
+        // Make sure the normal is valid
+        if !normal.is_normalized() {
+            return;
         }
+
+        let points = [ContactPoint::new(
+            contact.point1.into(),
+            contact.point2.into(),
+            -contact.dist,
+        )];
+
+        manifolds.push(ContactManifold::new(points, normal, 0));
     }
 
     let mut manifold_index = 0;

--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -1814,7 +1814,7 @@ mod tests {
         // 3. Apply grandparent's 90 Z rotation -> (0, 1, 0)
         // 4. Add grandparent's position (5, 0, 0) -> (5, 1, 0)
         let expected_grandchild_world_pos = Vector::new(5.0, 1.0, 0.0);
-        let actual_grandchild_world_pos = flattened_grandchild.0 .0;
+        let actual_grandchild_world_pos = flattened_grandchild.0.0;
 
         assert_relative_eq!(
             actual_grandchild_world_pos.x,
@@ -1836,7 +1836,7 @@ mod tests {
         // 1. Apply parent's 90 Z rotation -> (-3, 0, 0)
         // 2. Add parent's position (5, 0, 0) -> (2, 0, 0)
         let expected_sibling_world_pos = Vector::new(2.0, 0.0, 0.0);
-        let actual_sibling_world_pos = flattened_sibling.0 .0;
+        let actual_sibling_world_pos = flattened_sibling.0.0;
 
         assert_relative_eq!(
             actual_sibling_world_pos.x,

--- a/src/collision/collider/parry/primitives2d.rs
+++ b/src/collision/collider/parry/primitives2d.rs
@@ -1,4 +1,4 @@
-use crate::{math, AdjustPrecision, Scalar, Vector, FRAC_PI_2, PI, TAU};
+use crate::{AdjustPrecision, FRAC_PI_2, PI, Scalar, TAU, Vector, math};
 
 use super::{AsF32, Collider, IntoCollider};
 use bevy::prelude::{Deref, DerefMut};
@@ -8,8 +8,8 @@ use parry::{
     mass_properties::MassProperties,
     math::Isometry,
     query::{
-        details::local_ray_intersection_with_support_map_with_params, gjk::VoronoiSimplex,
-        point::local_point_projection_on_support_map, PointQuery, RayCast,
+        PointQuery, RayCast, details::local_ray_intersection_with_support_map_with_params,
+        gjk::VoronoiSimplex, point::local_point_projection_on_support_map,
     },
     shape::{
         FeatureId, PackedFeatureId, PolygonalFeature, PolygonalFeatureMap, Shape, SharedShape,

--- a/src/collision/diagnostics.rs
+++ b/src/collision/diagnostics.rs
@@ -5,7 +5,7 @@ use bevy::{
 };
 use core::time::Duration;
 
-use crate::diagnostics::{impl_diagnostic_paths, PhysicsDiagnostics};
+use crate::diagnostics::{PhysicsDiagnostics, impl_diagnostic_paths};
 
 /// Diagnostics for collision detection.
 #[derive(Resource, Debug, Default, Reflect)]

--- a/src/collision/mod.rs
+++ b/src/collision/mod.rs
@@ -85,13 +85,13 @@ pub mod prelude {
     #[cfg(all(feature = "collider-from-mesh", feature = "default-collider"))]
     pub use super::collider::ColliderCachePlugin;
     pub use super::collider::{
-        collider_hierarchy::{ColliderHierarchyPlugin, ColliderOf, RigidBodyColliders},
-        collider_transform::{ColliderTransform, ColliderTransformPlugin},
         AabbContext, AnyCollider, Collider, ColliderAabb, ColliderBackendPlugin,
         ColliderConstructor, ColliderConstructorHierarchy, ColliderDisabled, ColliderMarker,
         CollidingEntities, CollisionLayers, CollisionMargin, ContactManifoldContext, FillMode,
         IntoCollider, LayerMask, PhysicsLayer, ScalableCollider, Sensor, SimpleCollider,
         TrimeshFlags, VhacdParameters,
+        collider_hierarchy::{ColliderHierarchyPlugin, ColliderOf, RigidBodyColliders},
+        collider_transform::{ColliderTransform, ColliderTransformPlugin},
     };
     pub use super::collision_events::{
         CollisionEnded, CollisionEventsEnabled, CollisionStarted, OnCollisionEnd, OnCollisionStart,

--- a/src/collision/narrow_phase/mod.rs
+++ b/src/collision/narrow_phase/mod.rs
@@ -300,8 +300,12 @@ fn trigger_collision_events(
     // Collect `OnCollisionStart` and `OnCollisionEnd` events
     // for entities that have events enabled.
     for event in state.started.read() {
-        let Ok([(collider_of1, events_enabled1), (collider_of2, events_enabled2)]) =
-            state.query.get_many([event.0, event.1])
+        let Ok(
+            [
+                (collider_of1, events_enabled1),
+                (collider_of2, events_enabled2),
+            ],
+        ) = state.query.get_many([event.0, event.1])
         else {
             continue;
         };
@@ -317,8 +321,12 @@ fn trigger_collision_events(
         }
     }
     for event in state.ended.read() {
-        let Ok([(collider_of1, events_enabled1), (collider_of2, events_enabled2)]) =
-            state.query.get_many([event.0, event.1])
+        let Ok(
+            [
+                (collider_of1, events_enabled1),
+                (collider_of2, events_enabled2),
+            ],
+        ) = state.query.get_many([event.0, event.1])
         else {
             continue;
         };

--- a/src/collision/narrow_phase/system_param.rs
+++ b/src/collision/narrow_phase/system_param.rs
@@ -5,7 +5,7 @@ use core::cmp::Ordering;
 use crate::{
     collision::collider::ColliderQuery,
     data_structures::{bit_vec::BitVec, graph::EdgeIndex},
-    dynamics::solver::{contact::ContactConstraint, ContactSoftnessCoefficients},
+    dynamics::solver::{ContactSoftnessCoefficients, contact::ContactConstraint},
     prelude::*,
 };
 use bevy::{
@@ -13,8 +13,8 @@ use bevy::{
     prelude::*,
 };
 use dynamics::solver::{
-    contact::{ContactConstraintPoint, ContactNormalPart, ContactTangentPart},
     ContactConstraints,
+    contact::{ContactConstraintPoint, ContactNormalPart, ContactTangentPart},
 };
 #[cfg(feature = "parallel")]
 use thread_local::ThreadLocal;

--- a/src/data_structures/graph.rs
+++ b/src/data_structures/graph.rs
@@ -257,11 +257,11 @@ impl<N, E> UnGraph<N, E> {
     ///
     /// Panics if any of the nodes doesn't exist.
     pub fn update_edge(&mut self, a: NodeIndex, b: NodeIndex, weight: E) -> EdgeIndex {
-        if let Some(ix) = self.find_edge(a, b) {
-            if let Some(ed) = self.edge_weight_mut(ix) {
-                *ed = weight;
-                return ix;
-            }
+        if let Some(ix) = self.find_edge(a, b)
+            && let Some(ed) = self.edge_weight_mut(ix)
+        {
+            *ed = weight;
+            return ix;
         }
         self.add_edge(a, b, weight)
     }
@@ -508,12 +508,12 @@ impl<N, E> UnGraph<N, E> {
     }
 
     /// Returns an iterator over the node indices of the graph.
-    pub fn node_indices(&self) -> impl DoubleEndedIterator<Item = NodeIndex> {
+    pub fn node_indices(&self) -> impl DoubleEndedIterator<Item = NodeIndex> + use<N, E> {
         (0..self.node_count()).map(|i| NodeIndex(i as u32))
     }
 
     /// Returns an iterator over the edge indices of the graph
-    pub fn edge_indices(&self) -> impl DoubleEndedIterator<Item = EdgeIndex> {
+    pub fn edge_indices(&self) -> impl DoubleEndedIterator<Item = EdgeIndex> + use<N, E> {
         (0..self.edge_count()).map(|i| EdgeIndex(i as u32))
     }
 

--- a/src/data_structures/sparse_secondary_map.rs
+++ b/src/data_structures/sparse_secondary_map.rs
@@ -164,10 +164,10 @@ impl<V, S: hash::BuildHasher> SparseSecondaryEntityMap<V, S> {
     /// the entity was not previously removed.
     #[inline]
     pub fn remove(&mut self, entity: Entity) -> Option<V> {
-        if let hash_map::Entry::Occupied(entry) = self.slots.entry(entity.index()) {
-            if entry.get().generation == entity.generation() {
-                return Some(entry.remove_entry().1.value);
-            }
+        if let hash_map::Entry::Occupied(entry) = self.slots.entry(entity.index())
+            && entry.get().generation == entity.generation()
+        {
+            return Some(entry.remove_entry().1.value);
         }
 
         None

--- a/src/data_structures/sparse_secondary_map.rs
+++ b/src/data_structures/sparse_secondary_map.rs
@@ -198,7 +198,7 @@ impl<V, S: hash::BuildHasher> SparseSecondaryEntityMap<V, S> {
     #[inline]
     pub unsafe fn get_unchecked(&self, entity: Entity) -> &V {
         debug_assert!(self.contains(entity));
-        self.get(entity).unwrap_unchecked()
+        unsafe { self.get(entity).unwrap_unchecked() }
     }
 
     /// Returns a mutable reference to the value corresponding to the entity.
@@ -220,7 +220,7 @@ impl<V, S: hash::BuildHasher> SparseSecondaryEntityMap<V, S> {
     #[inline]
     pub unsafe fn get_unchecked_mut(&mut self, entity: Entity) -> &mut V {
         debug_assert!(self.contains(entity));
-        self.get_mut(entity).unwrap_unchecked()
+        unsafe { self.get_mut(entity).unwrap_unchecked() }
     }
 
     /// Returns the value corresponding to the entity if it exists, otherwise inserts
@@ -307,11 +307,13 @@ impl<V, S: hash::BuildHasher> SparseSecondaryEntityMap<V, S> {
         entities: [Entity; N],
     ) -> [&mut V; N] {
         // Safe, see get_disjoint_mut.
-        let mut ptrs: [MaybeUninit<*mut V>; N] = MaybeUninit::uninit().assume_init();
-        for i in 0..N {
-            ptrs[i] = MaybeUninit::new(self.get_unchecked_mut(entities[i]));
+        unsafe {
+            let mut ptrs: [MaybeUninit<*mut V>; N] = MaybeUninit::uninit().assume_init();
+            for i in 0..N {
+                ptrs[i] = MaybeUninit::new(self.get_unchecked_mut(entities[i]));
+            }
+            core::mem::transmute_copy::<_, [&mut V; N]>(&ptrs)
         }
-        core::mem::transmute_copy::<_, [&mut V; N]>(&ptrs)
     }
 }
 

--- a/src/diagnostics/entity_counters.rs
+++ b/src/diagnostics/entity_counters.rs
@@ -1,10 +1,10 @@
 use bevy::{diagnostic::DiagnosticPath, prelude::*};
 
 use crate::{
-    dynamics::solver::joints::*, ColliderMarker, PhysicsSchedule, PhysicsStepSet, RigidBody,
+    ColliderMarker, PhysicsSchedule, PhysicsStepSet, RigidBody, dynamics::solver::joints::*,
 };
 
-use super::{impl_diagnostic_paths, AppDiagnosticsExt, PhysicsDiagnostics};
+use super::{AppDiagnosticsExt, PhysicsDiagnostics, impl_diagnostic_paths};
 
 /// A plugin that adds diagnostics for physics entity counts.
 pub struct PhysicsEntityDiagnosticsPlugin;

--- a/src/diagnostics/mod.rs
+++ b/src/diagnostics/mod.rs
@@ -75,7 +75,7 @@ pub(crate) use path_macro::impl_diagnostic_paths;
 #[cfg(feature = "bevy_diagnostic")]
 pub use total::{PhysicsTotalDiagnostics, PhysicsTotalDiagnosticsPlugin};
 
-use crate::{schedule::PhysicsSchedule, PhysicsStepSet};
+use crate::{PhysicsStepSet, schedule::PhysicsSchedule};
 use bevy::{
     app::{App, Plugin},
     diagnostic::{Diagnostic, DiagnosticPath, Diagnostics, RegisterDiagnostic},

--- a/src/dynamics/integrator/mod.rs
+++ b/src/dynamics/integrator/mod.rs
@@ -196,15 +196,17 @@ fn integrate_velocities(
                 .map_or(LockedAxes::default(), |locked_axes| *locked_axes);
 
             // Apply damping
-            if let Some(lin_damping) = body.lin_damping {
-                if *linear_velocity != Vector::ZERO && lin_damping.0 != 0.0 {
-                    *linear_velocity *= 1.0 / (1.0 + delta_secs * lin_damping.0);
-                }
+            if let Some(lin_damping) = body.lin_damping
+                && *linear_velocity != Vector::ZERO
+                && lin_damping.0 != 0.0
+            {
+                *linear_velocity *= 1.0 / (1.0 + delta_secs * lin_damping.0);
             }
-            if let Some(ang_damping) = body.ang_damping {
-                if *angular_velocity != AngularVelocity::ZERO.0 && ang_damping.0 != 0.0 {
-                    *angular_velocity *= 1.0 / (1.0 + delta_secs * ang_damping.0);
-                }
+            if let Some(ang_damping) = body.ang_damping
+                && *angular_velocity != AngularVelocity::ZERO.0
+                && ang_damping.0 != 0.0
+            {
+                *angular_velocity *= 1.0 / (1.0 + delta_secs * ang_damping.0);
             }
 
             let external_force = body.force.force();

--- a/src/dynamics/mod.rs
+++ b/src/dynamics/mod.rs
@@ -70,13 +70,14 @@ pub mod solver;
 /// Re-exports common types related to the rigid body dynamics functionality.
 pub mod prelude {
     pub(crate) use super::rigid_body::mass_properties::{
-        components::GlobalAngularInertia, ComputeMassProperties, MassProperties,
+        ComputeMassProperties, MassProperties, components::GlobalAngularInertia,
     };
     pub use super::{
         ccd::{CcdPlugin, SpeculativeMargin, SweepMode, SweptCcd},
         integrator::{Gravity, IntegratorPlugin},
         rigid_body::{
             mass_properties::{
+                MassPropertiesExt, MassPropertyHelper, MassPropertyPlugin,
                 bevy_heavy::{
                     AngularInertiaTensor, AngularInertiaTensorError, ComputeMassProperties2d,
                     ComputeMassProperties3d, MassProperties2d, MassProperties3d,
@@ -86,16 +87,15 @@ pub mod prelude {
                     ComputedAngularInertia, ComputedCenterOfMass, ComputedMass, Mass,
                     MassPropertiesBundle, NoAutoAngularInertia, NoAutoCenterOfMass, NoAutoMass,
                 },
-                MassPropertiesExt, MassPropertyHelper, MassPropertyPlugin,
             },
             *,
         },
         sleeping::{DeactivationTime, SleepingPlugin, SleepingThreshold, WakeUpBody},
         solver::{
+            PhysicsLengthUnit, SolverPlugin,
             joints::*,
             schedule::{SolverSchedulePlugin, SolverSet, SubstepCount, SubstepSchedule},
             solver_body::SolverBodyPlugin,
-            PhysicsLengthUnit, SolverPlugin,
         },
     };
 }

--- a/src/dynamics/rigid_body/mass_properties/system_param.rs
+++ b/src/dynamics/rigid_body/mass_properties/system_param.rs
@@ -1,8 +1,8 @@
 use crate::prelude::*;
 use bevy::{
     ecs::system::{
-        lifetimeless::{Read, Write},
         SystemParam,
+        lifetimeless::{Read, Write},
     },
     prelude::*,
 };

--- a/src/dynamics/solver/diagnostics.rs
+++ b/src/dynamics/solver/diagnostics.rs
@@ -5,7 +5,7 @@ use bevy::{
 };
 use core::time::Duration;
 
-use crate::diagnostics::{impl_diagnostic_paths, PhysicsDiagnostics};
+use crate::diagnostics::{PhysicsDiagnostics, impl_diagnostic_paths};
 
 /// Diagnostics for the physics solver.
 #[derive(Resource, Debug, Default, Reflect)]

--- a/src/dynamics/solver/mod.rs
+++ b/src/dynamics/solver/mod.rs
@@ -647,7 +647,10 @@ pub fn joint_damping<T: Joint + EntityConstraint<2>>(
 
     for joint in &joints {
         if let Ok(
-            [(rb1, mut lin_vel1, mut ang_vel1, mass1, dominance1), (rb2, mut lin_vel2, mut ang_vel2, mass2, dominance2)],
+            [
+                (rb1, mut lin_vel1, mut ang_vel1, mass1, dominance1),
+                (rb2, mut lin_vel2, mut ang_vel2, mass2, dominance2),
+            ],
         ) = bodies.get_many_mut(joint.entities())
         {
             let delta_omega =

--- a/src/dynamics/solver/solver_body/mod.rs
+++ b/src/dynamics/solver/solver_body/mod.rs
@@ -14,7 +14,7 @@ pub use plugin::SolverBodyPlugin;
 use bevy::prelude::*;
 
 use super::{Rotation, Vector};
-use crate::{math::Scalar, prelude::LockedAxes, Tensor};
+use crate::{Tensor, math::Scalar, prelude::LockedAxes};
 
 // The `SolverBody` layout is inspired by `b2BodyState` in Box2D v3.
 

--- a/src/dynamics/solver/solver_body/plugin.rs
+++ b/src/dynamics/solver/solver_body/plugin.rs
@@ -4,14 +4,14 @@ use bevy::{
 };
 
 use super::{SolverBody, SolverBodyInertia};
-#[cfg(feature = "3d")]
-use crate::{dynamics::solver::solver_body::SolverBodyFlags, math::MatExt};
 use crate::{
-    dynamics::solver::SolverDiagnostics,
-    prelude::{ComputedAngularInertia, ComputedCenterOfMass, ComputedMass, LockedAxes},
     AngularVelocity, LinearVelocity, PhysicsSchedule, Position, RigidBody, RigidBodyActiveFilter,
     RigidBodyDisabled, Rotation, Sleeping, SolverSet, Vector,
+    dynamics::solver::SolverDiagnostics,
+    prelude::{ComputedAngularInertia, ComputedCenterOfMass, ComputedMass, LockedAxes},
 };
+#[cfg(feature = "3d")]
+use crate::{dynamics::solver::solver_body::SolverBodyFlags, math::MatExt};
 
 /// A plugin for managing solver bodies.
 ///

--- a/src/interpolation.rs
+++ b/src/interpolation.rs
@@ -3,16 +3,16 @@
 //! See [`PhysicsInterpolationPlugin`].
 
 use bevy::{ecs::query::QueryData, prelude::*};
-use bevy_transform_interpolation::{prelude::*, VelocitySource};
+use bevy_transform_interpolation::{VelocitySource, prelude::*};
 
 pub use bevy_transform_interpolation::{
+    TransformEasingSet,
     prelude::{
         NoRotationEasing, NoScaleEasing, NoTransformEasing, NoTranslationEasing,
         RotationExtrapolation, RotationHermiteEasing, RotationInterpolation, ScaleInterpolation,
         TransformExtrapolation, TransformHermiteEasing, TransformInterpolation,
         TranslationExtrapolation, TranslationHermiteEasing, TranslationInterpolation,
     },
-    TransformEasingSet,
 };
 
 use crate::prelude::*;
@@ -347,7 +347,7 @@ impl VelocitySource for AngVelSource {
     fn previous(previous: &Self::Previous) -> Vec3 {
         #[cfg(feature = "2d")]
         {
-            Vec3::Z * previous.0 .0 as f32
+            Vec3::Z * previous.0.0 as f32
         }
         #[cfg(feature = "3d")]
         {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,6 +437,7 @@
     unexpected_cfgs,
     clippy::type_complexity,
     clippy::too_many_arguments,
+    clippy::collapsible_if, // forcing if-let chains often hurts readability
     rustdoc::invalid_rust_codeblocks
 )]
 #![warn(clippy::doc_markdown, missing_docs)]
@@ -509,10 +510,10 @@ pub use type_registration::PhysicsTypeRegistrationPlugin;
 pub mod prelude {
     #[cfg(feature = "debug-plugin")]
     pub use crate::debug_render::*;
-    #[cfg(feature = "diagnostic_ui")]
-    pub use crate::diagnostics::ui::{PhysicsDiagnosticsUiPlugin, PhysicsDiagnosticsUiSettings};
     #[cfg(feature = "bevy_diagnostic")]
     pub use crate::diagnostics::PhysicsDiagnosticsPlugin;
+    #[cfg(feature = "diagnostic_ui")]
+    pub use crate::diagnostics::ui::{PhysicsDiagnosticsUiPlugin, PhysicsDiagnosticsUiSettings};
     #[cfg(feature = "bevy_picking")]
     pub use crate::picking::{
         PhysicsPickable, PhysicsPickingFilter, PhysicsPickingPlugin, PhysicsPickingSettings,
@@ -520,6 +521,7 @@ pub mod prelude {
     #[cfg(feature = "default-collider")]
     pub(crate) use crate::position::RotationValue;
     pub use crate::{
+        PhysicsPlugins,
         collision::prelude::*,
         dynamics::{self, ccd::SpeculativeMargin, prelude::*},
         interpolation::*,
@@ -529,7 +531,6 @@ pub mod prelude {
         spatial_query::{self, *},
         sync::SyncPlugin,
         type_registration::PhysicsTypeRegistrationPlugin,
-        PhysicsPlugins,
     };
     pub(crate) use crate::{
         diagnostics::AppDiagnosticsExt,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,7 +437,6 @@
     unexpected_cfgs,
     clippy::type_complexity,
     clippy::too_many_arguments,
-    clippy::collapsible_if, // forcing if-let chains often hurts readability
     rustdoc::invalid_rust_codeblocks
 )]
 #![warn(clippy::doc_markdown, missing_docs)]

--- a/src/picking/mod.rs
+++ b/src/picking/mod.rs
@@ -16,14 +16,14 @@ Note that in 3D, only the closest intersection will be reported."
 )]
 
 use crate::{
-    diagnostics::{impl_diagnostic_paths, PhysicsDiagnostics},
+    diagnostics::{PhysicsDiagnostics, impl_diagnostic_paths},
     prelude::*,
 };
 use bevy::{
     ecs::entity::hash_set::EntityHashSet,
     picking::{
-        backend::{ray::RayMap, HitData, PointerHits},
         PickSet,
+        backend::{HitData, PointerHits, ray::RayMap},
     },
     prelude::*,
 };

--- a/src/position.rs
+++ b/src/position.rs
@@ -1140,15 +1140,11 @@ pub(crate) fn init_physics_transform(world: &mut DeferredWorld, ctx: &HookContex
     }
 
     if !prepare_config.transform_to_position {
-        if is_pos_placeholder {
-            if let Some(mut position) = world.get_mut::<Position>(ctx.entity) {
-                position.0 = Vector::ZERO;
-            }
+        if is_pos_placeholder && let Some(mut position) = world.get_mut::<Position>(ctx.entity) {
+            position.0 = Vector::ZERO;
         }
-        if is_rot_placeholder {
-            if let Some(mut rotation) = world.get_mut::<Rotation>(ctx.entity) {
-                *rotation = Rotation::IDENTITY;
-            }
+        if is_rot_placeholder && let Some(mut rotation) = world.get_mut::<Rotation>(ctx.entity) {
+            *rotation = Rotation::IDENTITY;
         }
     } else if is_pos_placeholder || is_rot_placeholder {
         // If either `Position` or `Rotation` is a placeholder, we need to compute the global transform

--- a/src/spatial_query/diagnostics.rs
+++ b/src/spatial_query/diagnostics.rs
@@ -6,7 +6,7 @@ use bevy::{
     reflect::Reflect,
 };
 
-use crate::diagnostics::{impl_diagnostic_paths, PhysicsDiagnostics};
+use crate::diagnostics::{PhysicsDiagnostics, impl_diagnostic_paths};
 
 /// Diagnostics for spatial queries.
 #[derive(Resource, Debug, Default, Reflect)]

--- a/src/spatial_query/mod.rs
+++ b/src/spatial_query/mod.rs
@@ -284,17 +284,17 @@ fn update_ray_caster_positions(
                 .or(parent_transform.map(Rotation::from));
 
             // Apply parent transformations
-            if global_position.is_none() {
-                if let Some(position) = parent_position {
-                    let rotation = global_rotation.unwrap_or(parent_rotation.unwrap_or_default());
-                    ray.set_global_origin(position.0 + rotation * origin);
-                }
+            if global_position.is_none()
+                && let Some(position) = parent_position
+            {
+                let rotation = global_rotation.unwrap_or(parent_rotation.unwrap_or_default());
+                ray.set_global_origin(position.0 + rotation * origin);
             }
-            if global_rotation.is_none() {
-                if let Some(rotation) = parent_rotation {
-                    let global_direction = rotation * ray.direction;
-                    ray.set_global_direction(global_direction);
-                }
+            if global_rotation.is_none()
+                && let Some(rotation) = parent_rotation
+            {
+                let global_direction = rotation * ray.direction;
+                ray.set_global_direction(global_direction);
             }
         }
     }
@@ -372,25 +372,24 @@ fn update_shape_caster_positions(
                 .or(parent_transform.map(Rotation::from));
 
             // Apply parent transformations
-            if global_position.is_none() {
-                if let Some(position) = parent_position {
-                    let rotation = global_rotation.unwrap_or(parent_rotation.unwrap_or_default());
-                    shape_caster.set_global_origin(position.0 + rotation * origin);
-                }
+            if global_position.is_none()
+                && let Some(position) = parent_position
+            {
+                let rotation = global_rotation.unwrap_or(parent_rotation.unwrap_or_default());
+                shape_caster.set_global_origin(position.0 + rotation * origin);
             }
-            if global_rotation.is_none() {
-                if let Some(rotation) = parent_rotation {
-                    let global_direction = rotation * shape_caster.direction;
-                    shape_caster.set_global_direction(global_direction);
-                    #[cfg(feature = "2d")]
-                    {
-                        shape_caster
-                            .set_global_shape_rotation(shape_rotation + rotation.as_radians());
-                    }
-                    #[cfg(feature = "3d")]
-                    {
-                        shape_caster.set_global_shape_rotation(shape_rotation * rotation.0);
-                    }
+            if global_rotation.is_none()
+                && let Some(rotation) = parent_rotation
+            {
+                let global_direction = rotation * shape_caster.direction;
+                shape_caster.set_global_direction(global_direction);
+                #[cfg(feature = "2d")]
+                {
+                    shape_caster.set_global_shape_rotation(shape_rotation + rotation.as_radians());
+                }
+                #[cfg(feature = "3d")]
+                {
+                    shape_caster.set_global_shape_rotation(shape_rotation * rotation.0);
                 }
             }
         }

--- a/src/spatial_query/pipeline.rs
+++ b/src/spatial_query/pipeline.rs
@@ -277,23 +277,22 @@ impl SpatialQueryPipeline {
         let ray = parry::query::Ray::new(origin.into(), direction.adjust_precision().into());
 
         let mut leaf_callback = &mut |index: &u32| {
-            if let Some(proxy) = proxies.get(*index as usize) {
-                if filter.test(proxy.entity, proxy.layers) {
-                    if let Some(hit) = proxy.collider.shape_scaled().cast_ray_and_get_normal(
-                        &proxy.isometry,
-                        &ray,
-                        max_distance,
-                        solid,
-                    ) {
-                        let hit = RayHitData {
-                            entity: proxy.entity,
-                            distance: hit.time_of_impact,
-                            normal: hit.normal.into(),
-                        };
+            if let Some(proxy) = proxies.get(*index as usize)
+                && filter.test(proxy.entity, proxy.layers)
+                && let Some(hit) = proxy.collider.shape_scaled().cast_ray_and_get_normal(
+                    &proxy.isometry,
+                    &ray,
+                    max_distance,
+                    solid,
+                )
+            {
+                let hit = RayHitData {
+                    entity: proxy.entity,
+                    distance: hit.time_of_impact,
+                    normal: hit.normal.into(),
+                };
 
-                        return callback(hit);
-                    }
-                }
+                return callback(hit);
             }
             true
         };
@@ -645,15 +644,14 @@ impl SpatialQueryPipeline {
         let point = point.into();
 
         let mut leaf_callback = &mut |index: &u32| {
-            if let Some(proxy) = self.proxies.get(*index as usize) {
-                if filter.test(proxy.entity, proxy.layers)
-                    && proxy
-                        .collider
-                        .shape_scaled()
-                        .contains_point(&proxy.isometry, &point)
-                {
-                    return callback(proxy.entity);
-                }
+            if let Some(proxy) = self.proxies.get(*index as usize)
+                && filter.test(proxy.entity, proxy.layers)
+                && proxy
+                    .collider
+                    .shape_scaled()
+                    .contains_point(&proxy.isometry, &point)
+            {
+                return callback(proxy.entity);
             }
             true
         };
@@ -772,18 +770,18 @@ impl SpatialQueryPipeline {
         let dispatcher = &*self.dispatcher;
 
         let mut leaf_callback = &mut |index: &u32| {
-            if let Some(proxy) = proxies.get(*index as usize) {
-                if filter.test(proxy.entity, proxy.layers) {
-                    let isometry = inverse_shape_isometry * proxy.isometry;
+            if let Some(proxy) = proxies.get(*index as usize)
+                && filter.test(proxy.entity, proxy.layers)
+            {
+                let isometry = inverse_shape_isometry * proxy.isometry;
 
-                    if dispatcher.intersection_test(
-                        &isometry,
-                        shape.shape_scaled().as_ref(),
-                        proxy.collider.shape_scaled().as_ref(),
-                    ) == Ok(true)
-                    {
-                        return callback(proxy.entity);
-                    }
+                if dispatcher.intersection_test(
+                    &isometry,
+                    shape.shape_scaled().as_ref(),
+                    proxy.collider.shape_scaled().as_ref(),
+                ) == Ok(true)
+                {
+                    return callback(proxy.entity);
                 }
             }
             true
@@ -815,14 +813,14 @@ impl TypedSimdCompositeShape for QueryPipelineAsCompositeShape<'_> {
             Option<&Self::PartNormalConstraints>,
         ),
     ) {
-        if let Some(proxy) = self.proxies.get(shape_id as usize) {
-            if self.query_filter.test(proxy.entity, proxy.layers) {
-                f(
-                    Some(&proxy.isometry),
-                    proxy.collider.shape_scaled().as_ref(),
-                    None,
-                );
-            }
+        if let Some(proxy) = self.proxies.get(shape_id as usize)
+            && self.query_filter.test(proxy.entity, proxy.layers)
+        {
+            f(
+                Some(&proxy.isometry),
+                proxy.collider.shape_scaled().as_ref(),
+                None,
+            );
         }
     }
 
@@ -860,15 +858,15 @@ impl TypedSimdCompositeShape for QueryPipelineAsCompositeShapeWithPredicate<'_, 
             Option<&Self::PartNormalConstraints>,
         ),
     ) {
-        if let Some(proxy) = self.proxies.get(shape_id as usize) {
-            if self.query_filter.test(proxy.entity, proxy.layers) && (self.predicate)(proxy.entity)
-            {
-                f(
-                    Some(&proxy.isometry),
-                    proxy.collider.shape_scaled().as_ref(),
-                    None,
-                );
-            }
+        if let Some(proxy) = self.proxies.get(shape_id as usize)
+            && self.query_filter.test(proxy.entity, proxy.layers)
+            && (self.predicate)(proxy.entity)
+        {
+            f(
+                Some(&proxy.isometry),
+                proxy.collider.shape_scaled().as_ref(),
+                None,
+            );
         }
     }
 

--- a/src/spatial_query/pipeline.rs
+++ b/src/spatial_query/pipeline.rs
@@ -7,6 +7,7 @@ use parry::{
     math::Isometry,
     partitioning::Qbvh,
     query::{
+        DefaultQueryDispatcher, QueryDispatcher, ShapeCastOptions,
         details::{
             NormalConstraints, RayCompositeShapeToiAndNormalBestFirstVisitor,
             TOICompositeShapeShapeBestFirstVisitor,
@@ -15,7 +16,6 @@ use parry::{
         visitors::{
             BoundingVolumeIntersectionsVisitor, PointIntersectionsVisitor, RayIntersectionsVisitor,
         },
-        DefaultQueryDispatcher, QueryDispatcher, ShapeCastOptions,
     },
     shape::{Shape, TypedSimdCompositeShape},
 };

--- a/src/spatial_query/ray_caster.rs
+++ b/src/spatial_query/ray_caster.rs
@@ -300,33 +300,32 @@ impl RayCaster {
             );
 
             let mut leaf_callback = &mut |index: &u32| {
-                if let Some(proxy) = query_pipeline.proxies.get(*index as usize) {
-                    if self.query_filter.test(proxy.entity, proxy.layers) {
-                        if let Some(hit) = proxy.collider.shape_scaled().cast_ray_and_get_normal(
-                            &proxy.isometry,
-                            &ray,
-                            self.max_distance,
-                            self.solid,
-                        ) {
-                            if (hits.vector.len() as u32) < hits.count + 1 {
-                                hits.vector.push(RayHitData {
-                                    entity: proxy.entity,
-                                    distance: hit.time_of_impact,
-                                    normal: hit.normal.into(),
-                                });
-                            } else {
-                                hits.vector[hits.count as usize] = RayHitData {
-                                    entity: proxy.entity,
-                                    distance: hit.time_of_impact,
-                                    normal: hit.normal.into(),
-                                };
-                            }
-
-                            hits.count += 1;
-
-                            return hits.count < self.max_hits;
-                        }
+                if let Some(proxy) = query_pipeline.proxies.get(*index as usize)
+                    && self.query_filter.test(proxy.entity, proxy.layers)
+                    && let Some(hit) = proxy.collider.shape_scaled().cast_ray_and_get_normal(
+                        &proxy.isometry,
+                        &ray,
+                        self.max_distance,
+                        self.solid,
+                    )
+                {
+                    if (hits.vector.len() as u32) < hits.count + 1 {
+                        hits.vector.push(RayHitData {
+                            entity: proxy.entity,
+                            distance: hit.time_of_impact,
+                            normal: hit.normal.into(),
+                        });
+                    } else {
+                        hits.vector[hits.count as usize] = RayHitData {
+                            entity: proxy.entity,
+                            distance: hit.time_of_impact,
+                            normal: hit.normal.into(),
+                        };
                     }
+
+                    hits.count += 1;
+
+                    return hits.count < self.max_hits;
                 }
                 true
             };

--- a/src/spatial_query/shape_caster.rs
+++ b/src/spatial_query/shape_caster.rs
@@ -7,7 +7,7 @@ use bevy::{
     },
     prelude::*,
 };
-use parry::query::{details::TOICompositeShapeShapeBestFirstVisitor, ShapeCastOptions};
+use parry::query::{ShapeCastOptions, details::TOICompositeShapeShapeBestFirstVisitor};
 
 /// A component used for [shapecasting](spatial_query#shapecasting).
 ///

--- a/src/tests/determinism_2d.rs
+++ b/src/tests/determinism_2d.rs
@@ -18,7 +18,7 @@
 use core::time::Duration;
 
 use crate::{
-    math::{Vector, PI},
+    math::{PI, Vector},
     prelude::*,
 };
 use bevy::{ecs::system::SystemParam, prelude::*, time::TimeUpdateStrategy};
@@ -66,7 +66,9 @@ fn cross_platform_determinism_2d() {
 
     assert!(
         hash == expected,
-        "\nExpected transform hash 0x{:x}, found 0x{:x} instead.\nIf changes in behavior were expected, update the hash in src/tests/determinism_2d.rs on line 61.\n", expected, hash,
+        "\nExpected transform hash 0x{:x}, found 0x{:x} instead.\nIf changes in behavior were expected, update the hash in src/tests/determinism_2d.rs on line 61.\n",
+        expected,
+        hash,
     );
 }
 

--- a/src/type_registration.rs
+++ b/src/type_registration.rs
@@ -1,9 +1,9 @@
 use crate::{
     prelude::*,
-    sync::{ancestor_marker::AncestorMarker, PreviousGlobalTransform, SyncConfig},
+    sync::{PreviousGlobalTransform, SyncConfig, ancestor_marker::AncestorMarker},
 };
 use bevy::prelude::*;
-use dynamics::solver::{schedule::SubstepCount, SolverConfig};
+use dynamics::solver::{SolverConfig, schedule::SubstepCount};
 
 /// Registers physics types to the `TypeRegistry` resource in `bevy_reflect`.
 pub struct PhysicsTypeRegistrationPlugin;


### PR DESCRIPTION
# Objective

We're still on good ol' Rust 2021 edition. It's time to move on to the 2024 edition!

## Solution

Upgrade the edition and fix any errors and lints that rustc and clippy complain about. The biggest ones are if-let chains and some `use<...>` bounds.