### PR TITLE
Allocate free IDs lowest-first using an `IdPool` for `StableUnGraph`

### DIFF
--- a/crates/avian2d/examples/determinism_2d.rs
+++ b/crates/avian2d/examples/determinism_2d.rs
@@ -194,17 +194,12 @@ fn clear_scene(
             With<Camera>,
         )>,
     >,
-    mut collisions: Collisions,
     mut step: ResMut<Step>,
 ) {
     step.0 = 0;
     for entity in &query {
         commands.entity(entity).despawn();
     }
-
-    // We need to clear the contact graph and constraint graph to make sure
-    // that previous contacts and constraints do not affect the simulation.
-    collisions.clear();
 }
 
 #[derive(Pod, Zeroable, Clone, Copy)]

--- a/src/collision/contact_types/contact_graph.rs
+++ b/src/collision/contact_types/contact_graph.rs
@@ -814,18 +814,16 @@ impl ContactGraph {
 
     /// Clears all contact pairs and the contact graph.
     ///
-    /// This can be useful to ensure that the world is in a clean state
-    /// when for example reloading a scene or resetting the physics world.
-    ///
     /// # Warning
     ///
-    /// This does *not* clear the [`ConstraintGraph`]! You should additionally
-    /// call [`ConstraintGraph::clear`], or alternatively use [`Collisions::clear`]
-    /// that clears both resources.
+    /// Clearing contact pairs with this method will *not* trigger any collision events
+    /// or wake up the entities involved. Only use this method if you know what you are doing.
+    ///
+    /// Additionally, this does *not* clear the [`ConstraintGraph`]! You should additionally
+    /// call [`ConstraintGraph::clear`].
     ///
     /// [`ConstraintGraph`]: crate::dynamics::solver::constraint_graph::ConstraintGraph
     /// [`ConstraintGraph::clear`]: crate::dynamics::solver::constraint_graph::ConstraintGraph::clear
-    /// [`Collisions::clear`]: crate::collision::contact_types::Collisions::clear
     #[inline]
     pub fn clear(&mut self) {
         self.edges.clear();

--- a/src/collision/contact_types/system_param.rs
+++ b/src/collision/contact_types/system_param.rs
@@ -1,6 +1,4 @@
-use crate::{
-    data_structures::pair_key::PairKey, dynamics::solver::constraint_graph::ConstraintGraph,
-};
+use crate::data_structures::pair_key::PairKey;
 use bevy::{ecs::system::SystemParam, prelude::*};
 
 use super::{ContactGraph, ContactPair};
@@ -55,8 +53,6 @@ use super::{ContactGraph, ContactPair};
 pub struct Collisions<'w> {
     /// The [`ContactGraph`] that stores all contact edges.
     contact_graph: ResMut<'w, ContactGraph>,
-    /// The [`ConstraintGraph`] that stores all contact constraints.
-    constraint_graph: ResMut<'w, ConstraintGraph>,
 }
 
 impl Collisions<'_> {
@@ -124,15 +120,5 @@ impl Collisions<'_> {
                 contacts.collider1
             }
         })
-    }
-
-    /// Clears the [`ContactGraph`] and [`ConstraintGraph`].
-    ///
-    /// This can be useful to ensure that the world is in a clean state
-    /// when for example reloading a scene or resetting the physics world.
-    #[inline]
-    pub fn clear(&mut self) {
-        self.contact_graph.clear();
-        self.constraint_graph.clear();
     }
 }

