### PR TITLE
Expose anchors, world-space `point`, and `normal_speed` for contacts

### DIFF
--- a/src/collision/collider/parry/contact_query.rs
+++ b/src/collision/collider/parry/contact_query.rs
@@ -211,7 +211,7 @@ pub fn contact_manifolds(
         // The contact point is the midpoint of the two points in world space.
         // The anchors are relative to the positions of the colliders.
         let point1 = rotation1 * local_point1;
-        let anchor1 = point1 + normal * contact.dist * 0.5; // TODO: Is this accurate?
+        let anchor1 = point1 + normal * contact.dist * 0.5;
         let anchor2 = anchor1 + (position1.0 - position2.0);
         let world_point = position1.0 + anchor1;
         let points = [ContactPoint::new(
@@ -247,7 +247,7 @@ pub fn contact_manifolds(
             // The contact point is the midpoint of the two points in world space.
             // The anchors are relative to the positions of the colliders.
             let point1 = rotation1 * Vector::from(subpos1.transform_point(&contact.local_p1));
-            let anchor1 = point1 + normal * contact.dist * 0.5; // TODO: Is this accurate?
+            let anchor1 = point1 + normal * contact.dist * 0.5;
             let anchor2 = anchor1 + (position1.0 - position2.0);
             let world_point = position1.0 + anchor1;
             ContactPoint::new(anchor1, anchor2, world_point, -contact.dist)

--- a/src/collision/contact_types/mod.rs
+++ b/src/collision/contact_types/mod.rs
@@ -465,6 +465,22 @@ impl ContactManifold {
                 .unwrap_or(core::cmp::Ordering::Equal)
         })
     }
+
+    /// Retains only the elements specified by the predicate.
+    #[inline]
+    pub(crate) fn retain_points_mut<F>(&mut self, f: F)
+    where
+        F: FnMut(&mut ContactPoint) -> bool,
+    {
+        #[cfg(feature = "2d")]
+        {
+            self.points.retain(f);
+        }
+        #[cfg(feature = "3d")]
+        {
+            self.points.retain_mut(f);
+        }
+    }
 }
 
 /// Data associated with a contact point in a [`ContactManifold`].

--- a/src/collision/contact_types/mod.rs
+++ b/src/collision/contact_types/mod.rs
@@ -477,7 +477,7 @@ pub struct ContactPoint {
     pub anchor2: Vector,
     /// The contact point in world space.
     ///
-    /// This is the average position of the two contact points on the surfaces of the two shapes.
+    /// This is the midpoint between the closest points on the surfaces of the two shapes.
     ///
     /// Note that because the contact point is expressed in world space,
     /// it is subject to precision loss at large coordinates.

--- a/src/collision/contact_types/mod.rs
+++ b/src/collision/contact_types/mod.rs
@@ -154,10 +154,6 @@ pub struct ContactPair {
     ///
     /// [`ConstraintGraph`]: crate::dynamics::solver::constraint_graph::ConstraintGraph
     pub(crate) manifold_count_change: i16,
-    /// The effective speculative margin computed for this contact pair.
-    ///
-    /// This is computed in the narrow phase and reused during constraint preparation.
-    pub(crate) effective_speculative_margin: Scalar,
     /// Flag indicating the status and type of the contact pair.
     pub flags: ContactPairFlags,
 }
@@ -202,7 +198,6 @@ impl ContactPair {
             body2: None,
             manifolds: Vec::new(),
             manifold_count_change: 0,
-            effective_speculative_margin: 0.0,
             flags: ContactPairFlags::empty(),
         }
     }

--- a/src/collision/narrow_phase/system_param.rs
+++ b/src/collision/narrow_phase/system_param.rs
@@ -453,7 +453,7 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                         (
                             body.rb.is_static(),
                             collider1.position.0 - body.position.0,
-                            body.position.0 * body.center_of_mass.0,
+                            body.rotation * body.center_of_mass.0,
                             body.linear_velocity.0,
                             body.friction,
                             body.collision_margin,

--- a/src/collision/narrow_phase/system_param.rs
+++ b/src/collision/narrow_phase/system_param.rs
@@ -632,8 +632,7 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                         // Add the collision margin to the penetration depth.
                         point.penetration += collision_margin_sum;
 
-                        // Relative velocity at the contact point.
-                        // body2.velocity_at_point(r2) - body1.velocity_at_point(r1)
+                        // Compute the relative velocity along the contact normal.
                         #[cfg(feature = "2d")]
                         let relative_velocity = relative_linear_velocity
                             + ang_vel2 * point.anchor2.perp()
@@ -643,6 +642,7 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                             + ang_vel2.cross(point.anchor2)
                             - ang_vel1.cross(point.anchor1);
                         let normal_speed = relative_velocity.dot(normal);
+                        point.normal_speed = normal_speed;
 
                         // Keep the contact if (1) the separation distance is below the required threshold,
                         // or if (2) the bodies are expected to come into contact within the next time step.

--- a/src/collision/narrow_phase/system_param.rs
+++ b/src/collision/narrow_phase/system_param.rs
@@ -646,12 +646,10 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
 
                         // Keep the contact if (1) the separation distance is below the required threshold,
                         // or if (2) the bodies are expected to come into contact within the next time step.
-                        let keep_contact = -point.penetration < effective_speculative_margin || {
+                        -point.penetration < effective_speculative_margin || {
                             let delta_distance = normal_speed * delta_secs;
                             delta_distance - point.penetration < effective_speculative_margin
-                        };
-
-                        keep_contact
+                        }
                     });
                 });
 

