### PR TITLE
Enable `smallvec/serde` when `serialize` is enabled

### DIFF
--- a/crates/avian2d/Cargo.toml
+++ b/crates/avian2d/Cargo.toml
@@ -57,6 +57,7 @@ serialize = [
     "bevy_transform_interpolation/serialize",
     "parry2d?/serde-serialize",
     "parry2d-f64?/serde-serialize",
+    "smallvec/serde",
     "bitflags/serde",
 ]
 

--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -59,6 +59,7 @@ serialize = [
     "bevy_transform_interpolation/serialize",
     "parry3d?/serde-serialize",
     "parry3d-f64?/serde-serialize",
+    "smallvec/serde",
     "bitflags/serde",
 ]
 


### PR DESCRIPTION
# Objective

The `serialize` feature is currently broken unless `smallvec/serde` is enabled.

## Solution

Enable `smallvec/serde` when `serialize` is enabled.