--- a/src/data_structures/id_pool.rs
+++ b/src/data_structures/id_pool.rs
@@ -1,0 +1,91 @@
+//! An [`IdPool`] for managing and reusing identifiers.
+
+use alloc::collections::BinaryHeap;
+use core::cmp::Reverse;
+
+/// A pool for efficient allocation and reuse of `u32` identifiers.
+///
+/// Freed IDs are stored in a min-heap, and reused such that the lowest available IDs are allocated first.
+#[derive(Clone, Debug, Default)]
+pub struct IdPool {
+    /// A min-heap of free IDs. The lowest free IDs are allocated first.
+    free_ids: BinaryHeap<Reverse<u32>>,
+    /// The next ID to be allocated. Only incremented when no free IDs are available.
+    next_index: u32,
+}
+
+impl IdPool {
+    /// Creates a new empty [`IdPool`].
+    #[inline(always)]
+    pub const fn new() -> Self {
+        Self {
+            free_ids: BinaryHeap::new(),
+            next_index: 0,
+        }
+    }
+
+    /// Creates a new [`IdPool`] with the given initial capacity.
+    ///
+    /// This is useful for preallocating space for IDs to avoid reallocations.
+    #[inline(always)]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            free_ids: BinaryHeap::with_capacity(capacity),
+            next_index: 0,
+        }
+    }
+
+    /// Allocates a new ID.
+    ///
+    /// If there are free IDs available, the lowest free ID is reused.
+    #[inline(always)]
+    pub fn alloc(&mut self) -> u32 {
+        if let Some(id) = self.free_ids.pop() {
+            id.0
+        } else {
+            let id = self.next_index;
+            self.next_index += 1;
+            id
+        }
+    }
+
+    /// Frees an ID, making it available for reuse.
+    ///
+    /// The ID is assumed to not already be freed.
+    #[inline(always)]
+    pub fn free(&mut self, id: u32) {
+        debug_assert!(id < self.next_index);
+        self.free_ids.push(Reverse(id));
+    }
+
+    /// Clears the pool, removing all free IDs and resetting the next index.
+    #[inline(always)]
+    pub fn clear(&mut self) {
+        self.free_ids.clear();
+        self.next_index = 0;
+    }
+
+    /// Returns the number of allocated IDs.
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.next_index as usize - self.free_ids.len()
+    }
+
+    /// Returns the number of free IDs.
+    #[inline(always)]
+    pub fn free_len(&self) -> usize {
+        self.free_ids.len()
+    }
+
+    /// Returns the total number of IDs (allocated + free).
+    #[inline(always)]
+    pub fn total_len(&self) -> usize {
+        self.next_index as usize
+    }
+
+    /// Returns `true` if the pool is empty (no allocated IDs).
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}

--- a/src/data_structures/id_pool.rs
+++ b/src/data_structures/id_pool.rs
@@ -7,6 +7,7 @@ use core::cmp::Reverse;
 ///
 /// Freed IDs are stored in a min-heap, and reused such that the lowest available IDs are allocated first.
 #[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct IdPool {
     /// A min-heap of free IDs. The lowest free IDs are allocated first.
     free_ids: BinaryHeap<Reverse<u32>>,

--- a/src/data_structures/mod.rs
+++ b/src/data_structures/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod bit_vec;
 pub mod graph;
+pub mod id_pool;
 pub mod pair_key;
 pub mod sparse_secondary_map;
 pub mod stable_graph;

--- a/src/data_structures/stable_graph.rs
+++ b/src/data_structures/stable_graph.rs
@@ -1,6 +1,8 @@
-//! A stripped down version of petgraph's `StableUnGraph`.
+//! A stripped down and modified version of petgraph's `StableUnGraph`.
 //!
 //! - Index types always use `u32`.
+//! - Instead of free lists, [`IdPool`]s are used to allocate and free nodes and edges.
+//! - Vacant nodes and edges are occupied in the order of lowest index first.
 //! - Edge iteration order after serialization/deserialization is preserved.
 //! - Fewer iterators and helpers, and a few new ones.
 

--- a/src/data_structures/stable_graph.rs
+++ b/src/data_structures/stable_graph.rs
@@ -5,46 +5,28 @@
 //! - Fewer iterators and helpers, and a few new ones.
 
 use super::graph::{Edge, EdgeDirection, EdgeIndex, Node, NodeIndex, Pair, UnGraph, index_twice};
+use super::id_pool::IdPool;
 
 /// A graph with undirected edges and stable indices.
 ///
 /// Unlike [`UnGraph`], this graph *does not* invalidate any unrelated
-/// node or edge indices when items are removed.  This stable order
-/// is achieved by using a free list for both nodes and edges.
+/// node or edge indices when items are removed. Removed nodes and edges
+/// are replaced with vacant slots, which can be reused later in order
+/// of lowest index first.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct StableUnGraph<N, E> {
     graph: UnGraph<Option<N>, Option<E>>,
-    node_count: usize,
-    edge_count: usize,
-
-    // Node and edge free lists both work the same way.
-    //
-    // `free_node`, if not `NodeIndex::END`, points to a node index
-    // that is vacant (after a deletion).
-    //
-    // The free nodes form a doubly linked list using the field's `node.next[0]`
-    // for forward references and `node.next[1]` for backwards ones.
-    //
-    // The nodes are stored as `EdgeIndex`, and the `_into_edge()`/`_into_node()`
-    // methods convert.
-    //
-    // `free_edge`, if not `EdgeIndex::END`, points to a free edge.
-    //
-    // The edges only form a singly linked list using `edge.next[0]` to store
-    // the forward reference.
-    free_node: NodeIndex,
-    free_edge: EdgeIndex,
+    node_ids: IdPool,
+    edge_ids: IdPool,
 }
 
 impl<N, E> Default for StableUnGraph<N, E> {
     fn default() -> Self {
         StableUnGraph {
             graph: UnGraph::default(),
-            node_count: 0,
-            edge_count: 0,
-            free_node: NodeIndex::END,
-            free_edge: EdgeIndex::END,
+            node_ids: IdPool::new(),
+            edge_ids: IdPool::new(),
         }
     }
 }
