### PR TITLE
Allow `Forces` to wake or not wake up bodies

### DIFF
--- a/src/dynamics/integrator/mod.rs
+++ b/src/dynamics/integrator/mod.rs
@@ -47,15 +47,6 @@ impl Plugin for IntegratorPlugin {
         // Add `VelocityIntegrationData` to all `SolverBody`s.
         app.register_required_components::<SolverBody, VelocityIntegrationData>();
 
-        // Remove `VelocityIntegrationData` when `SolverBody` is removed.
-        app.add_observer(
-            |trigger: Trigger<OnRemove, SolverBody>, mut commands: Commands| {
-                commands
-                    .entity(trigger.target())
-                    .try_remove::<VelocityIntegrationData>();
-            },
-        );
-
         app.init_resource::<Gravity>();
 
         app.configure_sets(

--- a/src/dynamics/mod.rs
+++ b/src/dynamics/mod.rs
@@ -70,7 +70,7 @@ pub mod solver;
 /// Re-exports common types related to the rigid body dynamics functionality.
 pub mod prelude {
     #[cfg(feature = "3d")]
-    pub use super::rigid_body::forces::ConstantLocalTorque;
+    pub use super::rigid_body::forces::{ConstantLocalAngularAcceleration, ConstantLocalTorque};
     pub(crate) use super::rigid_body::mass_properties::{ComputeMassProperties, MassProperties};
     pub use super::{
         ccd::{CcdPlugin, SpeculativeMargin, SweepMode, SweptCcd},
@@ -78,8 +78,8 @@ pub mod prelude {
         rigid_body::{
             forces::{
                 ConstantAngularAcceleration, ConstantForce, ConstantLinearAcceleration,
-                ConstantLocalAngularAcceleration, ConstantLocalForce,
-                ConstantLocalLinearAcceleration, ConstantTorque, ForcePlugin, ForceSet, Forces,
+                ConstantLocalForce, ConstantLocalLinearAcceleration, ConstantTorque, ForcePlugin,
+                ForceSet, Forces, RigidBodyForces,
             },
             mass_properties::{
                 MassPropertiesExt, MassPropertyHelper, MassPropertyPlugin,

--- a/src/dynamics/rigid_body/forces/mod.rs
+++ b/src/dynamics/rigid_body/forces/mod.rs
@@ -1,4 +1,4 @@
-//! External forces, torques, impulses, and acceleration for dynamic [rigid bodies](RigidBody).
+//! External forces, impulses, and acceleration for dynamic [rigid bodies](RigidBody).
 //!
 //! # Overview
 //!
@@ -22,7 +22,7 @@
 //!
 //! ## Constant Forces
 //!
-//! Constant forces and torques that persist across time steps can be applied using the following components:
+//! Constant forces and accelerations that persist across time steps can be applied using the following components:
 //!
 //! - [`ConstantForce`]: Applies a constant force in world space.
 //! - [`ConstantTorque`]: Applies a constant torque in world space.

--- a/src/dynamics/rigid_body/forces/mod.rs
+++ b/src/dynamics/rigid_body/forces/mod.rs
@@ -37,7 +37,10 @@
     doc = "- [`ConstantLocalTorque`]: Applies a constant torque in local space."
 )]
 //! - [`ConstantLocalLinearAcceleration`]: Applies a constant linear acceleration in local space.
-//! - [`ConstantLocalAngularAcceleration`]: Applies a constant angular acceleration in local space.
+#![cfg_attr(
+    feature = "3d",
+    doc = "- [`ConstantLocalAngularAcceleration`]: Applies a constant angular acceleration in local space."
+)]
 //!
 //! These components are useful for simulating continuously applied forces that are expected
 //! to remain the same across time steps, such as per-body gravity or force fields.
@@ -74,7 +77,7 @@
 //! ```
 #![cfg_attr(feature = "2d", doc = "# use avian2d::prelude::*;")]
 #![cfg_attr(feature = "3d", doc = "# use avian3d::prelude::*;")]
-#![cfg_attr(feature = "serialize", doc = "# use bevy::prelude::*;")]
+//! # use bevy::prelude::*;
 //! #
 //! # #[cfg(feature = "f32")]
 //! fn apply_forces(mut query: Query<Forces>) {
@@ -94,20 +97,38 @@
 //!
 //! The force is applied continuously during the physics step, and cleared automatically after the step is complete.
 //!
-//! [`Forces`] can also apply forces and impulses at a specific point in the world. If the point is not aligned
-//! with the [`GlobalCenterOfMass`], it will also apply a torque to the body.
+//! By default, applying forces to [sleeping](Sleeping) bodies will wake them up. If this is not desired,
+//! the [`non_waking`](ForcesItem::non_waking) method can be used to fetch a [`NonWakingForcesItem`]
+//! that allows applying forces to a body without waking it up.
 //!
 //! ```
 #![cfg_attr(feature = "2d", doc = "# use avian2d::{math::Vector, prelude::*};")]
 #![cfg_attr(feature = "3d", doc = "# use avian3d::{math::Vector, prelude::*};")]
-#![cfg_attr(feature = "serialize", doc = "# use bevy::prelude::*;")]
+//! # use bevy::prelude::*;
+//! #
+//! # fn apply_forces(mut query: Query<Forces>) {
+//! #     for mut forces in &mut query {
+//! #         let force = Vector::default();
+//! // Apply a force without waking up the body if it is sleeping.
+//! forces.non_waking().apply_force(force);
+//! #     }
+//! # }
+//! ```
+//!
+//! [`Forces`] can also apply forces and impulses at a specific point in the world. If the point is not aligned
+//! with the [`GlobalCenterOfMass`], it will apply a torque to the body.
+//!
+//! ```
+#![cfg_attr(feature = "2d", doc = "# use avian2d::{math::Vector, prelude::*};")]
+#![cfg_attr(feature = "3d", doc = "# use avian3d::{math::Vector, prelude::*};")]
+//! # use bevy::prelude::*;
 //! #
 //! # fn apply_impulses(mut query: Query<Forces>) {
 //! #     for mut forces in &mut query {
 //! #         let force = Vector::default();
 //! #         let point = Vector::default();
 //! // Apply an impulse at a specific point in the world.
-//! // Unlike forces, impulses are applied immediately to the velocity,
+//! // Unlike forces, impulses are applied immediately to the velocity.
 //! forces.apply_linear_impulse_at_point(force, point);
 //! #     }
 //! # }
@@ -180,7 +201,7 @@ mod query_data;
 mod tests;
 
 pub use plugin::{ForcePlugin, ForceSet};
-pub use query_data::Forces;
+pub use query_data::{Forces, ForcesItem, NonWakingForcesItem, RigidBodyForces};
 
 use crate::prelude::*;
 use bevy::prelude::*;
@@ -336,7 +357,10 @@ impl ConstantTorque {
     doc = "- [`ConstantLocalTorque`]: Applies a constant torque in local space."
 )]
 /// - [`ConstantLocalLinearAcceleration`]: Applies a constant linear acceleration in local space.
-/// - [`ConstantLocalAngularAcceleration`]: Applies a constant angular acceleration in local space.
+#[cfg_attr(
+    feature = "3d",
+    doc = "- [`ConstantLocalAngularAcceleration`]: Applies a constant angular acceleration in local space."
+)]
 #[derive(Component, Clone, Debug, Default, Deref, DerefMut, PartialEq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
