### PR TITLE
Check minimal features in CI

### DIFF
--- a/src/collision/collider/mod.rs
+++ b/src/collision/collider/mod.rs
@@ -31,6 +31,10 @@ pub use layers::*;
     any(feature = "parry-f32", feature = "parry-f64")
 ))]
 mod parry;
+#[cfg(all(
+    feature = "default-collider",
+    any(feature = "parry-f32", feature = "parry-f64")
+))]
 pub use parry::*;
 
 #[cfg(feature = "default-collider")]


### PR DESCRIPTION
# Objective

Minimal feature configurations are easy to break accidentally. We should check them in CI.

## Solution

Change the "Check" job to "Check Minimal Features". The test suites run with (nearly) all features anyway, so they check those.