### PR TITLE
Improve inverse angular inertia tensor computation

### DIFF
--- a/src/dynamics/rigid_body/mass_properties/mod.rs
+++ b/src/dynamics/rigid_body/mass_properties/mod.rs
@@ -336,7 +336,7 @@ impl Plugin for MassPropertyPlugin {
         // Update mass properties for entities with the `RecomputeMassProperties` component.
         app.add_systems(
             self.schedule,
-            (update_mass_properties, warn_missing_mass)
+            (update_mass_properties, warn_invalid_mass)
                 .chain()
                 .in_set(MassPropertySystems::UpdateComputedMassProperties),
         );
@@ -423,7 +423,7 @@ fn update_mass_properties(
 }
 
 /// Logs warnings when dynamic bodies have invalid [`Mass`] or [`AngularInertia`].
-fn warn_missing_mass(
+fn warn_invalid_mass(
     mut bodies: Query<
         (
             Entity,
@@ -435,11 +435,11 @@ fn warn_missing_mass(
     >,
 ) {
     for (entity, rb, mass, inertia) in &mut bodies {
-        let is_mass_valid = mass.value().is_finite();
+        let is_mass_valid = mass.is_finite();
         #[cfg(feature = "2d")]
-        let is_inertia_valid = inertia.value().is_finite();
+        let is_inertia_valid = inertia.is_finite();
         #[cfg(feature = "3d")]
-        let is_inertia_valid = inertia.value().is_finite();
+        let is_inertia_valid = inertia.is_finite();
 
         // Warn about dynamic bodies with no mass or inertia
         if rb.is_dynamic() && !(is_mass_valid && is_inertia_valid) {

--- a/src/dynamics/rigid_body/mass_properties/system_param.rs
+++ b/src/dynamics/rigid_body/mass_properties/system_param.rs
@@ -103,11 +103,9 @@ impl MassPropertyHelper<'_, '_> {
                 {
                     mass_props.principal_angular_inertia = angular_inertia.principal;
                     mass_props.local_inertial_frame = angular_inertia.local_frame;
-                    computed_inertia.set(
-                        mass_props
-                            .angular_inertia_tensor()
-                            .as_symmetric_mat3()
-                            .adjust_precision(),
+                    *computed_inertia = ComputedAngularInertia::new_with_local_frame(
+                        mass_props.principal_angular_inertia.adjust_precision(),
+                        mass_props.local_inertial_frame.adjust_precision(),
                     );
                 }
             }
@@ -118,11 +116,9 @@ impl MassPropertyHelper<'_, '_> {
             }
             #[cfg(feature = "3d")]
             {
-                computed_inertia.set(
-                    mass_props
-                        .angular_inertia_tensor()
-                        .as_symmetric_mat3()
-                        .adjust_precision(),
+                *computed_inertia = ComputedAngularInertia::new_with_local_frame(
+                    mass_props.principal_angular_inertia.adjust_precision(),
+                    mass_props.local_inertial_frame.adjust_precision(),
                 );
             }
         }


### PR DESCRIPTION
# Objective

Closes #629.

`ComputedAngularInertia` updates in 3D currently invert the tensor rather than inverting the principal moments of inertia and using those to construct the matrix. This is both less efficient and has a more limited range of supported inertia values, as the determinant gets close to zero.

## Solution

Invert the principal angular inertia vector instead. Testing with a cuboid, this brings the range of supported mass values from about about `1e13` to about `1e19`.