@@ -369,8 +393,7 @@ impl ConstantLocalForce {
 /// # Example
 ///
 /// ```
-#[cfg_attr(feature = "2d", doc = "# use avian2d::prelude::*;")]
-#[cfg_attr(feature = "3d", doc = "# use avian3d::prelude::*;")]
+/// # use avian3d::prelude::*;
 /// # use bevy::prelude::*;
 /// #
 /// # fn setup(mut commands: Commands) {
@@ -378,8 +401,7 @@ impl ConstantLocalForce {
 ///     RigidBody::Dynamic,
 ///     Collider::capsule(0.5, 1.0),
 ///     // Apply a constant torque of 5 N⋅m in the positive Z direction in local space.
-#[cfg_attr(feature = "2d", doc = "    ConstantLocalTorque(5.0),")]
-#[cfg_attr(feature = "3d", doc = "    ConstantLocalTorque::new(0.0, 0.0, 5.0),")]
+///     ConstantLocalTorque::new(0.0, 0.0, 5.0),
 /// ));
 /// # }
 /// ```
@@ -499,7 +521,10 @@ impl ConstantLinearAcceleration {
 /// # Related Types
 ///
 /// - [`Forces`]: A helper [`QueryData`](bevy::ecs::query::QueryData) for applying forces, impulses, and acceleration to entities.
-/// - [`ConstantLocalAngularAcceleration`]: Applies a constant angular acceleration in local space.
+#[cfg_attr(
+    feature = "3d",
+    doc = "- [`ConstantLocalAngularAcceleration`]: Applies a constant angular acceleration in local space."
+)]
 /// - [`ConstantForce`]: Applies a constant force in world space.
 /// - [`ConstantTorque`]: Applies a constant torque in world space.
 /// - [`ConstantLinearAcceleration`]: Applies a constant linear acceleration in world space.
@@ -559,7 +584,10 @@ impl ConstantAngularAcceleration {
     feature = "3d",
     doc = "- [`ConstantLocalTorque`]: Applies a constant torque in local space."
 )]
-/// - [`ConstantLocalAngularAcceleration`]: Applies a constant angular acceleration in local space.
+#[cfg_attr(
+    feature = "3d",
+    doc = "- [`ConstantLocalAngularAcceleration`]: Applies a constant angular acceleration in local space."
+)]
 #[derive(Component, Clone, Debug, Default, Deref, DerefMut, PartialEq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
@@ -592,8 +620,7 @@ impl ConstantLocalLinearAcceleration {
 /// # Example
 ///
 /// ```
-#[cfg_attr(feature = "2d", doc = "# use avian2d::prelude::*;")]
-#[cfg_attr(feature = "3d", doc = "# use avian3d::prelude::*;")]
+/// # use avian3d::prelude::*;
 /// # use bevy::prelude::*;
 /// #
 /// # fn setup(mut commands: Commands) {
@@ -601,11 +628,7 @@ impl ConstantLocalLinearAcceleration {
 ///     RigidBody::Dynamic,
 ///     Collider::capsule(0.5, 1.0),
 ///     // Apply a constant angular acceleration of 1.0 rad/s² in the positive Z direction in local space.
-#[cfg_attr(feature = "2d", doc = "    ConstantLocalAngularAcceleration(1.0),")]
-#[cfg_attr(
-    feature = "3d",
-    doc = "    ConstantLocalAngularAcceleration::new(0.0, 0.0, 1.0),"
-)]
+///     ConstantLocalAngularAcceleration::new(0.0, 0.0, 1.0),
 /// ));
 /// # }
 /// ```
@@ -615,15 +638,13 @@ impl ConstantLocalLinearAcceleration {
 /// - [`Forces`]: A helper [`QueryData`](bevy::ecs::query::QueryData) for applying forces, impulses, and acceleration to entities.
 /// - [`ConstantAngularAcceleration`]: Applies a constant angular acceleration in world space.
 /// - [`ConstantLocalForce`]: Applies a constant force in local space.
-#[cfg_attr(
-    feature = "3d",
-    doc = "- [`ConstantLocalTorque`]: Applies a constant torque in local space."
-)]
+/// - [`ConstantLocalTorque`]: Applies a constant torque in local space.
 /// - [`ConstantLocalLinearAcceleration`]: Applies a constant linear acceleration in local space.
 #[derive(Component, Clone, Debug, Default, Deref, DerefMut, PartialEq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component, Debug, Default, PartialEq)]
+#[cfg(feature = "3d")]
 pub struct ConstantLocalAngularAcceleration(pub AngularVector);
 
 #[cfg(feature = "3d")]

