### PR TITLE
Expose total normal impulses, improve contact impulse APIs

### DIFF
--- a/src/collision/contact_types/mod.rs
+++ b/src/collision/contact_types/mod.rs
@@ -71,6 +71,7 @@ pub struct ContactEdge {
 
 impl ContactEdge {
     /// Creates a new non-touching [`ContactEdge`] with the given entities.
+    #[inline]
     pub fn new(collider1: Entity, collider2: Entity) -> Self {
         Self {
             // This gets set to a valid ID when the contact pair is added to the `ContactGraph`.
@@ -84,16 +85,19 @@ impl ContactEdge {
     }
 
     /// Returns `true` if the colliders are touching.
+    #[inline]
     pub fn is_touching(&self) -> bool {
         self.flags.contains(ContactEdgeFlags::TOUCHING)
     }
 
     /// Returns `true` if the contact pair is between sleeping bodies.
+    #[inline]
     pub fn is_sleeping(&self) -> bool {
         self.flags.contains(ContactEdgeFlags::SLEEPING)
     }
 
     /// Returns `true` if collision events are enabled for the contact.
+    #[inline]
     pub fn events_enabled(&self) -> bool {
         self.flags.contains(ContactEdgeFlags::CONTACT_EVENTS)
     }
@@ -205,7 +209,8 @@ impl ContactPair {
 
     /// Computes the sum of all impulses applied along contact normals between the contact pair.
     ///
-    /// To get the corresponding force, divide the impulse by `Time::<Substeps>::delta_secs()`.
+    /// To get the corresponding force, divide the impulse by the time step.
+    #[inline]
     pub fn total_normal_impulse(&self) -> Vector {
         self.manifolds.iter().fold(Vector::ZERO, |acc, manifold| {
             acc + manifold.normal * manifold.total_normal_impulse()
@@ -216,7 +221,8 @@ impl ContactPair {
     ///
     /// This is the sum of impulse magnitudes, *not* the magnitude of the [`total_normal_impulse`](Self::total_normal_impulse).
     ///
-    /// To get the corresponding force, divide the impulse by `Time::<Substeps>::delta_secs()`.
+    /// To get the corresponding force, divide the impulse by the time step.
+    #[inline]
     pub fn total_normal_impulse_magnitude(&self) -> Scalar {
         self.manifolds
             .iter()
@@ -224,58 +230,61 @@ impl ContactPair {
     }
 
     // TODO: We could also return a reference to the whole manifold. Would that be useful?
-    /// Finds the largest impulse between the contact pair, and the associated world-space contact normal,
-    /// pointing from the first shape to the second.
+    /// Finds the largest normal impulse between the contact pair, pointing along the world-space contact normal
+    /// from the first shape to the second.
     ///
-    /// To get the corresponding force, divide the impulse by `Time::<Substeps>::delta_secs()`.
-    pub fn max_normal_impulse(&self) -> (Scalar, Vector) {
-        let mut magnitude: Scalar = 0.0;
+    /// To get the corresponding force, divide the impulse by the time step.
+    #[inline]
+    pub fn max_normal_impulse(&self) -> Vector {
+        let mut magnitude: Scalar = Scalar::MIN;
         let mut normal = Vector::ZERO;
 
         for manifold in &self.manifolds {
             let impulse = manifold.max_normal_impulse();
-            if impulse.abs() > magnitude.abs() {
+            if impulse > magnitude {
                 magnitude = impulse;
                 normal = manifold.normal;
             }
         }
-
-        (magnitude, normal)
+        normal * magnitude
     }
 
-    /// The force corresponding to the total normal impulse applied over `delta_time`.
+    /// Finds the magnitude of the largest normal impulse between the contact pair.
     ///
-    /// Because contacts are solved over several substeps, `delta_time` should
-    /// typically use `Time<Substeps>::delta_secs()`.
-    #[deprecated(
-        note = "Use `total_normal_impulse` instead, and divide it by `Time<Substeps>::delta_secs()`",
-        since = "0.3.0"
-    )]
-    pub fn total_normal_force(&self, delta_time: Scalar) -> Scalar {
-        self.total_normal_impulse_magnitude() / delta_time
+    /// To get the corresponding force, divide the impulse by the time step.
+    #[inline]
+    pub fn max_normal_impulse_magnitude(&self) -> Scalar {
+        self.manifolds
+            .iter()
+            .fold(0.0, |acc, manifold| acc.max(manifold.max_normal_impulse()))
     }
 
     /// Returns `true` if at least one of the colliders is a [`Sensor`].
+    #[inline]
     pub fn is_sensor(&self) -> bool {
         self.flags.contains(ContactPairFlags::SENSOR)
     }
 
     /// Returns `true` if the colliders are touching, including sensors.
+    #[inline]
     pub fn is_touching(&self) -> bool {
         self.flags.contains(ContactPairFlags::TOUCHING)
     }
 
     /// Returns `true` if the AABBs of the colliders are no longer overlapping.
+    #[inline]
     pub fn aabbs_disjoint(&self) -> bool {
         self.flags.contains(ContactPairFlags::DISJOINT_AABB)
     }
 
     /// Returns `true` if a collision started during the current frame.
+    #[inline]
     pub fn collision_started(&self) -> bool {
         self.flags.contains(ContactPairFlags::STARTED_TOUCHING)
     }
 
     /// Returns `true` if a collision ended during the current frame.
+    #[inline]
     pub fn collision_ended(&self) -> bool {
         self.flags.contains(ContactPairFlags::STOPPED_TOUCHING)
     }
@@ -286,6 +295,7 @@ impl ContactPair {
     /// the penetration depth will be negative.
     ///
     /// If there are no contacts, `None` is returned.
+    #[inline]
     pub fn find_deepest_contact(&self) -> Option<&ContactPoint> {
         self.manifolds
             .iter()
@@ -352,6 +362,7 @@ impl ContactManifold {
     /// expressed in local space.
     ///
     /// `index` represents the index of the manifold in the collision.
+    #[inline]
     pub fn new(points: impl IntoIterator<Item = ContactPoint>, normal: Vector) -> Self {
         Self {
             #[cfg(feature = "2d")]
@@ -369,14 +380,16 @@ impl ContactManifold {
     }
 
     /// The sum of the impulses applied at the contact points in the manifold along the contact normal.
-    fn total_normal_impulse(&self) -> Scalar {
+    #[inline]
+    pub fn total_normal_impulse(&self) -> Scalar {
         self.points
             .iter()
             .fold(0.0, |acc, contact| acc + contact.normal_impulse)
     }
 
     /// The magnitude of the largest impulse applied at a contact point in the manifold along the contact normal.
-    fn max_normal_impulse(&self) -> Scalar {
+    #[inline]
+    pub fn max_normal_impulse(&self) -> Scalar {
         self.points
             .iter()
             .map(|contact| contact.normal_impulse)
@@ -389,6 +402,7 @@ impl ContactManifold {
     /// Contacts are first matched based on their [feature IDs](PackedFeatureId), and if they are unknown,
     /// matching is done based on contact positions using the given `distance_threshold`
     /// for determining if points are too far away from each other to be considered matching.
+    #[inline]
     pub fn match_contacts(
         &mut self,
         previous_contacts: &[ContactPoint],
@@ -407,8 +421,9 @@ impl ContactManifold {
                     (contact.feature_id2 == previous_contact.feature_id1
                     && contact.feature_id1 == previous_contact.feature_id2)
                 {
-                    contact.normal_impulse = previous_contact.normal_impulse;
-                    contact.tangent_impulse = previous_contact.tangent_impulse;
+                    contact.warm_start_normal_impulse = previous_contact.warm_start_normal_impulse;
+                    contact.warm_start_tangent_impulse =
+                        previous_contact.warm_start_tangent_impulse;
                     break;
                 }
 
@@ -435,8 +450,9 @@ impl ContactManifold {
                             .distance_squared(previous_contact.local_point1)
                             < distance_threshold_squared)
                 {
-                    contact.normal_impulse = previous_contact.normal_impulse;
-                    contact.tangent_impulse = previous_contact.tangent_impulse;
+                    contact.warm_start_normal_impulse = previous_contact.warm_start_normal_impulse;
+                    contact.warm_start_tangent_impulse =
+                        previous_contact.warm_start_tangent_impulse;
                     break;
                 }
             }
@@ -449,6 +465,7 @@ impl ContactManifold {
     /// the penetration depth will be negative.
     ///
     /// If there are no contacts, `None` is returned.
+    #[inline]
     pub fn find_deepest_contact(&self) -> Option<&ContactPoint> {
         self.points.iter().max_by(|a, b| {
             a.penetration
@@ -472,22 +489,31 @@ pub struct ContactPoint {
     ///
     /// [speculative collision]: crate::dynamics::ccd#speculative-collision
     pub penetration: Scalar,
-    /// The impulse applied to the first body along the contact normal.
+    /// The total normal impulse applied to the first body at this contact point.
+    /// The unit is typically N⋅s or kg⋅m/s.
     ///
-    /// To get the corresponding force, divide the impulse by `Time<Substeps>::delta_secs()`.
+    /// This can be used to determine how "strong" a contact is. To compute the corresponding
+    /// contact force, divide the impulse by the time step.
     pub normal_impulse: Scalar,
-    /// The impulse applied to the first body along the contact tangent. This corresponds to the impulse caused by friction.
+    /// The normal impulse used to warm start the contact solver.
     ///
-    /// To get the corresponding force, divide the impulse by `Time<Substeps>::delta_secs()`.
+    /// This corresponds to the clamped accumulated impulse from the last substep
+    /// of the previous time step.
+    pub warm_start_normal_impulse: Scalar,
+    /// The frictional impulse used to warm start the contact solver.
+    ///
+    /// This corresponds to the clamped accumulated impulse from the last substep
+    /// of the previous time step.
     #[cfg(feature = "2d")]
-    #[doc(alias = "friction_impulse")]
-    pub tangent_impulse: Scalar,
-    /// The impulse applied to the first body along the contact tangent. This corresponds to the impulse caused by friction.
+    #[doc(alias = "warm_start_friction_impulse")]
+    pub warm_start_tangent_impulse: Scalar,
+    /// The frictional impulse used to warm start the contact solver.
     ///
-    /// To get the corresponding force, divide the impulse by `Time<Substeps>::delta_secs()`.
+    /// This corresponds to the clamped accumulated impulse from the last substep
+    /// of the previous time step.
     #[cfg(feature = "3d")]
-    #[doc(alias = "friction_impulse")]
-    pub tangent_impulse: Vector2,
+    #[doc(alias = "warm_start_friction_impulse")]
+    pub warm_start_tangent_impulse: Vector2,
     /// The contact feature ID on the first shape. This indicates the ID of
     /// the vertex, edge, or face of the contact, if one can be determined.
     pub feature_id1: PackedFeatureId,
@@ -501,84 +527,67 @@ impl ContactPoint {
     /// of the first and second shape respectively.
     ///
     /// [Feature IDs](PackedFeatureId) can be specified for the contact points using [`with_feature_ids`](Self::with_feature_ids).
-    #[allow(clippy::too_many_arguments)]
+    #[inline]
     pub fn new(local_point1: Vector, local_point2: Vector, penetration: Scalar) -> Self {
         Self {
             local_point1,
             local_point2,
             penetration,
             normal_impulse: 0.0,
-            tangent_impulse: default(),
+            warm_start_normal_impulse: 0.0,
+            #[cfg(feature = "2d")]
+            warm_start_tangent_impulse: 0.0,
+            #[cfg(feature = "3d")]
+            warm_start_tangent_impulse: Vector2::ZERO,
             feature_id1: PackedFeatureId::UNKNOWN,
             feature_id2: PackedFeatureId::UNKNOWN,
         }
     }
 
     /// Sets the [feature IDs](PackedFeatureId) of the contact points.
+    #[inline]
     pub fn with_feature_ids(mut self, id1: PackedFeatureId, id2: PackedFeatureId) -> Self {
         self.feature_id1 = id1;
         self.feature_id2 = id2;
         self
     }
 
-    /// The force corresponding to the normal impulse applied over `delta_time`.
-    ///
-    /// Because contacts are solved over several substeps, `delta_time` should
-    /// typically use `Time<Substeps>::delta_secs()`.
-    pub fn normal_force(&self, delta_time: Scalar) -> Scalar {
-        self.normal_impulse / delta_time
-    }
-
-    /// The force corresponding to the tangent impulse applied over `delta_time`.
-    ///
-    /// Because contacts are solved over several substeps, `delta_time` should
-    /// typically use `Time<Substeps>::delta_secs()`.
-    #[cfg(feature = "2d")]
-    #[doc(alias = "friction_force")]
-    pub fn tangent_force(&self, delta_time: Scalar) -> Scalar {
-        self.tangent_impulse / delta_time
-    }
-
-    /// The force corresponding to the tangent impulse applied over `delta_time`.
-    ///
-    /// Because contacts are solved over several substeps, `delta_time` should
-    /// typically use `Time<Substeps>::delta_secs()`.
-    #[cfg(feature = "3d")]
-    #[doc(alias = "friction_force")]
-    pub fn tangent_force(&self, delta_time: Scalar) -> Vector2 {
-        self.tangent_impulse / delta_time
-    }
-
     /// Returns the global contact point on the first shape,
     /// transforming the local point by the given position and rotation.
+    #[inline]
     pub fn global_point1(&self, position: &Position, rotation: &Rotation) -> Vector {
         position.0 + rotation * self.local_point1
     }
 
     /// Returns the global contact point on the second shape,
     /// transforming the local point by the given position and rotation.
+    #[inline]
     pub fn global_point2(&self, position: &Position, rotation: &Rotation) -> Vector {
         position.0 + rotation * self.local_point2
     }
 
     /// Flips the contact data, swapping the points and feature IDs,
     /// and negating the impulses.
+    #[inline]
     pub fn flip(&mut self) {
         core::mem::swap(&mut self.local_point1, &mut self.local_point2);
         core::mem::swap(&mut self.feature_id1, &mut self.feature_id2);
         self.normal_impulse = -self.normal_impulse;
-        self.tangent_impulse = -self.tangent_impulse;
+        self.warm_start_normal_impulse = -self.warm_start_normal_impulse;
+        self.warm_start_tangent_impulse = -self.warm_start_tangent_impulse;
     }
 
     /// Returns a flipped copy of the contact data, swapping the points and feature IDs,
     /// and negating the impulses.
+    #[inline]
     pub fn flipped(&self) -> Self {
         Self {
             local_point1: self.local_point2,
             local_point2: self.local_point1,
             penetration: self.penetration,
             normal_impulse: -self.normal_impulse,
-            tangent_impulse: -self.tangent_impulse,
+            warm_start_normal_impulse: -self.warm_start_normal_impulse,
+            warm_start_tangent_impulse: -self.warm_start_tangent_impulse,
             feature_id1: self.feature_id2,
             feature_id2: self.feature_id1,
         }
@@ -606,6 +615,7 @@ pub struct SingleContact {
 
 impl SingleContact {
     /// Creates a new [`SingleContact`]. The contact points and normals should be given in local space.
+    #[inline]
     pub fn new(
         local_point1: Vector,
         local_point2: Vector,
@@ -624,33 +634,39 @@ impl SingleContact {
 
     /// Returns the global contact point on the first shape,
     /// transforming the local point by the given position and rotation.
+    #[inline]
     pub fn global_point1(&self, position: &Position, rotation: &Rotation) -> Vector {
         position.0 + rotation * self.local_point1
     }
 
     /// Returns the global contact point on the second shape,
     /// transforming the local point by the given position and rotation.
+    #[inline]
     pub fn global_point2(&self, position: &Position, rotation: &Rotation) -> Vector {
         position.0 + rotation * self.local_point2
     }
 
     /// Returns the world-space contact normal pointing from the first shape to the second.
+    #[inline]
     pub fn global_normal1(&self, rotation: &Rotation) -> Vector {
         rotation * self.local_normal1
     }
 
     /// Returns the world-space contact normal pointing from the second shape to the first.
+    #[inline]
     pub fn global_normal2(&self, rotation: &Rotation) -> Vector {
         rotation * self.local_normal2
     }
 
     /// Flips the contact data, swapping the points and normals.
+    #[inline]
     pub fn flip(&mut self) {
         core::mem::swap(&mut self.local_point1, &mut self.local_point2);
         core::mem::swap(&mut self.local_normal1, &mut self.local_normal2);
     }
 
     /// Returns a flipped copy of the contact data, swapping the points and normals.
+    #[inline]
     pub fn flipped(&self) -> Self {
         Self {
             local_point1: self.local_point2,

--- a/src/dynamics/solver/contact/normal_part.rs
+++ b/src/dynamics/solver/contact/normal_part.rs
@@ -17,6 +17,14 @@ pub struct ContactNormalPart {
     /// The magnitude of the contact impulse along the contact normal.
     pub impulse: NormalImpulse,
 
+    /// The total normal impulse applied across substeps and restitution.
+    /// The unit is typically N⋅s or kg⋅m/s.
+    ///
+    /// This is used by the solver to identify speculative contacts that did not generate
+    /// an impulse, but is also useful for users to determine how "strong" the contact is.
+    /// This is stored for contact manifolds as [`ContactPoint::normal_impulse`].
+    pub total_impulse: Scalar,
+
     /// The inertial properties of the bodies projected onto the contact normal,
     /// or in other words, the mass "seen" by the constraint along the normal.
     pub effective_mass: Scalar,
@@ -98,6 +106,7 @@ impl ContactNormalPart {
 
         Self {
             impulse: warm_start_impulse.unwrap_or_default(),
+            total_impulse: 0.0,
             effective_mass: k.recip_or_zero(),
             softness,
         }
@@ -151,6 +160,7 @@ impl ContactNormalPart {
         let new_impulse = (self.impulse + impulse).max(0.0);
         impulse = new_impulse - self.impulse;
         self.impulse = new_impulse;
+        self.total_impulse += new_impulse;
 
         // Return the clamped incremental normal impulse.
         impulse

--- a/src/dynamics/solver/mod.rs
+++ b/src/dynamics/solver/mod.rs
@@ -635,7 +635,7 @@ fn prepare_contact_constraints(
                         constraint.normal,
                         narrow_phase_config
                             .match_contacts
-                            .then_some(contact.normal_impulse),
+                            .then_some(contact.warm_start_normal_impulse),
                         contact_softness,
                     ),
                     // There should only be a friction part if the coefficient of friction is non-negative.
@@ -649,10 +649,9 @@ fn prepare_contact_constraints(
                             tangents,
                             narrow_phase_config
                                 .match_contacts
-                                .then_some(contact.tangent_impulse),
+                                .then_some(contact.warm_start_tangent_impulse),
                         ),
                     ),
-                    max_normal_impulse: 0.0,
                     anchor1: r1,
                     anchor2: r2,
                     normal_speed,
@@ -900,11 +899,12 @@ fn store_contact_impulses(
             for (contact, constraint_point) in
                 manifold.points.iter_mut().zip(constraint.points.iter())
             {
-                contact.normal_impulse = constraint_point.normal_part.impulse;
-                contact.tangent_impulse = constraint_point
+                contact.warm_start_normal_impulse = constraint_point.normal_part.impulse;
+                contact.warm_start_tangent_impulse = constraint_point
                     .tangent_part
                     .as_ref()
                     .map_or(default(), |part| part.impulse);
+                contact.normal_impulse = constraint_point.normal_part.total_impulse;
             }
         }
     }


### PR DESCRIPTION
# Objective

`ContactPoint` stores a `normal_impulse`. However, this is the clamped accumulated normal impulse from the last substep, used for warm starting the solver. It does *not* represent the total impulse applied across substeps and restitution, despite the ambiguous name.

As such, we are currently missing a proper way for users to determine how "strong" a contact is. Exposing this is important for numerous gameplay scenarios, like determining when a glass bottle or window should shatter, or how much damage a hit should deal.

## Solution

Rename the current `ContactPoint` properties `normal_impulse` and `tangent_impulse` to `warm_start_normal_impulse` and `warm_start_tangent_impulse`, and expose a new `normal_impulse` that represents the total normal impulse applied across substeps and restitution.

Contact constraints still store a `normal_impulse` with the old semantics, but the `max_normal_impulse` has been renamed to `total_normal_impulse`, which contains the total normal impulse. Some of the solver code here has also been slightly modified to fix some problems and work with the new semantics.

The method APIs like `ContactPair::total_normal_impulse` have been updated accordingly. `ContactPair::max_normal_impulse` has also been split into `ContactPair::max_normal_impulse` (returns a vector) and `ContactPair::max_normal_impulse_magnitude` (returns a scalar).

### Comparison to Box2D

Box2D has the same property, but there the warm starting impulse is stored on `b2ManifoldPoint` as `normalImpulse`, and the total normal impulse is stored as `totalNormalImpulse`. The former is intended to be more internal, and the latter is intended for gameplay purposes.

Using the more obvious name `normalImpulse` for the value intended for internals seems like an odd API choice to me, so I instead opted to make `normal_impulse` what users would expect to use, and give the less obvious / longer name to the warm starting impulse as `warm_start_normal_impulse`.

---

## Migration Guide

`ContactPoint::normal_impulse` previously corresponded to the clamped accumulated normal impulse from the last substep, used for warm starting the contact solver. It did *not* represent the total impulse applied across substeps and restitution, despite the ambiguous name.

Now, `ContactPoint::normal_impulse` works like you would expect, and represents the total normal impulse applied at a contact point. Divide by the time step to get the corresponding force.

The old warm starting impulses are now stored as `warm_start_normal_impulse` and `warm_start_tangent_impulse` (previously `tangent_impulse`).

The method APIs such as `total_normal_impulse`, `total_normal_impulse_magnitude`, and `max_normal_impulse` have been updated accordingly to use the new `normal_impulse`. Additionally, `ContactPair::max_normal_impulse` has been split into `ContactPair::max_normal_impulse` (returns a vector) and `ContactPair::max_normal_impulse_magnitude` (returns a scalar).

The `normal_force` and `tangent_force` methods of `ContactPoint` have been removed.

`ContactConstraintPoint::max_normal_impulse` is now stored in the `ContactNormalPart` as `total_impulse`.