@@ -54,10 +36,8 @@ impl<N, E> StableUnGraph<N, E> {
     pub fn with_capacity(nodes: usize, edges: usize) -> Self {
         StableUnGraph {
             graph: UnGraph::with_capacity(nodes, edges),
-            node_count: 0,
-            edge_count: 0,
-            free_node: NodeIndex::END,
-            free_edge: EdgeIndex::END,
+            node_ids: IdPool::with_capacity(nodes),
+            edge_ids: IdPool::with_capacity(edges),
         }
     }
 
@@ -65,14 +45,14 @@ impl<N, E> StableUnGraph<N, E> {
     ///
     /// Computes in **O(1)** time.
     pub fn node_count(&self) -> usize {
-        self.node_count
+        self.node_ids.len()
     }
 
     /// Returns the number of edges in the graph.
     ///
     /// Computes in **O(1)** time.
     pub fn edge_count(&self) -> usize {
-        self.edge_count
+        self.edge_ids.len()
     }
 
     /// Adds a node (also called vertex) with associated data `weight` to the graph.
@@ -85,21 +65,20 @@ impl<N, E> StableUnGraph<N, E> {
     ///
     /// Panics if the graph is at the maximum number of nodes.
     pub fn add_node(&mut self, weight: N) -> NodeIndex {
-        if self.free_node != NodeIndex::END {
+        // Allocate a node ID.
+        let node_idx = NodeIndex(self.node_ids.alloc());
+
+        if node_idx.index() != self.graph.nodes.len() {
             // Reuse a free node.
-            let node_idx = self.free_node;
             self.occupy_vacant_node(node_idx, weight);
             node_idx
         } else {
             // Create a new node.
-            let node = self.graph.add_node(Some(weight));
-            self.node_count += 1;
-            node
+            self.graph.add_node(Some(weight))
         }
     }
 
-    /// Creates a new node using a vacant position,
-    /// updating the doubly linked list of free nodes.
+    /// Creates a new node using a vacant position.
     fn occupy_vacant_node(&mut self, node_idx: NodeIndex, weight: N) {
         let node_slot = &mut self.graph.nodes[node_idx.index()];
 
@@ -116,11 +95,6 @@ impl<N, E> StableUnGraph<N, E> {
         if next_node != EdgeIndex::END {
             self.graph.nodes[next_node.index()].next[1] = previous_node;
         }
-        if self.free_node == node_idx {
-            self.free_node = NodeIndex(next_node.0);
-        }
-
-        self.node_count += 1;
     }
 
     /// Returns the node at index `a` if it is not vacant.
@@ -158,17 +132,19 @@ impl<N, E> StableUnGraph<N, E> {
         {
             let edge: &mut Edge<Option<E>>;
 
-            if self.free_edge != EdgeIndex::END {
-                edge_idx = self.free_edge;
+            // Allocate an edge ID.
+            edge_idx = EdgeIndex(self.edge_ids.alloc());
+
+            if edge_idx.index() != self.graph.edges.len() {
+                // Reuse a free edge.
                 edge = &mut self.graph.edges[edge_idx.index()];
 
                 let _old = edge.weight.replace(weight);
                 debug_assert!(_old.is_none());
 
-                self.free_edge = edge.next[0];
                 edge.node = [a, b];
             } else {
-                edge_idx = EdgeIndex(self.graph.edges.len() as u32);
+                // Create a new edge.
                 assert!(edge_idx != EdgeIndex::END);
                 new_edge = Some(Edge {
                     weight: Some(weight),
@@ -191,7 +167,7 @@ impl<N, E> StableUnGraph<N, E> {
                     }
                 }
                 Pair::Both(an, bn) => {
-                    // a and b are different indices
+                    // `a` and `b` are different indices.
                     if an.weight.is_none() {
                         Some(a.index())
                     } else if bn.weight.is_none() {
@@ -209,8 +185,6 @@ impl<N, E> StableUnGraph<N, E> {
                 wrong_index.is_none(),
                 "Tried adding an edge to a non-existent node."
             );
-
-            self.edge_count += 1;
         }
 
         if let Some(edge) = new_edge {
@@ -292,15 +266,11 @@ impl<N, E> StableUnGraph<N, E> {
             }
         }
 
+        // Clear the node and free its ID.
         let node_slot = &mut self.graph.nodes[a.index()];
-        node_slot.next = [EdgeIndex(self.free_node.0), EdgeIndex::END];
+        node_slot.next = [EdgeIndex::END; 2];
 
-        if self.free_node != NodeIndex::END {
-            self.graph.nodes[self.free_node.index()].next[1] = EdgeIndex(a.0);
-        }
-
-        self.free_node = a;
-        self.node_count -= 1;
+        self.node_ids.free(a.0);
 
         Some(node_weight)
     }
@@ -327,12 +297,13 @@ impl<N, E> StableUnGraph<N, E> {
         // a link to the next in the list.
         self.graph.change_edge_links(edge_node, e, edge_next);
 
-        // Clear the edge and put it in the free list.
+        // Clear the edge and free its ID.
         let edge_slot = &mut self.graph.edges[e.index()];
-        edge_slot.next = [self.free_edge, EdgeIndex::END];
+        edge_slot.next = [EdgeIndex::END; 2];
         edge_slot.node = [NodeIndex::END; 2];
-        self.free_edge = e;
-        self.edge_count -= 1;
+
+        self.edge_ids.free(e.0);
+
         edge_slot.weight.take()
     }
 
@@ -446,20 +417,17 @@ impl<N, E> StableUnGraph<N, E> {
 
     /// Removes all nodes and edges.
     pub fn clear(&mut self) {
-        self.node_count = 0;
-        self.edge_count = 0;
-        self.free_node = NodeIndex::END;
-        self.free_edge = EdgeIndex::END;
         self.graph.clear();
+        self.node_ids.clear();
+        self.edge_ids.clear();
     }
 
     /// Removes all edges.
     pub fn clear_edges(&mut self) {
-        self.edge_count = 0;
-        self.free_edge = EdgeIndex::END;
         self.graph.edges.clear();
+        self.edge_ids.clear();
 
-        // Clear edges without touching the free list.
+        // Clear edge links for all nodes.
         for node in &mut self.graph.nodes {
             if node.weight.is_some() {
                 node.next = [EdgeIndex::END, EdgeIndex::END];

--- a/src/dynamics/solver/constraint_graph.rs
+++ b/src/dynamics/solver/constraint_graph.rs
@@ -289,18 +289,13 @@ impl ConstraintGraph {
 
     /// Clears the constraint graph, removing all colors and their contents.
     ///
-    /// This can be useful to ensure that the world is in a clean state
-    /// when for example reloading a scene or resetting the physics world.
-    ///
     /// # Warning
     ///
     /// This does *not* clear the [`ContactGraph`]! You should additionally
-    /// call [`ContactGraph::clear`], or alternatively use [`Collisions::clear`]
-    /// that clears both resources.
+    /// call [`ContactGraph::clear`].
     ///
     /// [`ContactGraph`]: crate::collision::contact_types::ContactGraph
     /// [`ContactGraph::clear`]: crate::collision::contact_types::ContactGraph::clear
-    /// [`Collisions::clear`]: crate::collision::contact_types::Collisions::clear
     pub fn clear(&mut self) {
         for color in &mut self.colors {
             color.body_set.clear();

--- a/src/tests/determinism_2d.rs
+++ b/src/tests/determinism_2d.rs
@@ -60,7 +60,7 @@ fn cross_platform_determinism_2d() {
     let hash = compute_hash(app.world(), query);
 
     // Update this value if simulation behavior changes.
-    let expected = 0x8d1e9d85;
+    let expected = 0x2cfb788d;
 
     assert!(
         hash == expected,


### PR DESCRIPTION
# Objective

Contact pairs maintain stable indices using the `StableUnGraph`. It marks removes nodes and edges and vacant, and uses linked lists for free node and edge lists.

This results in reusing nodes and edges in removal order. The problem is that it causes perceived determinism issues when contacts are removed: when "restarting" a scene, old freed contacts affect the order of new reused contact edges, often causing different results. This can be seen in the `determinism_2d` example; respawning the scene produces different results *unless* the contact graph is cleared.

Ideally, this should not be something users need to worry about. Respawning the same scene should produce the same results each time without clearing any caches. This PR aims to fix this by allocating freed contact IDs in a lowest-first order, not in removal order.

## Solution

Add an `IdPool` that stores freed `u32` IDs in a min-heap, and use it for the free lists in the `StableUnGraph`. This way, the lowest IDs are allocated first.

Running the `determinism_2d` example, it is no longer necessary to manually clear any cached contact data to get deterministic results when resetting the scene.