### PR TITLE
Remove `count` from `RayHitData` and `ShapeHitData`

### DIFF
--- a/src/spatial_query/shape_caster.rs
+++ b/src/spatial_query/shape_caster.rs
@@ -505,10 +505,8 @@ impl ShapeCastConfig {
 /// # Example
 ///
 /// ```
-/// # #[cfg(feature = "2d")]
-/// # use avian2d::prelude::*;
-/// # #[cfg(feature = "3d")]
-/// use avian3d::prelude::*;
+#[cfg_attr(feature = "2d", doc = "use avian2d::prelude::*;")]
+#[cfg_attr(feature = "3d", doc = "use avian3d::prelude::*;")]
 /// use bevy::prelude::*;
 ///
 /// fn print_hits(query: Query<&ShapeHits, With<ShapeCaster>>) {


### PR DESCRIPTION
# Objective

`RayHits` and `ShapeHits` currently store a `count` property, and try to avoid clearing the vectors. However, clearing and pushing to an already allocated vector is very cheap, so we should just do that.

## Solution

Remove `count` from `RayHits` and `ShapeHits` and clean up the APIs.