### PR TITLE
Use `SymmetricMat3` from `glam_matrix_extensions` for angular inertia

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.3.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
  "concurrent-queue",
  "event-listener-strategy",
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "avian2d"
@@ -302,6 +302,7 @@ dependencies = [
  "derive_more",
  "examples_common_2d",
  "glam",
+ "glam_matrix_extensions",
  "itertools 0.13.0",
  "libm",
  "nalgebra",
@@ -327,6 +328,7 @@ dependencies = [
  "criterion",
  "derive_more",
  "examples_common_3d",
+ "glam_matrix_extensions",
  "itertools 0.13.0",
  "libm",
  "nalgebra",
@@ -690,12 +692,12 @@ dependencies = [
 [[package]]
 name = "bevy_heavy"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ccc861fea2ff58c67f4df119512e204050bd7631a3a9c65e1a5e9d162cce28"
+source = "git+https://github.com/Jondolf/bevy_heavy.git#f2a6e3b16c839cd8802512a4de737047314f3afc"
 dependencies = [
  "approx",
  "bevy_math",
  "bevy_reflect",
+ "glam_matrix_extensions",
  "serde",
 ]
 
@@ -1453,9 +1455,9 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
  "async-channel",
  "async-task",
@@ -1466,9 +1468,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytemuck"
@@ -1530,9 +1532,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
 dependencies = [
  "jobserver",
  "libc",
@@ -1606,18 +1608,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -1767,9 +1769,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -1861,9 +1863,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "ctrlc"
@@ -2026,12 +2028,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2270,6 +2272,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "glam_matrix_extensions"
+version = "0.1.0"
+source = "git+https://github.com/Jondolf/glam_matrix_extensions#3dcfc3b9279fbe792f240a56c96bae8949f4a499"
+dependencies = [
+ "approx",
+ "bevy_reflect",
+ "glam",
+ "libm",
+ "serde",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2493,9 +2507,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -2656,9 +2670,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -2735,9 +2749,9 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memmap2"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+checksum = "483758ad303d734cec05e5c12b41d7e93e6a6390c5e9dae6bdeb7c1259012d28"
 dependencies = [
  "libc",
 ]
@@ -2985,18 +2999,19 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
 dependencies = [
  "num_enum_derive",
+ "rustversion",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3528,7 +3543,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -3574,9 +3589,9 @@ checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -3624,9 +3639,9 @@ dependencies = [
 
 [[package]]
 name = "profiling"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afbdc74edc00b6f6a218ca6a5364d6226a259d4b8ea1af4a0ea063f27e179f4d"
+checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
 
 [[package]]
 name = "quote"
@@ -3873,15 +3888,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4070,9 +4085,9 @@ dependencies = [
 
 [[package]]
 name = "spade"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ece03ff43cd2a9b57ebf776ea5e78bd30b3b4185a619f041079f4109f385034"
+checksum = "a14e31a007e9f85c32784b04f89e6e194bb252a4d41b4a8ccd9e77245d901c8c"
 dependencies = [
  "hashbrown",
  "num-traits",
@@ -4158,9 +4173,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4728,9 +4743,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.32"
+version = "0.7.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -4856,6 +4871,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -5146,9 +5170,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]
@@ -5215,9 +5239,9 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
+checksum = "6fd8403733700263c6eb89f192880191f1b83e332f7a20371ddcf421c4a337c7"
 
 [[package]]
 name = "yazi"
@@ -5233,18 +5257,18 @@ checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/avian2d/Cargo.toml
+++ b/crates/avian2d/Cargo.toml
@@ -52,6 +52,7 @@ bevy_picking = ["bevy/bevy_picking"]
 serialize = [
     "dep:serde",
     "bevy/serialize",
+    "glam_matrix_extensions/serde",
     "bevy_heavy/serialize",
     "bevy_transform_interpolation/serialize",
     "parry2d?/serde-serialize",
@@ -78,7 +79,10 @@ bevy = { version = "0.16", default-features = false, features = [
     "bevy_log",
 ] }
 bevy_math = { version = "0.16" }
-bevy_heavy = { version = "0.2" }
+glam_matrix_extensions = { git = "https://github.com/Jondolf/glam_matrix_extensions", features = [
+    "bevy_reflect",
+] }
+bevy_heavy = { git = "https://github.com/Jondolf/bevy_heavy.git" }
 bevy_transform_interpolation = { version = "0.2" }
 libm = { version = "0.2", optional = true }
 approx = "0.5"
@@ -96,7 +100,9 @@ thread_local = { version = "1.1", optional = true }
 [dev-dependencies]
 examples_common_2d = { path = "../examples_common_2d" }
 bevy_math = { version = "0.16", features = ["approx"] }
-bevy_heavy = { version = "0.2", features = ["approx"] }
+bevy_heavy = { git = "https://github.com/Jondolf/bevy_heavy.git", features = [
+    "approx",
+] }
 glam = { version = "0.29", features = ["bytemuck"] }
 bytemuck = "1.19"
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -54,6 +54,7 @@ bevy_picking = ["bevy/bevy_picking"]
 serialize = [
     "dep:serde",
     "bevy/serialize",
+    "glam_matrix_extensions/serde",
     "bevy_heavy/serialize",
     "bevy_transform_interpolation/serialize",
     "parry3d?/serde-serialize",
@@ -80,7 +81,10 @@ bevy = { version = "0.16", default-features = false, features = [
     "bevy_log",
 ] }
 bevy_math = { version = "0.16" }
-bevy_heavy = { version = "0.2" }
+glam_matrix_extensions = { git = "https://github.com/Jondolf/glam_matrix_extensions", features = [
+    "bevy_reflect",
+] }
+bevy_heavy = { git = "https://github.com/Jondolf/bevy_heavy.git" }
 bevy_transform_interpolation = { version = "0.2" }
 libm = { version = "0.2", optional = true }
 approx = "0.5"
@@ -101,7 +105,9 @@ bevy = { version = "0.16", default-features = false, features = [
     "animation",
 ] }
 bevy_math = { version = "0.16", features = ["approx"] }
-bevy_heavy = { version = "0.2", features = ["approx"] }
+bevy_heavy = { git = "https://github.com/Jondolf/bevy_heavy.git", features = [
+    "approx",
+] }
 criterion = { version = "0.5", features = ["html_reports"] }
 bevy_mod_debugdump = { version = "0.13" }
 

--- a/src/dynamics/rigid_body/locked_axes.rs
+++ b/src/dynamics/rigid_body/locked_axes.rs
@@ -230,11 +230,10 @@ impl LockedAxes {
         angular_inertia: impl Into<ComputedAngularInertia>,
     ) -> ComputedAngularInertia {
         let mut angular_inertia = angular_inertia.into();
-
+        let angular_inertia_mut = angular_inertia.inverse_mut();
         if self.is_rotation_locked() {
-            *angular_inertia.inverse_mut() = 0.0;
+            *angular_inertia_mut = 0.0;
         }
-
         angular_inertia
     }
 
@@ -245,17 +244,22 @@ impl LockedAxes {
         angular_inertia: impl Into<ComputedAngularInertia>,
     ) -> ComputedAngularInertia {
         let mut angular_inertia = angular_inertia.into();
-
+        let angular_inertia_mut = angular_inertia.inverse_mut();
         if self.is_rotation_x_locked() {
-            angular_inertia.inverse_mut().x_axis = Vector::ZERO;
+            angular_inertia_mut.m00 = 0.0;
+            angular_inertia_mut.m01 = 0.0;
+            angular_inertia_mut.m02 = 0.0;
         }
         if self.is_rotation_y_locked() {
-            angular_inertia.inverse_mut().y_axis = Vector::ZERO;
+            angular_inertia_mut.m11 = 0.0;
+            angular_inertia_mut.m01 = 0.0;
+            angular_inertia_mut.m12 = 0.0;
         }
         if self.is_rotation_z_locked() {
-            angular_inertia.inverse_mut().z_axis = Vector::ZERO;
+            angular_inertia_mut.m22 = 0.0;
+            angular_inertia_mut.m02 = 0.0;
+            angular_inertia_mut.m12 = 0.0;
         }
-
         angular_inertia
     }
 

--- a/src/dynamics/rigid_body/mass_properties/components/computed.rs
+++ b/src/dynamics/rigid_body/mass_properties/components/computed.rs
@@ -431,7 +431,7 @@ impl From<ComputedAngularInertia> for AngularInertia {
 pub struct ComputedAngularInertia {
     // TODO: The matrix should be symmetric and positive definite.
     //       We could add a custom `SymmetricMat3` type to enforce symmetricity and reduce memory usage.
-    inverse: Matrix,
+    inverse: SymmetricMatrix,
 }
 
 impl Default for ComputedAngularInertia {
@@ -444,7 +444,7 @@ impl Default for ComputedAngularInertia {
 impl ComputedAngularInertia {
     /// Infinite angular inertia.
     pub const INFINITY: Self = Self {
-        inverse: Matrix::ZERO,
+        inverse: SymmetricMatrix::ZERO,
     };
 
     /// Creates a new [`ComputedAngularInertia`] from the given principal angular inertia.
@@ -468,7 +468,7 @@ impl ComputedAngularInertia {
             "principal angular inertia must be positive or zero for all axes"
         );
 
-        Self::from_inverse_tensor(Matrix::from_diagonal(
+        Self::from_inverse_tensor(SymmetricMatrix::from_diagonal(
             principal_angular_inertia.recip_or_zero(),
         ))
     }
@@ -491,7 +491,7 @@ impl ComputedAngularInertia {
         } else if !principal_angular_inertia.cmpge(Vector::ZERO).all() {
             Err(AngularInertiaError::Negative)
         } else {
-            Ok(Self::from_inverse_tensor(Matrix::from_diagonal(
+            Ok(Self::from_inverse_tensor(SymmetricMatrix::from_diagonal(
                 principal_angular_inertia.recip_or_zero(),
             )))
         }
@@ -520,11 +520,11 @@ impl ComputedAngularInertia {
             "principal angular inertia must be positive or zero for all axes"
         );
 
-        Self::from_inverse_tensor(
+        Self::from_inverse_tensor(SymmetricMatrix::from_mat3_unchecked(
             Matrix::from_quat(orientation)
                 * Matrix::from_diagonal(principal_angular_inertia.recip_or_zero())
                 * Matrix::from_quat(orientation.inverse()),
-        )
+        ))
     }
 
     /// Tries to create a new [`ComputedAngularInertia`] from the given principal angular inertia
@@ -549,9 +549,11 @@ impl ComputedAngularInertia {
             Err(AngularInertiaError::Negative)
         } else {
             Ok(Self::from_inverse_tensor(
-                Matrix::from_quat(orientation)
-                    * Matrix::from_diagonal(principal_angular_inertia.recip_or_zero())
-                    * Matrix::from_quat(orientation.inverse()),
+                SymmetricMatrix::from_mat3_unchecked(
+                    Matrix::from_quat(orientation)
+                        * Matrix::from_diagonal(principal_angular_inertia.recip_or_zero())
+                        * Matrix::from_quat(orientation.inverse()),
+                ),
             ))
         }
     }
@@ -563,7 +565,7 @@ impl ComputedAngularInertia {
     /// Note that this involves an invertion because [`ComputedAngularInertia`] internally stores the inverse angular inertia.
     #[inline]
     #[doc(alias = "from_mat3")]
-    pub fn from_tensor(tensor: Matrix) -> Self {
+    pub fn from_tensor(tensor: SymmetricMatrix) -> Self {
         Self::from_inverse_tensor(tensor.inverse_or_zero())
     }
 
@@ -572,7 +574,7 @@ impl ComputedAngularInertia {
     /// The tensor should be symmetric and positive definite.
     #[inline]
     #[doc(alias = "from_inverse_mat3")]
-    pub fn from_inverse_tensor(inverse_tensor: Matrix) -> Self {
+    pub fn from_inverse_tensor(inverse_tensor: SymmetricMatrix) -> Self {
         Self {
             inverse: inverse_tensor,
         }
@@ -586,7 +588,7 @@ impl ComputedAngularInertia {
     ///
     /// Equivalent to [`ComputedAngularInertia::tensor`].
     #[inline]
-    pub fn value(self) -> Matrix {
+    pub fn value(self) -> SymmetricMatrix {
         self.tensor()
     }
 
@@ -596,7 +598,7 @@ impl ComputedAngularInertia {
     ///
     /// Equivalent to [`ComputedAngularInertia::inverse_tensor`].
     #[inline]
-    pub fn inverse(self) -> Matrix {
+    pub fn inverse(self) -> SymmetricMatrix {
         self.inverse_tensor()
     }
 
@@ -604,7 +606,7 @@ impl ComputedAngularInertia {
     ///
     /// Note that this is a no-op because [`ComputedAngularInertia`] internally stores the inverse angular inertia.
     #[inline]
-    pub(crate) fn inverse_mut(&mut self) -> &mut Matrix {
+    pub(crate) fn inverse_mut(&mut self) -> &mut SymmetricMatrix {
         self.inverse_tensor_mut()
     }
 
@@ -615,7 +617,7 @@ impl ComputedAngularInertia {
     /// instead of `angular_inertia.value().inverse() * foo`.
     #[inline]
     #[doc(alias = "as_mat3")]
-    pub fn tensor(self) -> Matrix {
+    pub fn tensor(self) -> SymmetricMatrix {
         self.inverse.inverse_or_zero()
     }
 
@@ -624,7 +626,7 @@ impl ComputedAngularInertia {
     /// Note that this is a no-op because [`ComputedAngularInertia`] internally stores the inverse angular inertia.
     #[inline]
     #[doc(alias = "as_inverse_mat3")]
-    pub fn inverse_tensor(self) -> Matrix {
+    pub fn inverse_tensor(self) -> SymmetricMatrix {
         self.inverse
     }
 
@@ -633,7 +635,7 @@ impl ComputedAngularInertia {
     /// Note that this is a no-op because [`ComputedAngularInertia`] internally stores the inverse angular inertia.
     #[inline]
     #[doc(alias = "as_inverse_mat3_mut")]
-    pub fn inverse_tensor_mut(&mut self) -> &mut Matrix {
+    pub fn inverse_tensor_mut(&mut self) -> &mut SymmetricMatrix {
         &mut self.inverse
     }
 
@@ -663,18 +665,21 @@ impl ComputedAngularInertia {
     #[inline]
     pub fn rotated(self, rotation: Quaternion) -> Self {
         let rot_mat3 = Matrix::from_quat(rotation);
-        Self::from_inverse_tensor((rot_mat3 * self.inverse) * rot_mat3.transpose())
+        Self::from_inverse_tensor(SymmetricMatrix::from_mat3_unchecked(
+            (rot_mat3 * self.inverse) * rot_mat3.transpose(),
+        ))
     }
 
     /// Computes the angular inertia tensor shifted by the given offset, taking into account the given mass.
     #[inline]
-    pub fn shifted_tensor(&self, mass: Scalar, offset: Vector) -> Matrix3 {
+    pub fn shifted_tensor(&self, mass: Scalar, offset: Vector) -> SymmetricMatrix3 {
         if mass > 0.0 && mass.is_finite() && offset != Vector::ZERO {
             let diagonal_element = offset.length_squared();
             let diagonal_mat = Matrix3::from_diagonal(Vector::splat(diagonal_element));
             let offset_outer_product =
                 Matrix3::from_cols(offset * offset.x, offset * offset.y, offset * offset.z);
-            self.tensor() + (diagonal_mat + offset_outer_product) * mass
+            self.tensor()
+                + SymmetricMatrix::from_mat3_unchecked((diagonal_mat + offset_outer_product) * mass)
         } else {
             self.tensor()
         }
@@ -682,7 +687,7 @@ impl ComputedAngularInertia {
 
     /// Computes the inverse angular inertia tensor shifted by the given offset, taking into account the given mass.
     #[inline]
-    pub fn shifted_inverse_tensor(&self, mass: Scalar, offset: Vector) -> Matrix3 {
+    pub fn shifted_inverse_tensor(&self, mass: Scalar, offset: Vector) -> SymmetricMatrix3 {
         self.shifted_tensor(mass, offset).inverse_or_zero()
     }
 
@@ -706,8 +711,8 @@ impl ComputedAngularInertia {
 }
 
 #[cfg(feature = "3d")]
-impl From<Matrix> for ComputedAngularInertia {
-    fn from(tensor: Matrix) -> Self {
+impl From<SymmetricMatrix> for ComputedAngularInertia {
+    fn from(tensor: SymmetricMatrix) -> Self {
         Self::from_tensor(tensor)
     }
 }
@@ -798,8 +803,8 @@ impl From<GlobalAngularInertia> for ComputedAngularInertia {
 }
 
 #[cfg(feature = "3d")]
-impl From<Matrix> for GlobalAngularInertia {
-    fn from(tensor: Matrix) -> Self {
+impl From<SymmetricMatrix> for GlobalAngularInertia {
+    fn from(tensor: SymmetricMatrix) -> Self {
         Self(ComputedAngularInertia::from_tensor(tensor))
     }
 }
@@ -998,20 +1003,18 @@ mod tests {
         let angular_inertia = ComputedAngularInertia::new(Vector::new(10.0, 20.0, 30.0));
         assert_relative_eq!(
             angular_inertia.inverse_tensor(),
-            ComputedAngularInertia::from_inverse_tensor(Matrix::from_diagonal(Vector::new(
-                0.1,
-                0.05,
-                1.0 / 30.0
-            )))
+            ComputedAngularInertia::from_inverse_tensor(SymmetricMatrix::from_diagonal(
+                Vector::new(0.1, 0.05, 1.0 / 30.0)
+            ))
             .inverse_tensor()
         );
         assert_relative_eq!(
             angular_inertia.tensor(),
-            Matrix::from_diagonal(Vector::new(10.0, 20.0, 30.0))
+            SymmetricMatrix::from_diagonal(Vector::new(10.0, 20.0, 30.0))
         );
         assert_relative_eq!(
             angular_inertia.inverse_tensor(),
-            Matrix::from_diagonal(Vector::new(0.1, 0.05, 1.0 / 30.0))
+            SymmetricMatrix::from_diagonal(Vector::new(0.1, 0.05, 1.0 / 30.0))
         );
     }
 
@@ -1025,10 +1028,12 @@ mod tests {
         );
         assert_eq!(
             angular_inertia,
-            ComputedAngularInertia::from_inverse_tensor(Matrix::from_diagonal(Vector::ZERO))
+            ComputedAngularInertia::from_inverse_tensor(SymmetricMatrix::from_diagonal(
+                Vector::ZERO
+            ))
         );
-        assert_relative_eq!(angular_inertia.tensor(), Matrix::ZERO);
-        assert_relative_eq!(angular_inertia.inverse_tensor(), Matrix::ZERO);
+        assert_relative_eq!(angular_inertia.tensor(), SymmetricMatrix::ZERO);
+        assert_relative_eq!(angular_inertia.inverse_tensor(), SymmetricMatrix::ZERO);
         assert!(angular_inertia.is_infinite());
         assert!(!angular_inertia.is_finite());
         assert!(!angular_inertia.is_nan());
@@ -1044,10 +1049,10 @@ mod tests {
         );
         assert_eq!(
             angular_inertia,
-            ComputedAngularInertia::from_inverse_tensor(Matrix::ZERO)
+            ComputedAngularInertia::from_inverse_tensor(SymmetricMatrix::ZERO)
         );
-        assert_relative_eq!(angular_inertia.tensor(), Matrix::ZERO);
-        assert_relative_eq!(angular_inertia.inverse_tensor(), Matrix::ZERO);
+        assert_relative_eq!(angular_inertia.tensor(), SymmetricMatrix::ZERO);
+        assert_relative_eq!(angular_inertia.inverse_tensor(), SymmetricMatrix::ZERO);
         assert!(angular_inertia.is_infinite());
         assert!(!angular_inertia.is_finite());
         assert!(!angular_inertia.is_nan());

--- a/src/dynamics/rigid_body/mass_properties/components/mod.rs
+++ b/src/dynamics/rigid_body/mass_properties/components/mod.rs
@@ -8,6 +8,8 @@ use bevy::{
 #[cfg(feature = "3d")]
 use bevy_heavy::AngularInertiaTensor;
 use derive_more::From;
+#[cfg(feature = "3d")]
+use glam_matrix_extensions::{MatConversionError, SymmetricMat3};
 
 mod collider;
 pub use collider::*;
@@ -662,6 +664,47 @@ impl AngularInertia {
         }
     }
 
+    /// Creates a new [`AngularInertiaTensor`] from the given angular inertia [tensor]
+    /// represented as a [`SymmetricMat3`].
+    ///
+    /// The tensor should be [positive-semidefinite], but this is *not* checked.
+    ///
+    /// [tensor]: https://en.wikipedia.org/wiki/Moment_of_inertia#Inertia_tensor
+    /// [positive-semidefinite]: https://en.wikipedia.org/wiki/Definite_matrix
+    #[inline]
+    #[must_use]
+    #[doc(alias = "from_tensor")]
+    pub fn from_symmetric_mat3(mat: SymmetricMat3) -> Self {
+        Self::from_tensor(AngularInertiaTensor::from_symmetric_mat3(mat))
+    }
+
+    /// Tries to create a new [`AngularInertiaTensor`] from the given angular inertia [tensor]
+    /// represented as a [`Mat3`].
+    ///
+    /// The tensor should be [positive-semidefinite], but this is *not* checked.
+    ///
+    /// [tensor]: https://en.wikipedia.org/wiki/Moment_of_inertia#Inertia_tensor
+    /// [positive-semidefinite]: https://en.wikipedia.org/wiki/Definite_matrix
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`MatConversionError`] if the given matrix is not symmetric.
+    #[inline]
+    pub fn try_from_mat3(mat: Mat3) -> Result<Self, MatConversionError> {
+        SymmetricTensor::try_from_mat3(mat).map(Self::from_tensor)
+    }
+
+    /// Creates a new [`AngularInertiaTensor`] from the given angular inertia [tensor]
+    /// represented as a [`Mat3`].
+    ///
+    /// Only the lower left triangle of the matrix is used. No check is performed to ensure
+    /// that the given matrix is truly symmetric or positive-semidefinite.
+    #[inline]
+    #[must_use]
+    pub fn from_mat3_unchecked(mat: Mat3) -> Self {
+        Self::from_tensor(SymmetricMat3::from_mat3_unchecked(mat))
+    }
+
     /// Computes the [`AngularInertia`] of the given shape using the given mass.
     ///
     /// ```
@@ -702,8 +745,8 @@ impl AngularInertia {
 }
 
 #[cfg(feature = "3d")]
-impl From<Mat3> for AngularInertia {
-    fn from(tensor: Mat3) -> Self {
+impl From<SymmetricMat3> for AngularInertia {
+    fn from(tensor: SymmetricMat3) -> Self {
         Self::from_tensor(tensor)
     }
 }

--- a/src/dynamics/rigid_body/mass_properties/system_param.rs
+++ b/src/dynamics/rigid_body/mass_properties/system_param.rs
@@ -106,7 +106,7 @@ impl MassPropertyHelper<'_, '_> {
                     computed_inertia.set(
                         mass_props
                             .angular_inertia_tensor()
-                            .as_mat3()
+                            .as_symmetric_mat3()
                             .adjust_precision(),
                     );
                 }
@@ -121,7 +121,7 @@ impl MassPropertyHelper<'_, '_> {
                 computed_inertia.set(
                     mass_props
                         .angular_inertia_tensor()
-                        .as_mat3()
+                        .as_symmetric_mat3()
                         .adjust_precision(),
                 );
             }

--- a/src/dynamics/solver/joints/revolute.rs
+++ b/src/dynamics/solver/joints/revolute.rs
@@ -320,8 +320,8 @@ impl RevoluteJoint {
         &mut self,
         body1: &mut SolverBody,
         body2: &mut SolverBody,
-        inv_angular_inertia1: Tensor,
-        inv_angular_inertia2: Tensor,
+        inv_angular_inertia1: SymmetricTensor,
+        inv_angular_inertia2: SymmetricTensor,
         dt: Scalar,
     ) -> Torque {
         let Some(Some(correction)) = self.angle_limit.map(|angle_limit| {

--- a/src/dynamics/solver/mod.rs
+++ b/src/dynamics/solver/mod.rs
@@ -517,7 +517,7 @@ fn prepare_contact_constraints(
                 ),
                 Ordering::Greater => (
                     0.0,
-                    Tensor::ZERO,
+                    SymmetricTensor::ZERO,
                     body2.mass.inverse(),
                     body2.angular_inertia.value(),
                 ),
@@ -525,7 +525,7 @@ fn prepare_contact_constraints(
                     body1.mass.inverse(),
                     body1.angular_inertia.value(),
                     0.0,
-                    Tensor::ZERO,
+                    SymmetricTensor::ZERO,
                 ),
             };
 

--- a/src/dynamics/solver/solver_body/mod.rs
+++ b/src/dynamics/solver/solver_body/mod.rs
@@ -14,7 +14,9 @@ pub use plugin::SolverBodyPlugin;
 use bevy::prelude::*;
 
 use super::{Rotation, Vector};
-use crate::{Tensor, math::Scalar, prelude::LockedAxes};
+use crate::{SymmetricTensor, math::Scalar, prelude::LockedAxes};
+#[cfg(feature = "3d")]
+use crate::{math::Quaternion, prelude::ComputedAngularInertia};
 
 // The `SolverBody` layout is inspired by `b2BodyState` in Box2D v3.
 
@@ -159,11 +161,7 @@ The API abstracts over this difference in representation to reduce complexity.
 /// This includes the effective inverse mass and angular inertia,
 /// and flags indicating whether the body is static or has locked axes.
 ///
-/// 16 bytes in 2D and 44 bytes in 3D with the `f32` feature.
-///
-/// The 3D version will be 32 bytes in the future
-/// if/when we switch to a symmetric 3x3 matrix representation
-/// for the angular inertia tensor.
+/// 16 bytes in 2D and 32 bytes in 3D with the `f32` feature.
 #[derive(Component, Clone, Debug, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
@@ -187,21 +185,15 @@ pub struct SolverBodyInertia {
     ///
     /// 4 bytes with the `f32` feature.
     #[cfg(feature = "2d")]
-    effective_inv_inertia: Tensor,
+    effective_inv_angular_inertia: SymmetricTensor,
 
-    /// The world-space inverse angular inertia of the body
-    /// before the substepping loop of the solver.
+    /// The world-space inverse angular inertia of the body.
     ///
-    /// Rotate by `delta_rotation` to get the current angular inertia
-    /// during the substepping loop.
-    ///
-    /// 36 bytes with the `f32` feature. This will be 32 bytes
-    /// in the future if/when we switch to a symmetric 3x3 matrix representation.
+    /// 32 bytes with the `f32` feature.
     #[cfg(feature = "3d")]
-    inv_inertia: Tensor,
+    effective_inv_angular_inertia: SymmetricTensor,
 
     // TODO: We could also store the `Dominance` of the body here if we wanted to.
-    // TODO: Technically we don't even need these flags at the moment.
     /// Flags indicating the inertial properties of the body,
     /// like locked axes and whether the body is static.
     ///
@@ -217,9 +209,9 @@ impl Default for SolverBodyInertia {
             #[cfg(feature = "3d")]
             inv_mass: 0.0,
             #[cfg(feature = "2d")]
-            effective_inv_inertia: 0.0,
+            effective_inv_angular_inertia: 0.0,
             #[cfg(feature = "3d")]
-            inv_inertia: Tensor::ZERO,
+            effective_inv_angular_inertia: SymmetricTensor::ZERO,
             flags: InertiaFlags::STATIC,
         }
     }
@@ -267,9 +259,9 @@ impl SolverBodyInertia {
     /// and locked axes.
     #[inline]
     #[cfg(feature = "2d")]
-    pub fn new(inv_mass: Scalar, inv_inertia: Tensor, locked_axes: LockedAxes) -> Self {
+    pub fn new(inv_mass: Scalar, inv_inertia: SymmetricTensor, locked_axes: LockedAxes) -> Self {
         let mut effective_inv_mass = Vector::splat(inv_mass);
-        let mut effective_inv_inertia = inv_inertia;
+        let mut effective_inv_angular_inertia = inv_inertia;
         let mut flags = InertiaFlags(locked_axes.to_bits() as u32);
 
         if inv_mass == 0.0 {
@@ -286,12 +278,12 @@ impl SolverBodyInertia {
             effective_inv_mass.y = 0.0;
         }
         if locked_axes.is_rotation_locked() {
-            effective_inv_inertia = 0.0;
+            effective_inv_angular_inertia = 0.0;
         }
 
         Self {
             effective_inv_mass,
-            effective_inv_inertia,
+            effective_inv_angular_inertia,
             flags: InertiaFlags(flags.0),
         }
     }
@@ -300,19 +292,38 @@ impl SolverBodyInertia {
     /// and locked axes.
     #[inline]
     #[cfg(feature = "3d")]
-    pub fn new(inv_mass: Scalar, inv_inertia: Tensor, locked_axes: LockedAxes) -> Self {
+    pub fn new(inv_mass: Scalar, inv_inertia: SymmetricTensor, locked_axes: LockedAxes) -> Self {
+        let mut effective_inv_angular_inertia = inv_inertia;
         let mut flags = InertiaFlags(locked_axes.to_bits() as u32);
 
         if inv_mass == 0.0 {
             flags |= InertiaFlags::INFINITE_MASS;
         }
-        if inv_inertia == Tensor::ZERO {
+        if inv_inertia == SymmetricTensor::ZERO {
             flags |= InertiaFlags::INFINITE_ANGULAR_INERTIA;
+        }
+
+        if locked_axes.is_rotation_x_locked() {
+            effective_inv_angular_inertia.m00 = 0.0;
+            effective_inv_angular_inertia.m01 = 0.0;
+            effective_inv_angular_inertia.m02 = 0.0;
+        }
+
+        if locked_axes.is_rotation_y_locked() {
+            effective_inv_angular_inertia.m01 = 0.0;
+            effective_inv_angular_inertia.m11 = 0.0;
+            effective_inv_angular_inertia.m12 = 0.0;
+        }
+
+        if locked_axes.is_rotation_z_locked() {
+            effective_inv_angular_inertia.m02 = 0.0;
+            effective_inv_angular_inertia.m12 = 0.0;
+            effective_inv_angular_inertia.m22 = 0.0;
         }
 
         Self {
             inv_mass,
-            inv_inertia,
+            effective_inv_angular_inertia,
             flags: InertiaFlags(flags.0),
         }
     }
@@ -349,33 +360,50 @@ impl SolverBodyInertia {
     /// taking into account any locked axes.
     #[inline]
     #[cfg(feature = "2d")]
-    pub fn effective_inv_angular_inertia(&self) -> Tensor {
-        self.effective_inv_inertia
+    pub fn effective_inv_angular_inertia(&self) -> SymmetricTensor {
+        self.effective_inv_angular_inertia
     }
 
     /// Returns the effective inverse angular inertia of the body in world space,
     /// taking into account any locked axes.
-    ///
-    /// Note that this is the world-space value from before the substepping loop,
-    /// which may have changed if the body has rotated. For most cases,
-    /// the difference should be acceptable.
     #[inline]
     #[cfg(feature = "3d")]
-    pub fn effective_inv_angular_inertia(&self) -> Tensor {
-        let mut inv_inertia = self.inv_inertia;
+    pub fn effective_inv_angular_inertia(&self) -> SymmetricTensor {
+        self.effective_inv_angular_inertia
+    }
 
-        // TODO: Should we just store the effective version directly rather than computing it here?
-        if self.flags.contains(InertiaFlags::ROTATION_X_LOCKED) {
-            inv_inertia.x_axis = Vector::ZERO;
-        }
-        if self.flags.contains(InertiaFlags::ROTATION_Y_LOCKED) {
-            inv_inertia.y_axis = Vector::ZERO;
-        }
-        if self.flags.contains(InertiaFlags::ROTATION_Z_LOCKED) {
-            inv_inertia.z_axis = Vector::ZERO;
+    /// Updates the effective inverse angular inertia of the body in world space,
+    /// taking into account any locked axes.
+    #[inline]
+    #[cfg(feature = "3d")]
+    pub fn update_effective_inv_angular_inertia(
+        &mut self,
+        computed_angular_inertia: &ComputedAngularInertia,
+        rotation: Quaternion,
+        locked_axes: LockedAxes,
+    ) {
+        let mut effective_inv_angular_inertia =
+            computed_angular_inertia.rotated(rotation).inverse();
+
+        if locked_axes.is_rotation_x_locked() {
+            effective_inv_angular_inertia.m00 = 0.0;
+            effective_inv_angular_inertia.m01 = 0.0;
+            effective_inv_angular_inertia.m02 = 0.0;
         }
 
-        inv_inertia
+        if locked_axes.is_rotation_y_locked() {
+            effective_inv_angular_inertia.m11 = 0.0;
+            effective_inv_angular_inertia.m01 = 0.0;
+            effective_inv_angular_inertia.m12 = 0.0;
+        }
+
+        if locked_axes.is_rotation_z_locked() {
+            effective_inv_angular_inertia.m22 = 0.0;
+            effective_inv_angular_inertia.m02 = 0.0;
+            effective_inv_angular_inertia.m12 = 0.0;
+        }
+
+        self.effective_inv_angular_inertia = effective_inv_angular_inertia;
     }
 
     /// Returns the [`InertiaFlags`] of the body.

--- a/src/dynamics/solver/xpbd/angular_constraint.rs
+++ b/src/dynamics/solver/xpbd/angular_constraint.rs
@@ -13,8 +13,8 @@ pub trait AngularConstraint: XpbdConstraint<2> {
         &self,
         body1: &mut SolverBody,
         body2: &mut SolverBody,
-        inv_angular_inertia1: Tensor,
-        inv_angular_inertia2: Tensor,
+        inv_angular_inertia1: SymmetricTensor,
+        inv_angular_inertia2: SymmetricTensor,
         delta_lagrange: Scalar,
     ) -> Scalar {
         if delta_lagrange.abs() <= Scalar::EPSILON {
@@ -39,8 +39,8 @@ pub trait AngularConstraint: XpbdConstraint<2> {
         &self,
         body1: &mut SolverBody,
         body2: &mut SolverBody,
-        inv_angular_inertia1: Tensor,
-        inv_angular_inertia2: Tensor,
+        inv_angular_inertia1: SymmetricTensor,
+        inv_angular_inertia2: SymmetricTensor,
         impulse: Scalar,
     ) -> Scalar {
         // Apply rotational updates
@@ -62,8 +62,8 @@ pub trait AngularConstraint: XpbdConstraint<2> {
         &self,
         body1: &mut SolverBody,
         body2: &mut SolverBody,
-        inv_angular_inertia1: Tensor,
-        inv_angular_inertia2: Tensor,
+        inv_angular_inertia1: SymmetricTensor,
+        inv_angular_inertia2: SymmetricTensor,
         delta_lagrange: Scalar,
         axis: Vector,
     ) -> Vector {
@@ -91,8 +91,8 @@ pub trait AngularConstraint: XpbdConstraint<2> {
         &self,
         body1: &mut SolverBody,
         body2: &mut SolverBody,
-        inv_angular_inertia1: Tensor,
-        inv_angular_inertia2: Tensor,
+        inv_angular_inertia1: SymmetricTensor,
+        inv_angular_inertia2: SymmetricTensor,
         impulse: Vector,
     ) -> Vector {
         // Apply rotational updates
@@ -113,8 +113,8 @@ pub trait AngularConstraint: XpbdConstraint<2> {
         &self,
         body1: &mut SolverBody,
         body2: &mut SolverBody,
-        inv_angular_inertia1: Tensor,
-        inv_angular_inertia2: Tensor,
+        inv_angular_inertia1: SymmetricTensor,
+        inv_angular_inertia2: SymmetricTensor,
         angle: Scalar,
         lagrange: &mut Scalar,
         compliance: Scalar,
@@ -151,8 +151,8 @@ pub trait AngularConstraint: XpbdConstraint<2> {
         &self,
         body1: &mut SolverBody,
         body2: &mut SolverBody,
-        inv_angular_inertia1: Tensor,
-        inv_angular_inertia2: Tensor,
+        inv_angular_inertia1: SymmetricTensor,
+        inv_angular_inertia2: SymmetricTensor,
         rotation_difference: Vector,
         lagrange: &mut Scalar,
         compliance: Scalar,
@@ -201,8 +201,8 @@ pub trait AngularConstraint: XpbdConstraint<2> {
         &self,
         body1: &mut SolverBody,
         body2: &mut SolverBody,
-        inv_angular_inertia1: Tensor,
-        inv_angular_inertia2: Tensor,
+        inv_angular_inertia1: SymmetricTensor,
+        inv_angular_inertia2: SymmetricTensor,
         delta_lagrange: Scalar,
         axis: Vector3,
     ) -> Scalar {
@@ -232,8 +232,8 @@ pub trait AngularConstraint: XpbdConstraint<2> {
         &self,
         body1: &mut SolverBody,
         body2: &mut SolverBody,
-        inv_angular_inertia1: Tensor,
-        inv_angular_inertia2: Tensor,
+        inv_angular_inertia1: SymmetricTensor,
+        inv_angular_inertia2: SymmetricTensor,
         delta_lagrange: Scalar,
         axis: Vector,
     ) -> Vector {
@@ -261,7 +261,7 @@ pub trait AngularConstraint: XpbdConstraint<2> {
     /// clockwise rotation.
     fn compute_generalized_inverse_mass(
         &self,
-        inv_angular_inertia: Tensor,
+        inv_angular_inertia: SymmetricTensor,
         axis: Vector3,
     ) -> Scalar {
         axis.dot(inv_angular_inertia * axis)
@@ -269,14 +269,14 @@ pub trait AngularConstraint: XpbdConstraint<2> {
 
     /// Computes the update in rotation when applying an angular correction `p`.
     #[cfg(feature = "2d")]
-    fn get_delta_rot(inverse_inertia: Tensor, p: Scalar) -> Scalar {
+    fn get_delta_rot(inverse_inertia: SymmetricTensor, p: Scalar) -> Scalar {
         // Equation 8/9 but in 2D
         inverse_inertia * p
     }
 
     /// Computes the update in rotation when applying an angular correction `p`.
     #[cfg(feature = "3d")]
-    fn get_delta_rot(inverse_inertia: Tensor, p: Vector) -> Quaternion {
+    fn get_delta_rot(inverse_inertia: SymmetricTensor, p: Vector) -> Quaternion {
         // Equation 8/9
         Quaternion::from_scaled_axis(inverse_inertia * p)
     }

--- a/src/dynamics/solver/xpbd/positional_constraint.rs
+++ b/src/dynamics/solver/xpbd/positional_constraint.rs
@@ -83,7 +83,7 @@ pub trait PositionConstraint: XpbdConstraint<2> {
     fn compute_generalized_inverse_mass(
         &self,
         inverse_mass: Scalar,
-        inverse_angular_inertia: Scalar,
+        inverse_angular_inertia: SymmetricTensor,
         r: Vector,
         n: Vector,
     ) -> Scalar {
@@ -96,7 +96,7 @@ pub trait PositionConstraint: XpbdConstraint<2> {
     fn compute_generalized_inverse_mass(
         &self,
         inverse_mass: Scalar,
-        inverse_angular_inertia: Matrix3,
+        inverse_angular_inertia: SymmetricTensor,
         r: Vector,
         n: Vector,
     ) -> Scalar {
@@ -109,14 +109,14 @@ pub trait PositionConstraint: XpbdConstraint<2> {
 
     /// Computes the update in rotation when applying a positional correction `p` at point `r`.
     #[cfg(feature = "2d")]
-    fn get_delta_rot(inverse_angular_inertia: Scalar, r: Vector, p: Vector) -> Scalar {
+    fn get_delta_rot(inverse_angular_inertia: SymmetricTensor, r: Vector, p: Vector) -> Scalar {
         // Equation 8/9 but in 2D
         inverse_angular_inertia * r.perp_dot(p)
     }
 
     /// Computes the update in rotation when applying a positional correction `p` at point `r`.
     #[cfg(feature = "3d")]
-    fn get_delta_rot(inverse_angular_inertia: Matrix3, r: Vector, p: Vector) -> Quaternion {
+    fn get_delta_rot(inverse_angular_inertia: SymmetricTensor, r: Vector, p: Vector) -> Quaternion {
         // Equation 8/9
         Quaternion::from_scaled_axis(inverse_angular_inertia * r.cross(p))
     }

--- a/src/math/double.rs
+++ b/src/math/double.rs
@@ -1,5 +1,6 @@
 use super::AdjustPrecision;
 use bevy_math::*;
+use glam_matrix_extensions::*;
 
 /// The floating point number type used by Avian.
 pub type Scalar = f64;
@@ -33,6 +34,16 @@ pub type Matrix = DMat3;
 pub type Matrix2 = DMat2;
 /// The 3x3 matrix type used by Avian.
 pub type Matrix3 = DMat3;
+/// The dimension-specific matrix type used by Avian.
+#[cfg(feature = "2d")]
+pub type SymmetricMatrix = SymmetricDMat2;
+/// The dimension-specific matrix type used by Avian.
+#[cfg(feature = "3d")]
+pub type SymmetricMatrix = SymmetricDMat3;
+/// The 2x2 matrix type used by Avian.
+pub type SymmetricMatrix2 = SymmetricDMat2;
+/// The 3x3 matrix type used by Avian.
+pub type SymmetricMatrix3 = SymmetricDMat3;
 /// The quaternion type used by Avian.
 pub type Quaternion = DQuat;
 
@@ -101,6 +112,34 @@ impl AdjustPrecision for Mat3 {
 
 impl AdjustPrecision for DMat3 {
     type Adjusted = Matrix3;
+    fn adjust_precision(&self) -> Self::Adjusted {
+        *self
+    }
+}
+
+impl AdjustPrecision for SymmetricMat2 {
+    type Adjusted = SymmetricMatrix2;
+    fn adjust_precision(&self) -> Self::Adjusted {
+        self.as_symmetric_dmat2()
+    }
+}
+
+impl AdjustPrecision for SymmetricDMat2 {
+    type Adjusted = SymmetricMatrix2;
+    fn adjust_precision(&self) -> Self::Adjusted {
+        *self
+    }
+}
+
+impl AdjustPrecision for SymmetricMat3 {
+    type Adjusted = SymmetricMatrix3;
+    fn adjust_precision(&self) -> Self::Adjusted {
+        self.as_symmetric_dmat3()
+    }
+}
+
+impl AdjustPrecision for SymmetricDMat3 {
+    type Adjusted = SymmetricMatrix3;
     fn adjust_precision(&self) -> Self::Adjusted {
         *self
     }

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -5,6 +5,7 @@
 #[cfg(feature = "f32")]
 mod single;
 use approx::abs_diff_ne;
+use glam_matrix_extensions::{SymmetricDMat2, SymmetricDMat3, SymmetricMat2, SymmetricMat3};
 #[cfg(feature = "f32")]
 pub use single::*;
 
@@ -53,18 +54,18 @@ pub(crate) type Dir = Dir2;
 #[cfg(feature = "3d")]
 pub(crate) type Dir = Dir3;
 
-/// The tensor type chosen based on the dimension.
+/// The symmetric tensor type chosen based on the dimension.
 /// Often used for angular inertia.
 ///
 /// In 2D, this is a scalar, while in 3D, it is a 3x3 matrix.
 #[cfg(feature = "2d")]
-pub(crate) type Tensor = Scalar;
-/// The tensor type chosen based on the dimension.
+pub(crate) type SymmetricTensor = Scalar;
+/// The symmetric tensor type chosen based on the dimension.
 /// Often used for angular inertia.
 ///
 /// In 2D, this is a scalar, while in 3D, it is a 3x3 matrix.
 #[cfg(feature = "3d")]
-pub(crate) type Tensor = Matrix3;
+pub(crate) type SymmetricTensor = SymmetricMatrix;
 
 /// Adjust the precision of the math construct to the precision chosen for compilation.
 pub trait AdjustPrecision {
@@ -145,6 +146,24 @@ impl AsF32 for Mat2 {
     }
 }
 
+impl AsF32 for SymmetricDMat2 {
+    type F32 = SymmetricMat2;
+    fn f32(&self) -> Self::F32 {
+        SymmetricMat2 {
+            m00: self.m00 as f32,
+            m01: self.m01 as f32,
+            m11: self.m11 as f32,
+        }
+    }
+}
+
+impl AsF32 for SymmetricMat2 {
+    type F32 = Self;
+    fn f32(&self) -> Self::F32 {
+        *self
+    }
+}
+
 impl AsF32 for DMat3 {
     type F32 = Mat3;
     fn f32(&self) -> Self::F32 {
@@ -153,6 +172,27 @@ impl AsF32 for DMat3 {
 }
 
 impl AsF32 for Mat3 {
+    type F32 = Self;
+    fn f32(&self) -> Self::F32 {
+        *self
+    }
+}
+
+impl AsF32 for SymmetricDMat3 {
+    type F32 = SymmetricMat3;
+    fn f32(&self) -> Self::F32 {
+        SymmetricMat3 {
+            m00: self.m00 as f32,
+            m01: self.m01 as f32,
+            m02: self.m02 as f32,
+            m11: self.m11 as f32,
+            m12: self.m12 as f32,
+            m22: self.m22 as f32,
+        }
+    }
+}
+
+impl AsF32 for SymmetricMat3 {
     type F32 = Self;
     fn f32(&self) -> Self::F32 {
         *self
@@ -311,6 +351,60 @@ impl MatExt for DMat2 {
     }
 }
 
+impl MatExt for SymmetricMat2 {
+    type Scalar = f32;
+
+    #[inline]
+    fn inverse_or_zero(self) -> Self {
+        if self.determinant() == 0.0 {
+            Self::ZERO
+        } else {
+            self.inverse()
+        }
+    }
+
+    #[inline]
+    fn is_isotropic(&self, epsilon: f32) -> bool {
+        // Extract diagonal elements.
+        let diag = Vec2::new(self.m00, self.m11);
+
+        // All diagonal elements must be approximately equal.
+        if abs_diff_ne!(diag.x, diag.y, epsilon = epsilon) {
+            return false;
+        }
+
+        // All off-diagonal elements must be approximately zero.
+        self.m01.abs() < epsilon
+    }
+}
+
+impl MatExt for SymmetricDMat2 {
+    type Scalar = f64;
+
+    #[inline]
+    fn inverse_or_zero(self) -> Self {
+        if self.determinant() == 0.0 {
+            Self::ZERO
+        } else {
+            self.inverse()
+        }
+    }
+
+    #[inline]
+    fn is_isotropic(&self, epsilon: f64) -> bool {
+        // Extract diagonal elements.
+        let diag = DVec2::new(self.m00, self.m11);
+
+        // All diagonal elements must be approximately equal.
+        if abs_diff_ne!(diag.x, diag.y, epsilon = epsilon) {
+            return false;
+        }
+
+        // All off-diagonal elements must be approximately zero.
+        self.m01.abs() < epsilon
+    }
+}
+
 impl MatExt for Mat3 {
     type Scalar = f32;
 
@@ -383,6 +477,70 @@ impl MatExt for DMat3 {
             self.z_axis.x,
             self.z_axis.y,
         ];
+
+        // All off-diagonal elements must be approximately zero.
+        off_diag.iter().all(|&x| x.abs() < epsilon)
+    }
+}
+
+impl MatExt for SymmetricMat3 {
+    type Scalar = f32;
+
+    #[inline]
+    fn inverse_or_zero(self) -> Self {
+        if self.determinant() == 0.0 {
+            Self::ZERO
+        } else {
+            self.inverse()
+        }
+    }
+
+    #[inline]
+    fn is_isotropic(&self, epsilon: f32) -> bool {
+        // Extract diagonal elements.
+        let diag = Vec3::new(self.m00, self.m11, self.m22);
+
+        // All diagonal elements must be approximately equal.
+        if abs_diff_ne!(diag.x, diag.y, epsilon = epsilon)
+            || abs_diff_ne!(diag.y, diag.z, epsilon = epsilon)
+        {
+            return false;
+        }
+
+        // Extract off-diagonal elements.
+        let off_diag = [self.m01, self.m02, self.m12];
+
+        // All off-diagonal elements must be approximately zero.
+        off_diag.iter().all(|&x| x.abs() < epsilon)
+    }
+}
+
+impl MatExt for SymmetricDMat3 {
+    type Scalar = f64;
+
+    #[inline]
+    fn inverse_or_zero(self) -> Self {
+        if self.determinant() == 0.0 {
+            Self::ZERO
+        } else {
+            self.inverse()
+        }
+    }
+
+    #[inline]
+    fn is_isotropic(&self, epsilon: f64) -> bool {
+        // Extract diagonal elements.
+        let diag = DVec3::new(self.m00, self.m11, self.m22);
+
+        // All diagonal elements must be approximately equal.
+        if abs_diff_ne!(diag.x, diag.y, epsilon = epsilon)
+            || abs_diff_ne!(diag.y, diag.z, epsilon = epsilon)
+        {
+            return false;
+        }
+
+        // Extract off-diagonal elements.
+        let off_diag = [self.m01, self.m02, self.m12];
 
         // All off-diagonal elements must be approximately zero.
         off_diag.iter().all(|&x| x.abs() < epsilon)

--- a/src/math/single.rs
+++ b/src/math/single.rs
@@ -1,5 +1,6 @@
 use super::AdjustPrecision;
 use bevy_math::*;
+use glam_matrix_extensions::*;
 
 /// The floating point number type used by Avian.
 pub type Scalar = f32;
@@ -33,6 +34,16 @@ pub type Matrix = Mat3;
 pub type Matrix2 = Mat2;
 /// The 3x3 matrix type used by Avian.
 pub type Matrix3 = Mat3;
+/// The dimension-specific matrix type used by Avian.
+#[cfg(feature = "2d")]
+pub type SymmetricMatrix = SymmetricMat2;
+/// The dimension-specific matrix type used by Avian.
+#[cfg(feature = "3d")]
+pub type SymmetricMatrix = SymmetricMat3;
+/// The 2x2 matrix type used by Avian.
+pub type SymmetricMatrix2 = SymmetricMat2;
+/// The 3x3 matrix type used by Avian.
+pub type SymmetricMatrix3 = SymmetricMat3;
 /// The quaternion type used by Avian.
 pub type Quaternion = Quat;
 
@@ -103,5 +114,33 @@ impl AdjustPrecision for DMat3 {
     type Adjusted = Matrix3;
     fn adjust_precision(&self) -> Self::Adjusted {
         self.as_mat3()
+    }
+}
+
+impl AdjustPrecision for SymmetricMat2 {
+    type Adjusted = SymmetricMatrix2;
+    fn adjust_precision(&self) -> Self::Adjusted {
+        *self
+    }
+}
+
+impl AdjustPrecision for SymmetricDMat2 {
+    type Adjusted = SymmetricMatrix2;
+    fn adjust_precision(&self) -> Self::Adjusted {
+        self.as_symmetric_mat2()
+    }
+}
+
+impl AdjustPrecision for SymmetricMat3 {
+    type Adjusted = SymmetricMatrix3;
+    fn adjust_precision(&self) -> Self::Adjusted {
+        *self
+    }
+}
+
+impl AdjustPrecision for SymmetricDMat3 {
+    type Adjusted = SymmetricMatrix3;
+    fn adjust_precision(&self) -> Self::Adjusted {
+        self.as_symmetric_mat3()
     }
 }


### PR DESCRIPTION
# Objective

Currently, we use a full `Mat3` for the 3D angular inertia tensor. However, angular inertia tensors should always be symmetric and positive semidefinite. By taking advantage of this symmetricity, we can represent angular inertia with 6 floats instead of 9. This reduces memory usage, improves the memory layout of the 3D `SolverBodyInertia` (from 44 bytes down to 32), and also optimizes many operations.

We need these symmetric matrices in both Avian and `bevy_heavy`, and possibly other crates, so I have extracted them into a more general `glam_matrix_extensions` crate. It not only includes `SymmetricMat3` and `SymmetricDMat3`, but also has symmetric 2x2, 4x4, 5x5, and 6x6 matrices, along with extension traits to add various commonly used helpers for Glam's matrices. The other matrices should be useful later on for the joint rework.

## Solution

Update `bevy_heavy` to use `SymmetricMat3` for the `AngularInertiaTensor`, and change Avian's APIs and internals to use `SymmetricMat3` for angular inertia.

---

## Migration Guide

TODO