### PR TITLE
Fix global center of mass for `Forces` and add `PhysicsTransformHelper`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,7 @@ dependencies = [
  "parry2d-f64",
  "serde",
  "smallvec",
+ "thiserror 2.0.12",
  "thread_local",
 ]
 
@@ -336,6 +337,7 @@ dependencies = [
  "parry3d-f64",
  "serde",
  "smallvec",
+ "thiserror 2.0.12",
  "thread_local",
 ]
 

--- a/crates/avian2d/Cargo.toml
+++ b/crates/avian2d/Cargo.toml
@@ -91,6 +91,7 @@ parry2d-f64 = { version = "0.21", optional = true }
 nalgebra = { version = "0.33", features = ["convert-glam029"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 derive_more = "1"
+thiserror = "2"
 arrayvec = "0.7"
 smallvec = "1.15"
 itertools = "0.13"

--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -93,6 +93,7 @@ parry3d-f64 = { version = "0.21", optional = true }
 nalgebra = { version = "0.33", features = ["convert-glam029"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 derive_more = "1"
+thiserror = "2"
 smallvec = "1.15"
 itertools = "0.13"
 bitflags = "2.5.0"

--- a/src/dynamics/mod.rs
+++ b/src/dynamics/mod.rs
@@ -89,9 +89,8 @@ pub mod prelude {
                 },
                 components::{
                     AngularInertia, CenterOfMass, ColliderDensity, ColliderMassProperties,
-                    ComputedAngularInertia, ComputedCenterOfMass, ComputedMass, GlobalCenterOfMass,
-                    Mass, MassPropertiesBundle, NoAutoAngularInertia, NoAutoCenterOfMass,
-                    NoAutoMass,
+                    ComputedAngularInertia, ComputedCenterOfMass, ComputedMass, Mass,
+                    MassPropertiesBundle, NoAutoAngularInertia, NoAutoCenterOfMass, NoAutoMass,
                 },
             },
             *,

--- a/src/dynamics/rigid_body/forces/mod.rs
+++ b/src/dynamics/rigid_body/forces/mod.rs
@@ -116,7 +116,7 @@
 //! ```
 //!
 //! [`Forces`] can also apply forces and impulses at a specific point in the world. If the point is not aligned
-//! with the [`GlobalCenterOfMass`], it will apply a torque to the body.
+//! with the [center of mass](CenterOfMass), it will apply a torque to the body.
 //!
 //! ```
 #![cfg_attr(feature = "2d", doc = "# use avian2d::{math::Vector, prelude::*};")]

--- a/src/dynamics/rigid_body/mass_properties/components/computed.rs
+++ b/src/dynamics/rigid_body/mass_properties/components/computed.rs
@@ -764,8 +764,6 @@ impl core::ops::Mul<Vector> for ComputedAngularInertia {
 /// # Related Types
 ///
 /// - [`CenterOfMass`] can be used to set the local center of mass associated with an individual entity.
-/// - [`GlobalCenterOfMass`] stores the global center of mass, which is automatically recomputed whenever the local center of mass,
-///   position, or rotation is changed.
 /// - [`ComputedMass`] stores the total mass of a rigid body, taking into account colliders and descendants.
 /// - [`ComputedAngularInertia`] stores the total angular inertia of a rigid body, taking into account colliders and descendants.
 /// - [`MassPropertyHelper`] is a [`SystemParam`] with utilities for computing and updating mass properties.
@@ -805,59 +803,6 @@ impl From<CenterOfMass> for ComputedCenterOfMass {
 impl From<ComputedCenterOfMass> for CenterOfMass {
     fn from(center_of_mass: ComputedCenterOfMass) -> Self {
         Self(center_of_mass.f32())
-    }
-}
-
-/// The global [center of mass] computed for a dynamic [rigid body], taking into account
-/// colliders and descendants. Represents the average position of mass in the body in world space.
-///
-/// This component is updated automatically whenever the local [`ComputedCenterOfMass`], position, or rotation is changed.
-/// To manually update it, use the associated [`update`](Self::update) method.
-///
-/// [rigid body]: RigidBody
-#[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, PartialEq, From)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Debug, Component, PartialEq)]
-pub struct GlobalCenterOfMass(Vector);
-
-impl GlobalCenterOfMass {
-    /// A center of mass set at the world origin.
-    pub const ZERO: Self = Self(Vector::ZERO);
-
-    /// Creates a new [`GlobalCenterOfMass`] at the given world position.
-    #[inline]
-    #[cfg(feature = "2d")]
-    pub const fn new(x: Scalar, y: Scalar) -> Self {
-        Self(Vector::new(x, y))
-    }
-
-    /// Creates a new [`GlobalCenterOfMass`] at the given world position.
-    #[inline]
-    #[cfg(feature = "3d")]
-    pub const fn new(x: Scalar, y: Scalar, z: Scalar) -> Self {
-        Self(Vector::new(x, y, z))
-    }
-
-    /// Returns the global center of mass as a vector.
-    #[inline]
-    pub fn get(&self) -> Vector {
-        self.0
-    }
-
-    /// Updates the global center of mass,
-    #[inline]
-    pub fn update(
-        &mut self,
-        local_com: impl Into<ComputedCenterOfMass>,
-        position: impl Into<Vector>,
-        rotation: impl Into<Rotation>,
-    ) {
-        let local_com: ComputedCenterOfMass = local_com.into();
-        let position: Vector = position.into();
-        let rotation: Rotation = rotation.into();
-        let global_com = position + rotation * local_com.0;
-        self.0 = global_com;
     }
 }
 

--- a/src/dynamics/rigid_body/mass_properties/components/computed.rs
+++ b/src/dynamics/rigid_body/mass_properties/components/computed.rs
@@ -845,19 +845,19 @@ impl GlobalCenterOfMass {
         self.0
     }
 
-    /// Updates the global angular inertia with the given local angular inertia and rotation.
+    /// Updates the global center of mass,
     #[inline]
     pub fn update(
         &mut self,
-        local_angular_inertia: impl Into<ComputedCenterOfMass>,
+        local_com: impl Into<ComputedCenterOfMass>,
         position: impl Into<Vector>,
         rotation: impl Into<Rotation>,
     ) {
-        let local_angular_inertia: ComputedCenterOfMass = local_angular_inertia.into();
+        let local_com: ComputedCenterOfMass = local_com.into();
         let position: Vector = position.into();
         let rotation: Rotation = rotation.into();
-        let global_angular_inertia = position + rotation * local_angular_inertia.0;
-        self.0 = global_angular_inertia;
+        let global_com = position + rotation * local_com.0;
+        self.0 = global_com;
     }
 }
 

--- a/src/dynamics/rigid_body/mass_properties/components/mod.rs
+++ b/src/dynamics/rigid_body/mass_properties/components/mod.rs
@@ -901,8 +901,6 @@ impl From<AngularInertia> for AngularInertiaTensor {
 /// # Related Types
 ///
 /// - [`ComputedCenterOfMass`] stores the total center of mass of a dynamic [rigid body] that considers child entities and colliders.
-/// - [`GlobalCenterOfMass`] stores the global center of mass, which is automatically recomputed whenever the local center of mass,
-///   position, or rotation is changed.
 /// - [`NoAutoCenterOfMass`] disables the centers of mass of child entities being taken into account for the [`ComputedCenterOfMass`].
 /// - [`Mass`] represents resistance to linear acceleration.
 /// - [`AngularInertia`] is the rotational equivalent of mass, representing resistance to angular acceleration.

--- a/src/dynamics/rigid_body/mod.rs
+++ b/src/dynamics/rigid_body/mod.rs
@@ -19,9 +19,7 @@ pub(crate) use forces::FloatZero;
 
 use crate::{
     physics_transform::init_physics_transform,
-    prelude::{
-        forces::AccumulatedLocalAcceleration, mass_properties::components::GlobalCenterOfMass, *,
-    },
+    prelude::{forces::AccumulatedLocalAcceleration, *},
 };
 use bevy::{
     ecs::{component::HookContext, world::DeferredWorld},
@@ -277,7 +275,6 @@ use derive_more::From;
     ComputedMass,
     ComputedAngularInertia,
     ComputedCenterOfMass,
-    GlobalCenterOfMass,
     // Required for local forces and acceleration.
     AccumulatedLocalAcceleration,
     // TODO: We can remove these pre-solve deltas once joints don't use XPBD.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -524,8 +524,7 @@ pub mod prelude {
         collision::prelude::*,
         dynamics::{self, ccd::SpeculativeMargin, prelude::*},
         interpolation::*,
-        physics_transform::PhysicsTransformPlugin,
-        physics_transform::{Position, Rotation},
+        physics_transform::{PhysicsTransformHelper, PhysicsTransformPlugin, Position, Rotation},
         schedule::{
             Physics, PhysicsSchedule, PhysicsSchedulePlugin, PhysicsSet, PhysicsStepSet,
             PhysicsTime, Substeps,

--- a/src/physics_transform/helper.rs
+++ b/src/physics_transform/helper.rs
@@ -1,0 +1,104 @@
+use bevy::{
+    ecs::{
+        entity::Entity,
+        system::{Query, SystemParam, lifetimeless::Write},
+        world::Mut,
+    },
+    transform::{
+        components::GlobalTransform,
+        helper::{ComputeGlobalTransformError, TransformHelper},
+    },
+};
+use thiserror::Error;
+
+use crate::prelude::{Position, Rotation};
+
+/// A system parameter for computing up-to-date [`Position`] and [`Rotation`] components
+/// of entities based on their [`Transform`]s.
+///
+/// This can be useful to ensure that physics transforms are immediately updated after changes
+/// to the [`Transform`], before transform propagation systems are run.
+///
+/// Computing the global transform of each entity individually can be expensive,
+/// so it is recommended to only use this for specific entities that require immediate updates,
+/// such as right after teleporting an entity.
+///
+/// [`Transform`]: bevy::transform::components::Transform
+#[derive(SystemParam)]
+pub struct PhysicsTransformHelper<'w, 's> {
+    /// The [`TransformHelper`] used to compute the global transform.
+    pub transform_helper: TransformHelper<'w, 's>,
+    /// A query for the [`Position`] and [`Rotation`] components.
+    pub query: Query<'w, 's, (Write<Position>, Write<Rotation>)>,
+}
+
+impl PhysicsTransformHelper<'_, '_> {
+    /// Computes the [`GlobalTransform`] of the given entity from its [`Transform`] and ancestors.
+    ///
+    /// [`Transform`]: bevy::transform::components::Transform
+    pub fn compute_global_transform(
+        &self,
+        entity: Entity,
+    ) -> Result<GlobalTransform, ComputeGlobalTransformError> {
+        self.transform_helper.compute_global_transform(entity)
+    }
+
+    /// Updates the [`Position`] and [`Rotation`] components of the given entity based on its
+    /// [`Transform`] and ancestors.
+    ///
+    /// Returns a mutable reference to the updated [`Position`] and [`Rotation`] components.
+    ///
+    /// [`Transform`]: bevy::transform::components::Transform
+    pub fn update_physics_transform(
+        &mut self,
+        entity: Entity,
+    ) -> Result<(Mut<Position>, Mut<Rotation>), UpdatePhysicsTransformError> {
+        use ComputeGlobalTransformError::*;
+
+        // Compute the global transform.
+        let global_transform = self
+            .transform_helper
+            .compute_global_transform(entity)
+            .map_err(|err| match err {
+                MissingTransform(e) => UpdatePhysicsTransformError::MissingTransform(e),
+                NoSuchEntity(e) => UpdatePhysicsTransformError::NoSuchEntity(e),
+                MalformedHierarchy(e) => UpdatePhysicsTransformError::MalformedHierarchy(e),
+            })?;
+
+        // Update the physics transform components.
+        let Ok((mut position, mut rotation)) = self.query.get_mut(entity) else {
+            return Err(UpdatePhysicsTransformError::MissingTransform(entity));
+        };
+        #[cfg(feature = "2d")]
+        {
+            position.0 = global_transform.translation().truncate();
+            *rotation = Rotation::from(global_transform.rotation());
+        }
+        #[cfg(feature = "3d")]
+        {
+            position.0 = global_transform.translation();
+            rotation.0 = global_transform.rotation();
+        }
+
+        Ok((position, rotation))
+    }
+}
+
+/// Error returned by [`PhysicsTransformHelper::update_physics_transform`].
+#[derive(Debug, Error)]
+pub enum UpdatePhysicsTransformError {
+    /// The entity or one of its ancestors is missing either the [`Transform`], [`Position`], or [`Rotation`] component.
+    ///
+    /// [`Transform`]: bevy::transform::components::Transform
+    #[error(
+        "The entity {0:?} or one of its ancestors is missing either the `Transform`, `Position`, or `Rotation` component"
+    )]
+    MissingTransform(Entity),
+    /// The entity does not exist.
+    #[error("The entity {0:?} does not exist")]
+    NoSuchEntity(Entity),
+    /// An ancestor is missing.
+    /// This probably means that your hierarchy has been improperly maintained.
+    #[error("The ancestor {0:?} is missing")]
+    MalformedHierarchy(Entity),
+}

--- a/src/physics_transform/mod.rs
+++ b/src/physics_transform/mod.rs
@@ -6,6 +6,9 @@ mod transform;
 pub use transform::{Position, PreSolveDeltaPosition, PreSolveDeltaRotation, Rotation};
 pub(crate) use transform::{RotationValue, init_physics_transform};
 
+mod helper;
+pub use helper::PhysicsTransformHelper;
+
 #[cfg(test)]
 mod tests;
 


### PR DESCRIPTION
# Objective

`Forces` has methods like `apply_force_at_point` that use the `GlobalCenterOfMass`. However, the `GlobalCenterOfMass` can be incorrect in two common cases:

1. At spawn, it is currently not initialized correctly until the first time physics runs.
2. If you change the `Transform` (e.g. to teleport an entity), it is only updated the next time physics runs.

This can lead to wildly incorrect torques or angular impulses as the force is applied relative to an incorrect center of mass.

Problem 1 is easy to fix with an observer, but problem 2 is very difficult. We cannot know the up-to-date global physics position without first running some form of transform propagation, and we cannot immediately react to `Transform` changes either.

For now, I think we should simply provide APIs for people to update global physics positions in an ad hoc way, and to remove the reliance on `GlobalCenterOfMass` in favor of simply computing it based on the `Position`, `Rotation`, and `ComputedCenterOfMass`.

## Solution

Add a `PhysicsTransformHelper` system parameter for updating the physics transform of a given entity, and remove `GlobalCenterOfMass`.

TODO document the relevant force APIs