### PR TITLE
Fix `Plane3d` colliders ignoring half size

### DIFF
--- a/src/collision/collider/parry/primitives3d.rs
+++ b/src/collision/collider/parry/primitives3d.rs
@@ -29,7 +29,7 @@ impl IntoCollider<Collider> for InfinitePlane3d {
 
 impl IntoCollider<Collider> for Plane3d {
     fn collider(&self) -> Collider {
-        let half_size = self.half_size;
+        let half_size = self.half_size.adjust_precision();
         let rotation = Quaternion::from_rotation_arc(Vector::Y, self.normal.adjust_precision());
         let vertices = vec![
             rotation * Vector::new(half_size.x, 0.0, -half_size.y),

--- a/src/collision/collider/parry/primitives3d.rs
+++ b/src/collision/collider/parry/primitives3d.rs
@@ -17,10 +17,10 @@ impl IntoCollider<Collider> for Plane3d {
         let half_size = self.half_size;
         let rotation = Quaternion::from_rotation_arc(Vector::Y, self.normal.adjust_precision());
         let vertices = vec![
-            rotation * Vector::new(half_size, 0.0, -half_size),
-            rotation * Vector::new(-half_size, 0.0, -half_size),
-            rotation * Vector::new(-half_size, 0.0, half_size),
-            rotation * Vector::new(half_size, 0.0, half_size),
+            rotation * Vector::new(half_size.x, 0.0, -half_size.y),
+            rotation * Vector::new(-half_size.x, 0.0, -half_size.y),
+            rotation * Vector::new(-half_size.x, 0.0, half_size.y),
+            rotation * Vector::new(half_size.x, 0.0, half_size.y),
         ];
 
         Collider::trimesh(vertices, vec![[0, 1, 2], [1, 2, 0]])

--- a/src/collision/collider/parry/primitives3d.rs
+++ b/src/collision/collider/parry/primitives3d.rs
@@ -14,7 +14,7 @@ impl IntoCollider<Collider> for Sphere {
 
 impl IntoCollider<Collider> for Plane3d {
     fn collider(&self) -> Collider {
-        let half_size = 10_000.0;
+        let half_size = self.half_size;
         let rotation = Quaternion::from_rotation_arc(Vector::Y, self.normal.adjust_precision());
         let vertices = vec![
             rotation * Vector::new(half_size, 0.0, -half_size),

--- a/src/collision/collider/parry/primitives3d.rs
+++ b/src/collision/collider/parry/primitives3d.rs
@@ -1,6 +1,6 @@
 use bevy_math::primitives::{
-    BoxedPolyline3d, Capsule3d, Cone, Cuboid, Cylinder, Line3d, Plane3d, Polyline3d, Segment3d,
-    Sphere,
+    BoxedPolyline3d, Capsule3d, Cone, Cuboid, Cylinder, InfinitePlane3d, Line3d, Plane3d,
+    Polyline3d, Segment3d, Sphere,
 };
 use parry::shape::SharedShape;
 
@@ -9,6 +9,21 @@ use crate::{AdjustPrecision, Collider, IntoCollider, Quaternion, Vector};
 impl IntoCollider<Collider> for Sphere {
     fn collider(&self) -> Collider {
         Collider::sphere(self.radius.adjust_precision())
+    }
+}
+
+impl IntoCollider<Collider> for InfinitePlane3d {
+    fn collider(&self) -> Collider {
+        let half_size = 10_000.0;
+        let rotation = Quaternion::from_rotation_arc(Vector::Y, self.normal.adjust_precision());
+        let vertices = vec![
+            rotation * Vector::new(half_size, 0.0, -half_size),
+            rotation * Vector::new(-half_size, 0.0, -half_size),
+            rotation * Vector::new(-half_size, 0.0, half_size),
+            rotation * Vector::new(half_size, 0.0, half_size),
+        ];
+
+        Collider::trimesh(vertices, vec![[0, 1, 2], [1, 2, 0]])
     }
 }
 


### PR DESCRIPTION
# Objective

- While generating a navmesh for a tiny tiny scene, my AABB was surprisingly so huge that I ran out of RAM

## Solution

- Actually use the user-provided `half_size` instead of just using `10_000`. Note that that approach is alright for `InfinitePlane3d`, but not `Plane3d`
- Because it seemed like the original intent, I added support for `InfinitePlane3d` using the old behavior

-----

## Changelog

### Added

- Implemented `IntoCollider<Collider> for InfinitePlane3d`. This allows you to call `Collider::from` with `InfinitePlane3d`. Note that the resulting collider is not infinite, but simply has a huge half size of 10000 units.

## Migration

- Calling `Collider::from` with a `Plane3d` will now respect the plane's `half_size` instead of hardcoding it to 10000 units. If you depended on the old behavior, use `InfinitePlane3d` instead.