### PR TITLE
fix doc example for `shape_hits` 

### DIFF
--- a/src/spatial_query/system_param.rs
+++ b/src/spatial_query/system_param.rs
@@ -522,7 +522,7 @@ impl SpatialQuery<'_, '_> {
     ///     let filter = SpatialQueryFilter::default();
     ///
     ///     // Cast shape and get up to 20 hits
-    ///     let hits = spatial_query.cast_shape(&shape, origin, rotation, direction, 20, &config, &filter);
+    ///     let hits = spatial_query.shape_hits(&shape, origin, rotation, direction, 20, &config, &filter);
     ///
     ///     // Print hits
     ///     for hit in hits.iter() {


### PR DESCRIPTION
# Objective

Small doc change for `shape_hits` as the example is incorrect. Was a compile error and quickly solved it!

## Solution

Just changed text :smile: 