### PR TITLE
Fix UB and improve parallel iteration in solver

### DIFF
--- a/src/collision/narrow_phase/system_param.rs
+++ b/src/collision/narrow_phase/system_param.rs
@@ -383,7 +383,7 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
         //
         // TODO: An alternative to thread-local bit vectors could be to have one larger bit vector
         //       and to chunk it into smaller bit vectors for each thread. Might not be any faster though.
-        crate::utils::par_for_each!(self.contact_graph.active_pairs_mut(), |_i, contacts| {
+        crate::utils::par_for_each(self.contact_graph.active_pairs_mut(), 64, |_i, contacts| {
             let contact_id = contacts.contact_id.0 as usize;
 
             #[cfg(not(feature = "parallel"))]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,11 +2,10 @@
 
 pub(crate) use bevy::platform::time::Instant;
 
-/// A helper macro for iterating over a slice in parallel or serially
+/// A helper function for iterating over a slice in parallel or serially
 /// based on the `parallel` feature.
 ///
-/// The macro takes an expression that evaluates to a mutable slice,
-/// and a closure that takes two arguments: the index and the item at the index.
+/// If `slice.len() < min_len`, serial iteration will be used.
 ///
 /// The `ComputeTaskPool` is used if parallelism is enabled.
 ///
@@ -15,47 +14,44 @@ pub(crate) use bevy::platform::time::Instant;
 /// ```ignore
 /// let mut slice = vec![1, 2, 3, 4];
 ///
-/// par_for_each!(slice, |index, item| {
+/// par_for_each(&mut slice, |index, item| {
 ///     *item += index;
 /// });
 ///
 /// assert_eq!(slice, vec![1, 3, 5, 7]);
 /// ```
-macro_rules! par_for_each {
-    ($expression:expr, |$index:ident, $item:ident $(,)?| $body:block) => {
-        #[cfg(not(feature = "parallel"))]
-        $expression
-            .iter_mut()
-            .enumerate()
-            .for_each(|($index, $item)| $body);
+#[inline(always)]
+pub fn par_for_each<T, F>(mut slice: &mut [T], min_len: usize, f: F)
+where
+    T: Send + Sync,
+    F: Fn(usize, &mut T) + Send + Sync,
+{
+    #[cfg(not(feature = "parallel"))]
+    slice.iter_mut().enumerate().for_each(f);
 
-        #[cfg(feature = "parallel")]
-        {
-            let task_pool_ = bevy::tasks::ComputeTaskPool::get();
+    #[cfg(feature = "parallel")]
+    {
+        let task_pool_ = bevy::tasks::ComputeTaskPool::get();
 
-            if task_pool_.thread_num() == 1 {
-                $expression
-                    .iter_mut()
-                    .enumerate()
-                    .for_each(|($index, $item)| $body);
-            } else {
-                // TODO: Is there a better approach than `par_chunk_map_mut`?
-                let chunk_size_ = ($expression.len() / task_pool_.thread_num()).max(1);
-                bevy::tasks::ParallelSliceMut::par_chunk_map_mut(
-                    &mut $expression,
-                    task_pool_,
-                    chunk_size_,
-                    |chunk_index_, chunk_| {
-                        let index_offset_ = chunk_index_ * chunk_size_;
-                        chunk_.iter_mut().enumerate().for_each(|(index_, $item)| {
-                            let $index = index_offset_ + index_;
-                            $body
-                        });
-                    },
-                );
-            }
+        if task_pool_.thread_num() == 1 || slice.len() < min_len {
+            slice.iter_mut().enumerate().for_each(|(index, item)| {
+                f(index, item);
+            });
+        } else {
+            // TODO: Is there a better approach than `par_chunk_map_mut`?
+            let chunk_size_ = (slice.len() / task_pool_.thread_num()).max(1);
+            bevy::tasks::ParallelSliceMut::par_chunk_map_mut(
+                &mut slice,
+                task_pool_,
+                chunk_size_,
+                |chunk_index_, chunk_| {
+                    let index_offset_ = chunk_index_ * chunk_size_;
+                    chunk_.iter_mut().enumerate().for_each(|(i, item)| {
+                        let index = index_offset_ + i;
+                        f(index, item);
+                    });
+                },
+            );
         }
-    };
+    }
 }
-
-pub(crate) use par_for_each;


### PR DESCRIPTION
# Objective

The solver currently has some UB that is making local determinism tests fail on Windows. This is because we use parallel iteration even for the overflow constraints that should be solved serially.

## Solution

Solve overflow serially. This will be reworked further when we implement wide SIMD.

I also changed the `par_for_each!` macro to a normal function, which fixes autocomplete when using the macro, and added some bounds on when to use parallel iteration and when to use serial iteration.