### PR TITLE
Contact pruning for 3D

### DIFF
--- a/src/collision/contact_types/mod.rs
+++ b/src/collision/contact_types/mod.rs
@@ -527,7 +527,7 @@ impl ContactManifold {
             }
         }
 
-        // C*onstruct the manifold, ensuring the order is correct to form a convex polygon.
+        // Construct the manifold, ensuring the order is correct to form a convex polygon.
         // TODO: The points in the manifold should be in an `ArrayVec`, and the input points should be separate.
         let points = core::mem::take(&mut self.points);
         self.points.push(points[point1_index]);

--- a/src/collision/contact_types/mod.rs
+++ b/src/collision/contact_types/mod.rs
@@ -464,7 +464,7 @@ impl ContactManifold {
         // Neither of these should become zero, so we clamp the minimum distance.
         const MIN_DISTANCE_SQUARED: Scalar = 1e-6;
 
-        // Project the contact points onto the contact normal and compute the squared penetrations depths.
+        // Project the contact points onto the contact normal and compute the squared penetration depths.
         let (projected, penetrations_squared): (Vec<Vector>, Vec<Scalar>) = self
             .points
             .iter()

--- a/src/collision/contact_types/mod.rs
+++ b/src/collision/contact_types/mod.rs
@@ -505,7 +505,7 @@ impl ContactManifold {
             }
         }
         debug_assert!(point2_index != usize::MAX, "No second point found");
-        let point2 = projected[point2_index as usize];
+        let point2 = projected[point2_index];
 
         // Find the farthest points on both sides of the line segment in order to maximize the area.
         let mut point3_index = usize::MAX;

--- a/src/collision/narrow_phase/system_param.rs
+++ b/src/collision/narrow_phase/system_param.rs
@@ -651,6 +651,12 @@ impl<C: AnyCollider> NarrowPhase<'_, '_, C> {
                             delta_distance - point.penetration < effective_speculative_margin
                         }
                     });
+
+                    // Prune extra contact points.
+                    #[cfg(feature = "3d")]
+                    if manifold.points.len() > 4 {
+                        manifold.prune_points();
+                    }
                 });
 
                 // Check if the colliders are now touching.


### PR DESCRIPTION
# Objective

Contact manifolds in 3D should be limited to 4 contact points. This is important for both stability and performance, especially when we implement wide SIMD contacts.

Some specific cases (some convex polyhedron collisions or possible custom shapes) can produce more than 4 points. We should have a contact pruning algorithm to get rid of these extra points.

## Solution

Implement a contact pruning algorithm that chooses the optimal points based on the distance to the center of mass, the penetration depth, and the contact area. The implementation is mostly based on Jolt.

In the future, we can combine this with a manifold reduction scheme that combines manifolds that have similar normals, pruning the resulting larger manifold.