--- a/src/dynamics/rigid_body/forces/plugin.rs
+++ b/src/dynamics/rigid_body/forces/plugin.rs
@@ -89,13 +89,13 @@ pub enum ForceSet {
     /// Adds [`ConstantForce`], [`ConstantTorque`], [`ConstantLinearAcceleration`], and [`ConstantAngularAcceleration`]
     #[cfg_attr(
         feature = "2d",
-        doc = "to [`VelocityIntegrationData`] and [`ConstantLocalForce`], [`ConstantLocalLinearAcceleration`],"
+        doc = "to [`VelocityIntegrationData`], and [`ConstantLocalForce`] and [`ConstantLocalLinearAcceleration`]"
     )]
     #[cfg_attr(
         feature = "3d",
-        doc = "to [`VelocityIntegrationData`] and [`ConstantLocalForce`], [`ConstantLocalTorque`], [`ConstantLocalLinearAcceleration`],"
+        doc = "to [`VelocityIntegrationData`], and [`ConstantLocalForce`], [`ConstantLocalTorque`], [`ConstantLocalLinearAcceleration`], and [`ConstantLocalAngularAcceleration`]"
     )]
-    /// and [`ConstantLocalAngularAcceleration`] to [`AccumulatedLocalAcceleration`].
+    /// to [`AccumulatedLocalAcceleration`].
     ApplyConstantForces,
     /// Applies [`AccumulatedLocalAcceleration`] to the linear and angular velocities of bodies.
     ApplyLocalAcceleration,

--- a/src/dynamics/rigid_body/forces/plugin.rs
+++ b/src/dynamics/rigid_body/forces/plugin.rs
@@ -27,11 +27,10 @@ impl Plugin for ForcePlugin {
             ConstantAngularAcceleration,
             ConstantLocalForce,
             ConstantLocalLinearAcceleration,
-            ConstantLocalAngularAcceleration,
             AccumulatedLocalAcceleration,
         )>();
         #[cfg(feature = "3d")]
-        app.register_type::<ConstantLocalTorque>();
+        app.register_type::<(ConstantLocalTorque, ConstantLocalAngularAcceleration)>();
 
         // Set up system sets.
         app.configure_sets(

--- a/src/dynamics/rigid_body/forces/query_data.rs
+++ b/src/dynamics/rigid_body/forces/query_data.rs
@@ -1,9 +1,9 @@
 use crate::{
-    dynamics::{integrator::VelocityIntegrationData, solver::solver_body::SolverBodyInertia},
+    dynamics::integrator::VelocityIntegrationData,
     prelude::{mass_properties::components::GlobalCenterOfMass, *},
 };
 use bevy::ecs::{
-    query::QueryData,
+    query::{Has, QueryData},
     system::lifetimeless::{Read, Write},
 };
 
@@ -23,7 +23,7 @@ use super::AccumulatedLocalAcceleration;
 /// ```
 #[cfg_attr(feature = "2d", doc = "# use avian2d::prelude::*;")]
 #[cfg_attr(feature = "3d", doc = "# use avian3d::prelude::*;")]
-#[cfg_attr(feature = "serialize", doc = "# use bevy::prelude::*;")]
+/// # use bevy::prelude::*;
 /// #
 /// # #[cfg(feature = "f32")]
 /// fn apply_forces(mut query: Query<Forces>) {
@@ -43,20 +43,38 @@ use super::AccumulatedLocalAcceleration;
 ///
 /// The force is applied continuously during the physics step, and cleared automatically after the step is complete.
 ///
-/// [`Forces`] can also apply forces and impulses at a specific point in the world. If the point is not aligned
-/// with the [`GlobalCenterOfMass`], it will also apply a torque to the body.
+/// By default, applying forces to [sleeping](Sleeping) bodies will wake them up. If this is not desired,
+/// the [`non_waking`](ForcesItem::non_waking) method can be used to fetch a [`NonWakingForcesItem`]
+/// that allows applying forces to a body without waking it up.
 ///
 /// ```
 #[cfg_attr(feature = "2d", doc = "# use avian2d::{math::Vector, prelude::*};")]
 #[cfg_attr(feature = "3d", doc = "# use avian3d::{math::Vector, prelude::*};")]
-#[cfg_attr(feature = "serialize", doc = "# use bevy::prelude::*;")]
+/// # use bevy::prelude::*;
+/// #
+/// # fn apply_impulses(mut query: Query<Forces>) {
+/// #     for mut forces in &mut query {
+/// #         let force = Vector::default();
+/// // Apply a force without waking up the body if it is sleeping.
+/// forces.non_waking().apply_force(force);
+/// #     }
+/// # }
+/// ```
+///
+/// [`Forces`] can also apply forces and impulses at a specific point in the world. If the point is not aligned
+/// with the [`GlobalCenterOfMass`], it will apply a torque to the body.
+///
+/// ```
+#[cfg_attr(feature = "2d", doc = "# use avian2d::{math::Vector, prelude::*};")]
+#[cfg_attr(feature = "3d", doc = "# use avian3d::{math::Vector, prelude::*};")]
+/// # use bevy::prelude::*;
 /// #
 /// # fn apply_impulses(mut query: Query<Forces>) {
 /// #     for mut forces in &mut query {
 /// #         let force = Vector::default();
 /// #         let point = Vector::default();
 /// // Apply an impulse at a specific point in the world.
-/// // Unlike forces, impulses are applied immediately to the velocity,
+/// // Unlike forces, impulses are applied immediately to the velocity.
 /// forces.apply_linear_impulse_at_point(force, point);
 /// #     }
 /// # }
@@ -96,18 +114,79 @@ pub struct Forces {
     mass: Read<ComputedMass>,
     angular_inertia: Read<ComputedAngularInertia>,
     global_center_of_mass: Read<GlobalCenterOfMass>,
-    inertia: Read<SolverBodyInertia>,
+    locked_axes: Option<Read<LockedAxes>>,
     integration: Write<VelocityIntegrationData>,
     accumulated_local_acceleration: Write<AccumulatedLocalAcceleration>,
+    time_sleeping: Write<TimeSleeping>,
+    is_sleeping: Has<Sleeping>,
 }
 
+/// A [`ForcesItem`] that does not wake up the body when applying forces, torques, impulses, or accelerations.
+/// Returned by [`ForcesItem::non_waking`].
+///
+/// See the documentation of [`Forces`] for more information on how to apply forces in Avian.
+pub struct NonWakingForcesItem<'a>(pub ForcesItem<'a>);
+
 impl ForcesItem<'_> {