--- a/src/dynamics/solver/contact/tangent_part.rs
+++ b/src/dynamics/solver/contact/tangent_part.rs
@@ -32,20 +32,17 @@ pub struct ContactTangentPart {
 
 impl ContactTangentPart {
     /// Generates a new [`ContactTangentPart`].
-    #[allow(clippy::too_many_arguments)]
     pub fn generate(
-        inverse_mass_sum: Scalar,
-        angular_inertia1: impl Into<ComputedAngularInertia>,
-        angular_inertia2: impl Into<ComputedAngularInertia>,
+        effective_inverse_mass_sum: Vector,
+        inverse_angular_inertia1: &SymmetricTensor,
+        inverse_angular_inertia2: &SymmetricTensor,
         r1: Vector,
         r2: Vector,
         tangents: [Vector; DIM - 1],
         warm_start_impulse: Option<TangentImpulse>,
     ) -> Self {
-        let angular_inertia1: ComputedAngularInertia = angular_inertia1.into();
-        let angular_inertia2: ComputedAngularInertia = angular_inertia2.into();
-        let i1 = angular_inertia1.inverse();
-        let i2 = angular_inertia2.inverse();
+        let i1 = inverse_angular_inertia1;
+        let i2 = inverse_angular_inertia2;
 
         let mut part = Self {
             impulse: warm_start_impulse.unwrap_or_default(),
@@ -113,7 +110,8 @@ impl ContactTangentPart {
             let rt1 = cross(r1, tangents[0]);
             let rt2 = cross(r2, tangents[0]);
 
-            let k = inverse_mass_sum + i1 * rt1 * rt1 + i2 * rt2 * rt2;
+            let k_linear = tangents[0].dot(effective_inverse_mass_sum * tangents[0]);
+            let k = k_linear + i1 * rt1 * rt1 + i2 * rt2 * rt2;
 
             part.effective_mass = k.recip_or_zero();
         }
@@ -134,8 +132,10 @@ impl ContactTangentPart {
             let i1_rt21 = i1 * rt21;
             let i2_rt22 = i2 * rt22;
 
-            let k1 = inverse_mass_sum + rt11.dot(i1_rt11) + rt12.dot(i2_rt12);
-            let k2 = inverse_mass_sum + rt21.dot(i1_rt21) + rt22.dot(i2_rt22);
+            let k_linear1 = tangents[0].dot(effective_inverse_mass_sum * tangents[0]);
+            let k_linear2 = tangents[1].dot(effective_inverse_mass_sum * tangents[1]);
+            let k1 = k_linear1 + rt11.dot(i1_rt11) + rt12.dot(i2_rt12);
+            let k2 = k_linear2 + rt21.dot(i1_rt21) + rt22.dot(i2_rt22);
 
             // Note: The invertion is done in `solve_impulse`, unlike in 2D.
             part.effective_inverse_mass[0] = k1;

--- a/src/dynamics/solver/mod.rs
+++ b/src/dynamics/solver/mod.rs
@@ -947,7 +947,6 @@ fn store_contact_impulses(
                     .as_ref()
                     .map_or(default(), |part| part.impulse);
                 contact.normal_impulse = constraint_point.normal_part.total_impulse;
-                contact.normal_speed = constraint_point.normal_speed;
             }
         }
     }

--- a/src/dynamics/solver/mod.rs
+++ b/src/dynamics/solver/mod.rs
@@ -556,7 +556,7 @@ fn prepare_contact_constraints(
             let tangents =
                 constraint.tangent_directions(body1.linear_velocity.0, body2.linear_velocity.0);
 
-            for point in manifold.points.iter().copied() {
+            for point in manifold.points.iter() {
                 // Use fixed world-space anchors.
                 // This improves rolling behavior for shapes like balls and capsules.
                 let anchor1 = point.anchor1;

--- a/src/tests/determinism_2d.rs
+++ b/src/tests/determinism_2d.rs
@@ -62,7 +62,7 @@ fn cross_platform_determinism_2d() {
     let hash = compute_hash(app.world(), query);
 
     // Update this value if simulation behavior changes.
-    let expected = 0x83514313;
+    let expected = 0x804f0822;
 
     assert!(
         hash == expected,

--- a/src/tests/determinism_2d.rs
+++ b/src/tests/determinism_2d.rs
@@ -62,7 +62,7 @@ fn cross_platform_determinism_2d() {
     let hash = compute_hash(app.world(), query);
 
     // Update this value if simulation behavior changes.
-    let expected = 0x804f0822;
+    let expected = 0x679775fa;
 
     assert!(
         hash == expected,

--- a/src/tests/determinism_2d.rs
+++ b/src/tests/determinism_2d.rs
@@ -62,7 +62,7 @@ fn cross_platform_determinism_2d() {
     let hash = compute_hash(app.world(), query);
 
     // Update this value if simulation behavior changes.
-    let expected = 0x98d5fcca;
+    let expected = 0x83514313;
 
     assert!(
         hash == expected,


### PR DESCRIPTION
# Objective

Currently, `ContacttPoint` stores a `local_point1` and `local_point2` on the surfaces of the two shapes. These are the closest points in local space.

However:

- The solver needs the world-space contact points relative to the centers of mass. The local points are not actually needed for anything, they are just the output of Parry.
- The solver should not be using the closest points for constraints. There should be a single world-space contact point that is the midpoint between the two closest points, and world-space anchors that correspond to this point.
- Users typically only need world-space values, but getting them currently requires manual transformations.
- For users, it is confusing that a `ClosestPoint` type actually stores two points, one for each shape.

We can do better! We can store the world-space anchors directly in `ContactPoint`, and also store a single world-space `point` for debugging and user convenience.

## Solution

Remove `local_point1` and `local_point2` in favor of a world-space `anchor1` and `anchor2` relative to the center of mass. These are computed in the narrow phase, removing the need to query for collider data in `prepare_contact_constraints`.

A world-space `point` for the midpoint between the closest points is now stored and used for debug rendering. The contact anchors point to this.

Additionally, I have exposed a `normal_speed` property for `ContactPoint`, computed by `ContactConstraint`.
It is computed before the solver, and can be used as an impact velocity to determine how "strong" the contact is in a mass-independent way. `-normal_speed` is equivalent to how fast the shapes are approaching each other at this point.

Unrelated to the core changes, I also fixed the linear part of the effective mass computation not taking locked axes into account.

---

## Migration Guide

The `local_point1` and `local_point2` properties of `ContactPoint` have been removed in favor of a world-space `anchor1` and `anchor2` relative to the center of mass.

The `global_point1` and `global_point2` methods have also been removed, but a new world-space `point` is available for the midpoint between the closest points.