+    /// Reborrows `self` as a new instance of [`ForcesItem`].
+    pub fn reborrow(&mut self) -> ForcesItem<'_> {
+        ForcesItem {
+            rotation: self.rotation,
+            linear_velocity: self.linear_velocity.reborrow(),
+            angular_velocity: self.angular_velocity.reborrow(),
+            mass: self.mass,
+            angular_inertia: self.angular_inertia,
+            global_center_of_mass: self.global_center_of_mass,
+            locked_axes: self.locked_axes,
+            integration: self.integration.reborrow(),
+            accumulated_local_acceleration: self.accumulated_local_acceleration.reborrow(),
+            time_sleeping: self.time_sleeping.reborrow(),
+            is_sleeping: self.is_sleeping,
+        }
+    }
+
+    /// Returns a [`NonWakingForcesItem`] that allows applying forces, impulses, and accelerations
+    /// without waking up the body if it is sleeping.
+    #[inline]
+    #[must_use]
+    pub fn non_waking(&mut self) -> NonWakingForcesItem<'_> {
+        NonWakingForcesItem(self.reborrow())
+    }
+}
+
+impl<'a> NonWakingForcesItem<'a> {
+    /// Returns a [`ForcesItem`] that will wake up the body when applying forces, impulses, or accelerations.
+    #[inline]
+    #[must_use]
+    pub fn waking(self) -> ForcesItem<'a> {
+        self.0
+    }
+}
+
+impl RigidBodyForces for ForcesItem<'_> {}
+impl RigidBodyForces for NonWakingForcesItem<'_> {}
+
+/// A trait for applying forces, torques, impulses, and accelerations to a dynamic [rigid body](RigidBody).
+///
+/// This is implemented as a shared interface for the [`ForcesItem`] and [`NonWakingForcesItem`]
+/// returned by [`Forces`].
+///
+/// See the documentation of [`Forces`] for more information on how to apply forces in Avian.
+#[expect(
+    private_bounds,
+    reason = "The `data` method should not be publicly accessible."
+)]
+pub trait RigidBodyForces: RigidBodyForcesInternal {
     /// Applies a force at the center of mass in world space. The unit is typically N or kg⋅m/s².
     ///
     /// The force is applied continuously over the physics step and cleared afterwards.
+    ///
+    /// By default, a non-zero force will wake up the body if it is sleeping. This can be prevented
+    /// by first calling [`ForcesItem::non_waking`] to get a [`NonWakingForcesItem`].
     #[inline]
-    pub fn apply_force(&mut self, force: Vector) {
-        self.integration.linear_increment += self.mass.inverse() * force;
+    fn apply_force(&mut self, force: Vector) {
+        let force = self.inverse_mass() * force;
+        self.apply_linear_acceleration(force);
     }
 
     /// Applies a force at the given point in world space. The unit is typically N or kg⋅m/s².
@@ -115,48 +194,70 @@ impl ForcesItem<'_> {
     /// If the point is not at the center of mass, the force will also generate a torque.
     ///
     /// The force is applied continuously over the physics step and cleared afterwards.
+    ///
+    /// By default, a non-zero force will wake up the body if it is sleeping. This can be prevented
+    /// by first calling [`ForcesItem::non_waking`] to get a [`NonWakingForcesItem`].
     #[inline]
-    pub fn apply_force_at_point(&mut self, force: Vector, world_point: Vector) {
+    fn apply_force_at_point(&mut self, force: Vector, world_point: Vector) {
         // Note: This does not consider the rotation of the body during substeps,
         //       so the torque may not be accurate if the body is rotating quickly.
         self.apply_force(force);
-        self.apply_torque(cross(world_point - self.global_center_of_mass.get(), force));
+        self.apply_torque(cross(world_point - self.global_center_of_mass(), force));
     }
 
     /// Applies a force at the center of mass in local space. The unit is typically N or kg⋅m/s².
     ///
     /// The force is applied continuously over the physics step and cleared afterwards.
+    ///
+    /// By default, a non-zero force will wake up the body if it is sleeping. This can be prevented
+    /// by first calling [`ForcesItem::non_waking`] to get a [`NonWakingForcesItem`].
     #[inline]
-    pub fn apply_local_force(&mut self, force: Vector) {
-        self.accumulated_local_acceleration.linear += self.mass.inverse() * force;
+    fn apply_local_force(&mut self, force: Vector) {
+        let acceleration = self.inverse_mass() * force;
+        self.apply_local_linear_acceleration(acceleration);
     }
 
     /// Applies a torque in world space. The unit is typically N⋅m or kg⋅m²/s².
     ///
     /// The torque is applied continuously over the physics step and cleared afterwards.
+    ///
+    /// By default, a non-zero torque will wake up the body if it is sleeping. This can be prevented
+    /// by first calling [`ForcesItem::non_waking`] to get a [`NonWakingForcesItem`].
     #[inline]
-    pub fn apply_torque(&mut self, torque: AngularVector) {
-        self.integration.angular_increment += self.inertia.effective_inv_angular_inertia() * torque;
+    fn apply_torque(&mut self, torque: AngularVector) {
+        let acceleration = self.global_inverse_angular_inertia() * torque;
+        self.apply_angular_acceleration(acceleration);
     }
 
     /// Applies a torque in local space. The unit is typically N⋅m or kg⋅m²/s².
     ///
     /// The torque is applied continuously over the physics step and cleared afterwards.
     ///
-    /// **Note:** This does not consider the rotation of the body during substeps,
-    ///           so the torque may not be accurate if the body is rotating quickly.
+    /// By default, a non-zero torque will wake up the body if it is sleeping. This can be prevented
+    /// by first calling [`ForcesItem::non_waking`] to get a [`NonWakingForcesItem`].
     #[cfg(feature = "3d")]
     #[inline]
-    pub fn apply_local_torque(&mut self, torque: AngularVector) {
-        self.accumulated_local_acceleration.angular += self.angular_inertia.inverse() * torque;
+    fn apply_local_torque(&mut self, torque: AngularVector) {
+        let acceleration = self.inverse_angular_inertia() * torque;
+        self.apply_local_angular_acceleration(acceleration);
     }
 
     /// Applies a linear impulse at the center of mass in world space. The unit is typically N⋅s or kg⋅m/s.
     ///
     /// The impulse modifies the [`LinearVelocity`] of the body immediately.
+    ///
+    /// By default, a non-zero impulse will wake up the body if it is sleeping. This can be prevented
+    /// by first calling [`ForcesItem::non_waking`] to get a [`NonWakingForcesItem`].
     #[inline]
-    pub fn apply_linear_impulse(&mut self, impulse: Vector) {
-        self.linear_velocity.0 += self.inertia.effective_inv_mass() * impulse;
+    fn apply_linear_impulse(&mut self, impulse: Vector) {
+        let effective_inverse_mass = self
+            .locked_axes()
+            .apply_to_vec(Vector::splat(self.inverse_mass()));
+        let delta_vel = effective_inverse_mass * impulse;
+
+        if impulse != Vector::ZERO && self.try_wake_up() {
+            *self.linear_velocity_mut() += delta_vel;
+        }
     }
 
     /// Applies a linear impulse at the given point in world space. The unit is typically N⋅s or kg⋅m/s.
@@ -164,73 +265,111 @@ impl ForcesItem<'_> {
     /// If the point is not at the center of mass, the impulse will also generate an angular impulse.
     ///
     /// The impulse modifies the [`LinearVelocity`] and [`AngularVelocity`] of the body immediately.
+    ///
+    /// By default, a non-zero impulse will wake up the body if it is sleeping. This can be prevented
+    /// by first calling [`ForcesItem::non_waking`] to get a [`NonWakingForcesItem`].
     #[inline]
-    pub fn apply_linear_impulse_at_point(&mut self, impulse: Vector, world_point: Vector) {
+    fn apply_linear_impulse_at_point(&mut self, impulse: Vector, world_point: Vector) {
         self.apply_linear_impulse(impulse);
-        self.apply_angular_impulse(cross(
-            world_point - self.global_center_of_mass.get(),
-            impulse,
-        ));
+        self.apply_angular_impulse(cross(world_point - self.global_center_of_mass(), impulse));
     }
 
     /// Applies a linear impulse in local space. The unit is typically N⋅s or kg⋅m/s.
     ///
     /// The impulse modifies the [`LinearVelocity`] of the body immediately.
+    ///
+    /// By default, a non-zero impulse will wake up the body if it is sleeping. This can be prevented
+    /// by first calling [`ForcesItem::non_waking`] to get a [`NonWakingForcesItem`].
     #[inline]
-    pub fn apply_local_linear_impulse(&mut self, impulse: Vector) {
-        let world_impulse = self.rotation * impulse;
+    fn apply_local_linear_impulse(&mut self, impulse: Vector) {
+        let world_impulse = self.rotation() * impulse;
         self.apply_linear_impulse(world_impulse);
     }
 
     /// Applies an angular impulse in world space. The unit is typically N⋅m⋅s or kg⋅m²/s.
     ///
     /// The impulse modifies the [`AngularVelocity`] of the body immediately.
+    ///
+    /// By default, a non-zero impulse will wake up the body if it is sleeping. This can be prevented
+    /// by first calling [`ForcesItem::non_waking`] to get a [`NonWakingForcesItem`].
     #[inline]
-    pub fn apply_angular_impulse(&mut self, impulse: AngularVector) {
-        self.angular_velocity.0 += self.inertia.effective_inv_angular_inertia() * impulse;
+    fn apply_angular_impulse(&mut self, impulse: AngularVector) {
+        let effective_inverse_angular_inertia = self
+            .locked_axes()
+            .apply_to_angular_inertia(self.global_inverse_angular_inertia());
+        let delta_vel = effective_inverse_angular_inertia * impulse;
+
+        if impulse != AngularVector::ZERO && self.try_wake_up() {
+            *self.angular_velocity_mut() += delta_vel;
+        }
     }
 
     /// Applies an angular impulse in local space. The unit is typically N⋅m⋅s or kg⋅m²/s.
     ///
     /// The impulse modifies the [`AngularVelocity`] of the body immediately.
+    ///
+    /// By default, a non-zero impulse will wake up the body if it is sleeping. This can be prevented
+    /// by first calling [`ForcesItem::non_waking`] to get a [`NonWakingForcesItem`].
     #[cfg(feature = "3d")]
     #[inline]
-    pub fn apply_local_angular_impulse(&mut self, impulse: AngularVector) {
-        let world_impulse = self.rotation * impulse;
+    fn apply_local_angular_impulse(&mut self, impulse: AngularVector) {
+        let world_impulse = self.rotation() * impulse;
         self.apply_angular_impulse(world_impulse);
     }
 
     /// Applies a linear acceleration, ignoring mass. The unit is typically m/s².
     ///
     /// The acceleration is applied continuously over the physics step and cleared afterwards.
+    ///
+    /// By default, a non-zero acceleration will wake up the body if it is sleeping. This can be prevented
+    /// by first calling [`ForcesItem::non_waking`] to get a [`NonWakingForcesItem`].
     #[inline]
-    pub fn apply_linear_acceleration(&mut self, acceleration: Vector) {
-        self.integration.apply_linear_acceleration(acceleration);
+    fn apply_linear_acceleration(&mut self, acceleration: Vector) {
+        if acceleration != Vector::ZERO && self.try_wake_up() {
+            self.integration_data_mut()
+                .apply_linear_acceleration(acceleration);
+        }
     }
 
     /// Applies a linear acceleration in local space, ignoring mass. The unit is typically m/s².
     ///
     /// The acceleration is applied continuously over the physics step and cleared afterwards.
+    ///
+    /// By default, a non-zero acceleration will wake up the body if it is sleeping. This can be prevented
+    /// by first calling [`ForcesItem::non_waking`] to get a [`NonWakingForcesItem`].
     #[inline]
-    pub fn apply_local_linear_acceleration(&mut self, acceleration: Vector) {
-        self.accumulated_local_acceleration.linear += acceleration;
+    fn apply_local_linear_acceleration(&mut self, acceleration: Vector) {
+        if acceleration != Vector::ZERO && self.try_wake_up() {
+            self.accumulated_local_acceleration_mut().linear += acceleration;
+        }
     }
 
     /// Applies an angular acceleration, ignoring angular inertia. The unit is rad/s².
     ///
     /// The acceleration is applied continuously over the physics step and cleared afterwards.
+    ///
+    /// By default, a non-zero acceleration will wake up the body if it is sleeping. This can be prevented
+    /// by first calling [`ForcesItem::non_waking`] to get a [`NonWakingForcesItem`].
     #[inline]
-    pub fn apply_angular_acceleration(&mut self, acceleration: AngularVector) {
-        self.integration.apply_angular_acceleration(acceleration);
+    fn apply_angular_acceleration(&mut self, acceleration: AngularVector) {
+        if acceleration != AngularVector::ZERO && self.try_wake_up() {
+            self.integration_data_mut()
+                .apply_angular_acceleration(acceleration);
+        }
     }
 
     /// Applies an angular acceleration in local space, ignoring angular inertia. The unit is rad/s².
     ///
     /// The acceleration is applied continuously over the physics step and cleared afterwards.
+    ///
+    /// By default, a non-zero acceleration will wake up the body if it is sleeping. This can be prevented
+    /// by first calling [`ForcesItem::non_waking`] to get a [`NonWakingForcesItem`].
     #[cfg(feature = "3d")]
     #[inline]
-    pub fn apply_local_angular_acceleration(&mut self, acceleration: AngularVector) {
-        self.accumulated_local_acceleration.angular += acceleration;
+    fn apply_local_angular_acceleration(&mut self, acceleration: AngularVector) {
+        if acceleration != AngularVector::ZERO && self.try_wake_up() {
+            self.accumulated_local_acceleration_mut().angular += acceleration;
+        }
     }
 
     /// Returns the linear acceleration that the body has accumulated
@@ -240,16 +379,14 @@ impl ForcesItem<'_> {
     /// This does not include gravity, contact forces, or joint forces.
     /// Only forces and accelerations applied through [`Forces`] are included.
     #[inline]
-    pub fn accumulated_linear_acceleration(&self) -> Vector {
+    fn accumulated_linear_acceleration(&self) -> Vector {
         // The linear increment is treated as linear acceleration until the integration step.
-        let world_linear_acceleration = self.integration.linear_increment;
-        let local_linear_acceleration = self.accumulated_local_acceleration.linear;
+        let world_linear_acceleration = self.integration_data().linear_increment;
+        let local_linear_acceleration = self.accumulated_local_acceleration().linear;
 
         // Return the total world-space linear acceleration.
-        self.inertia
-            .flags()
-            .locked_axes()
-            .apply_to_vec(world_linear_acceleration + self.rotation * local_linear_acceleration)
+        self.locked_axes()
+            .apply_to_vec(world_linear_acceleration + self.rotation() * local_linear_acceleration)
     }
 
     /// Returns the angular acceleration that the body has accumulated
@@ -260,12 +397,10 @@ impl ForcesItem<'_> {
     /// Only torques and accelerations applied through [`Forces`] are included.
     #[cfg(feature = "2d")]
     #[inline]
-    pub fn accumulated_angular_acceleration(&self) -> AngularVector {
+    fn accumulated_angular_acceleration(&self) -> AngularVector {
         // The angular increment is treated as angular acceleration until the integration step.
-        self.inertia
-            .flags()
-            .locked_axes()
-            .apply_to_angular_velocity(self.integration.angular_increment)
+        self.locked_axes()
+            .apply_to_angular_velocity(self.integration_data().angular_increment)
     }
 
     /// Returns the angular acceleration that the body has accumulated
@@ -276,58 +411,213 @@ impl ForcesItem<'_> {
     /// Only torques and accelerations applied through [`Forces`] are included.
     #[cfg(feature = "3d")]
     #[inline]
-    pub fn accumulated_angular_acceleration(&self) -> AngularVector {
+    fn accumulated_angular_acceleration(&self) -> AngularVector {
         // The angular increment is treated as angular acceleration until the integration step.
-        let world_angular_acceleration = self.integration.angular_increment;
-        let local_angular_acceleration = self.accumulated_local_acceleration.angular;
+        let world_angular_acceleration = self.integration_data().angular_increment;
+        let local_angular_acceleration = self.accumulated_local_acceleration().angular;
 
         // Return the total world-space angular acceleration.
-        self.inertia
-            .flags()
-            .locked_axes()
-            .apply_to_angular_velocity(
-                world_angular_acceleration + self.rotation * local_angular_acceleration,
-            )
+        self.locked_axes().apply_to_angular_velocity(
+            world_angular_acceleration + self.rotation() * local_angular_acceleration,
+        )
     }
 
     /// Resets the accumulated linear acceleration to zero.
     #[inline]
-    pub fn reset_accumulated_linear_acceleration(&mut self) {
-        self.integration.linear_increment = Vector::ZERO;
-        self.accumulated_local_acceleration.linear = Vector::ZERO;
+    fn reset_accumulated_linear_acceleration(&mut self) {
+        self.integration_data_mut().linear_increment = Vector::ZERO;
+        self.accumulated_local_acceleration_mut().linear = Vector::ZERO;
     }
 
     /// Resets the accumulated angular acceleration to zero.
     #[inline]
-    pub fn reset_accumulated_angular_acceleration(&mut self) {
-        self.integration.angular_increment = AngularVector::ZERO;
+    fn reset_accumulated_angular_acceleration(&mut self) {
+        self.integration_data_mut().angular_increment = AngularVector::ZERO;
         #[cfg(feature = "3d")]
         {
-            self.accumulated_local_acceleration.angular = AngularVector::ZERO;
+            self.accumulated_local_acceleration_mut().angular = AngularVector::ZERO;
         }
     }
 
     /// Returns the [`LinearVelocity`] of the body in world space.
     #[inline]
-    pub fn linear_velocity(&self) -> Vector {
-        self.linear_velocity.0
+    fn linear_velocity(&self) -> Vector {
+        self.lin_vel()
     }
 
     /// Returns a mutable reference to the [`LinearVelocity`] of the body in world space.
     #[inline]
-    pub fn linear_velocity_mut(&mut self) -> &mut Vector {
-        &mut self.linear_velocity.0
+    fn linear_velocity_mut(&mut self) -> &mut Vector {
+        self.lin_vel_mut()
     }
 
     /// Returns the [`AngularVelocity`] of the body in world space.
     #[inline]
-    pub fn angular_velocity(&self) -> AngularVector {
-        self.angular_velocity.0
+    fn angular_velocity(&self) -> AngularVector {
+        self.ang_vel()
     }
 
     /// Returns a mutable reference to the [`AngularVelocity`] of the body in world space.
     #[inline]
-    pub fn angular_velocity_mut(&mut self) -> &mut AngularVector {
+    fn angular_velocity_mut(&mut self) -> &mut AngularVector {
+        self.ang_vel_mut()
+    }
+}
+
+/// A trait to provide internal getters and helpers for [`RigidBodyForces`].
+trait RigidBodyForcesInternal {
+    fn rotation(&self) -> &Rotation;
+    fn lin_vel(&self) -> Vector;
+    fn lin_vel_mut(&mut self) -> &mut Vector;
+    fn ang_vel(&self) -> AngularVector;
+    fn ang_vel_mut(&mut self) -> &mut AngularVector;
+    fn inverse_mass(&self) -> Scalar;
+    #[cfg(feature = "3d")]
+    fn inverse_angular_inertia(&self) -> SymmetricTensor;
+    fn global_inverse_angular_inertia(&self) -> SymmetricTensor;
+    fn global_center_of_mass(&self) -> Vector;
+    fn locked_axes(&self) -> LockedAxes;
+    fn integration_data(&self) -> &VelocityIntegrationData;
+    fn integration_data_mut(&mut self) -> &mut VelocityIntegrationData;
+    fn accumulated_local_acceleration(&self) -> &AccumulatedLocalAcceleration;
+    fn accumulated_local_acceleration_mut(&mut self) -> &mut AccumulatedLocalAcceleration;
+    fn try_wake_up(&mut self) -> bool;
+}
+
+impl RigidBodyForcesInternal for ForcesItem<'_> {
+    #[inline]
+    fn rotation(&self) -> &Rotation {
+        &self.rotation
+    }
+    #[inline]
+    fn lin_vel(&self) -> Vector {
+        self.linear_velocity.0
+    }
+    #[inline]
+    fn lin_vel_mut(&mut self) -> &mut Vector {
+        &mut self.linear_velocity.0
+    }
+    #[inline]
+    fn ang_vel(&self) -> AngularVector {
+        self.angular_velocity.0
+    }
+    #[inline]
+    fn ang_vel_mut(&mut self) -> &mut AngularVector {
         &mut self.angular_velocity.0
+    }
+    #[inline]
+    fn inverse_mass(&self) -> Scalar {
+        self.mass.inverse()
+    }
+    #[inline]
+    #[cfg(feature = "3d")]
+    fn inverse_angular_inertia(&self) -> SymmetricTensor {
+        self.angular_inertia.inverse()
+    }
+    #[inline]
+    fn global_inverse_angular_inertia(&self) -> SymmetricTensor {
+        #[cfg(feature = "2d")]
+        let global_angular_inertia = *self.angular_inertia;
+        #[cfg(feature = "3d")]
+        let global_angular_inertia = self.angular_inertia.rotated(self.rotation.0);
+        self.locked_axes()
+            .apply_to_angular_inertia(global_angular_inertia)
+            .inverse()
+    }
+    #[inline]
+    fn global_center_of_mass(&self) -> Vector {
+        self.global_center_of_mass.get()
+    }
+    #[inline]
+    fn locked_axes(&self) -> LockedAxes {
+        self.locked_axes.copied().unwrap_or_default()
+    }
+    #[inline]
+    fn integration_data(&self) -> &VelocityIntegrationData {
+        &self.integration
+    }
+    #[inline]
+    fn integration_data_mut(&mut self) -> &mut VelocityIntegrationData {
+        &mut self.integration
+    }
+    #[inline]
+    fn accumulated_local_acceleration(&self) -> &AccumulatedLocalAcceleration {
+        &self.accumulated_local_acceleration
+    }
+    #[inline]
+    fn accumulated_local_acceleration_mut(&mut self) -> &mut AccumulatedLocalAcceleration {
+        &mut self.accumulated_local_acceleration
+    }
+    #[inline]
+    fn try_wake_up(&mut self) -> bool {
+        // Wake up the body. Return `true` to indicate that the body is awake.
+        self.time_sleeping.reset();
+        true
+    }
+}
+
+impl RigidBodyForcesInternal for NonWakingForcesItem<'_> {
+    #[inline]
+    fn rotation(&self) -> &Rotation {
+        self.0.rotation()
+    }
+    #[inline]
+    fn lin_vel(&self) -> Vector {
+        self.0.lin_vel()
+    }
+    #[inline]
+    fn lin_vel_mut(&mut self) -> &mut Vector {
+        self.0.lin_vel_mut()
+    }
+    #[inline]
+    fn ang_vel(&self) -> AngularVector {
+        self.0.ang_vel()
+    }
+    #[inline]
+    fn ang_vel_mut(&mut self) -> &mut AngularVector {
+        self.0.ang_vel_mut()
+    }
+    #[inline]
+    fn inverse_mass(&self) -> Scalar {
+        self.0.inverse_mass()
+    }
+    #[inline]
+    #[cfg(feature = "3d")]
+    fn inverse_angular_inertia(&self) -> SymmetricTensor {
+        self.0.inverse_angular_inertia()
+    }
+    #[inline]
+    fn global_inverse_angular_inertia(&self) -> SymmetricTensor {
+        self.0.global_inverse_angular_inertia()
+    }
+    #[inline]
+    fn global_center_of_mass(&self) -> Vector {
+        self.0.global_center_of_mass()
+    }
+    #[inline]
+    fn locked_axes(&self) -> LockedAxes {
+        self.0.locked_axes()
+    }
+    #[inline]
+    fn integration_data(&self) -> &VelocityIntegrationData {
+        self.0.integration_data()
+    }
+    #[inline]
+    fn integration_data_mut(&mut self) -> &mut VelocityIntegrationData {
+        self.0.integration_data_mut()
+    }
+    #[inline]
+    fn accumulated_local_acceleration(&self) -> &AccumulatedLocalAcceleration {
+        self.0.accumulated_local_acceleration()
+    }
+    #[inline]
+    fn accumulated_local_acceleration_mut(&mut self) -> &mut AccumulatedLocalAcceleration {
+        self.0.accumulated_local_acceleration_mut()
+    }
+    #[inline]
+    fn try_wake_up(&mut self) -> bool {
+        // Don't wake up the body.
+        // Return `true` if the body is already awake and forces should be applied.
+        !self.0.is_sleeping
     }
 }

--- a/src/dynamics/rigid_body/forces/query_data.rs
+++ b/src/dynamics/rigid_body/forces/query_data.rs
@@ -129,6 +129,8 @@ pub struct NonWakingForcesItem<'a>(pub ForcesItem<'a>);
 
 impl ForcesItem<'_> {
     /// Reborrows `self` as a new instance of [`ForcesItem`].
+    #[inline]
+    #[must_use]
     pub fn reborrow(&mut self) -> ForcesItem<'_> {
         ForcesItem {
             rotation: self.rotation,

--- a/src/dynamics/rigid_body/forces/query_data.rs
+++ b/src/dynamics/rigid_body/forces/query_data.rs
@@ -9,7 +9,7 @@ use bevy::ecs::{
 
 use super::AccumulatedLocalAcceleration;
 
-/// A helper [`QueryData`] for applying forces, torques, impulses, and accelerations to dynamic [rigid bodies](RigidBody).
+/// A helper [`QueryData`] for applying forces, impulses, and accelerations to dynamic [rigid bodies](RigidBody).
 ///
 /// For constant forces that persist across time steps, consider using components like [`ConstantForce`] instead.
 ///
@@ -166,7 +166,7 @@ impl<'a> NonWakingForcesItem<'a> {
 impl RigidBodyForces for ForcesItem<'_> {}
 impl RigidBodyForces for NonWakingForcesItem<'_> {}
 
-/// A trait for applying forces, torques, impulses, and accelerations to a dynamic [rigid body](RigidBody).
+/// A trait for applying forces, impulses, and accelerations to a dynamic [rigid body](RigidBody).
 ///
 /// This is implemented as a shared interface for the [`ForcesItem`] and [`NonWakingForcesItem`]
 /// returned by [`Forces`].

--- a/src/dynamics/rigid_body/forces/query_data.rs
+++ b/src/dynamics/rigid_body/forces/query_data.rs
@@ -487,7 +487,7 @@ trait RigidBodyForcesInternal {
 impl RigidBodyForcesInternal for ForcesItem<'_> {
     #[inline]
     fn rotation(&self) -> &Rotation {
-        &self.rotation
+        self.rotation
     }
     #[inline]
     fn lin_vel(&self) -> Vector {

--- a/src/dynamics/rigid_body/forces/tests.rs
+++ b/src/dynamics/rigid_body/forces/tests.rs
@@ -243,7 +243,7 @@ fn apply_local_linear_impulse() {
             -0.5 * 9.81 * duration.squared(),
             0.0
         ),
-        epsilon = 1.0
+        epsilon = 1.5
     );
 }
 

--- a/src/dynamics/rigid_body/forces/tests.rs
+++ b/src/dynamics/rigid_body/forces/tests.rs
@@ -243,7 +243,7 @@ fn apply_local_linear_impulse() {
             -0.5 * 9.81 * duration.squared(),
             0.0
         ),
-        epsilon = 1.5
+        epsilon = 2.0
     );
 }
 

--- a/src/dynamics/rigid_body/mod.rs
+++ b/src/dynamics/rigid_body/mod.rs
@@ -409,6 +409,14 @@ pub struct Sleeping;
 #[reflect(Debug, Component, Default, PartialEq)]
 pub struct TimeSleeping(pub Scalar);
 
+impl TimeSleeping {
+    /// Resets the time sleeping to zero.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.0 = 0.0;
+    }
+}
+
 /// Indicates that the body can not be deactivated by the physics engine. See [`Sleeping`] for information about sleeping.
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, PartialEq, Eq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]


### PR DESCRIPTION
# Objective

#770 added a `Forces` helper `QueryData` for applying forces, impulses, and accelerations to dynamic bodies. The intent was that forces would wake up bodies by default, but this was actually not the case, as `Forces` has some components that sleeping bodies don't.

However, we should *also* have a way to allow forces not to wake up bodies. This can be important for optimization in some cases.

## Solution

Rework `Forces` to wake up bodies by default when applying non-zero forces, impulses, or accelerations. Additionally, add a `ForcesItem::non_waking` method that returns a `NonWakingForcesItem`. The two force types share a `RigidBodyForces` trait and the same API, but the former wakes up bodies while the latter doesn't.

The API looks like this:

```rust
// This does not wake up the body.
forces.non_waking().apply_force(force);

// This wakes up the body if it is sleeping.
forces.apply_force(force);
```

Many existing physics engines instead take a boolean argument in all force methods to control whether the force should wake the body up. However, I am of the opinion that sleeping should primarily be transparent to the user and just an internal optimization, and that intuitively you would expect a force or impulse to *always* have an effect on a body by default. Disabling waking for a force should be a more advanced use case, so it should not affect the common API.

Game engines like Unity and Godot actually seem to always wake up bodies for non-zero forces, with no option to configure this. I took the middle route, defaulting to waking up, but having an additional `non_waking` method to opt in to the non-waking behavior.

I considered some component-driven approaches like a `ForceWakingMode` component, but I think this needs to be easily configurable per force and not a persisted per-entity setting.