### PR TITLE
Fix temporaries in bevy-0.17 branch

### DIFF
--- a/src/dynamics/solver/joint_graph/plugin.rs
+++ b/src/dynamics/solver/joint_graph/plugin.rs
@@ -162,8 +162,10 @@ fn on_add_joint<T: Component + EntityConstraint<2>>(mut world: DeferredWorld, ct
 
             // Log a warning about the joint replacement in case it was not intentional.
             let components = world.components();
-            let old_joint_name = ShortName(&components.get_info(old_joint).unwrap().name());
-            let new_joint_name = ShortName(&components.get_info(component_id).unwrap().name());
+            let old_joint_shortname = components.get_info(old_joint).unwrap().name();
+            let old_joint_name = ShortName(&old_joint_shortname);
+            let new_joint_shortname = components.get_info(component_id).unwrap().name();
+            let new_joint_name = ShortName(&new_joint_shortname);
 
             warn!(
                 "{old_joint_name} was replaced with {new_joint_name} on entity {entity}. An entity can only hold one joint type at a time."

--- a/src/spatial_query/pipeline.rs
+++ b/src/spatial_query/pipeline.rs
@@ -168,8 +168,8 @@ impl SpatialQueryPipeline {
         filter: &SpatialQueryFilter,
         predicate: &dyn Fn(Entity) -> bool,
     ) -> Option<RayHitData> {
-        let pipeline_shape =
-            CompositeShapeRef(&self.as_composite_shape_with_predicate(filter, predicate));
+        let composite = self.as_composite_shape_with_predicate(filter, predicate);
+        let pipeline_shape = CompositeShapeRef(&composite);
         let ray = parry::query::Ray::new(origin.into(), direction.adjust_precision().into());
 
         pipeline_shape
@@ -366,8 +366,8 @@ impl SpatialQueryPipeline {
 
         let shape_isometry = make_isometry(origin, rotation);
         let shape_direction = direction.adjust_precision().into();
-        let pipeline_shape =
-            CompositeShapeRef(&self.as_composite_shape_with_predicate(filter, predicate));
+        let composite = self.as_composite_shape_with_predicate(filter, predicate);
+        let pipeline_shape = CompositeShapeRef(&composite);
 
         pipeline_shape
             .cast_shape(
@@ -493,7 +493,8 @@ impl SpatialQueryPipeline {
         let shape_direction = direction.adjust_precision().into();
 
         loop {
-            let pipeline_shape = CompositeShapeRef(&self.as_composite_shape(&query_filter));
+            let composite = self.as_composite_shape(&query_filter);
+            let pipeline_shape = CompositeShapeRef(&composite);
 
             let hit = pipeline_shape
                 .cast_shape(
@@ -572,8 +573,8 @@ impl SpatialQueryPipeline {
         }
 
         let point = point.into();
-        let pipeline_shape =
-            CompositeShapeRef(&self.as_composite_shape_with_predicate(filter, predicate));
+        let composite = self.as_composite_shape_with_predicate(filter, predicate);
+        let pipeline_shape = CompositeShapeRef(&composite);
 
         let (index, projection) = pipeline_shape.project_local_point(&point, solid);
 

--- a/src/spatial_query/shape_caster.rs
+++ b/src/spatial_query/shape_caster.rs
@@ -370,8 +370,8 @@ impl ShapeCaster {
         let shape_direction = self.global_direction().adjust_precision().into();
 
         while hits.len() < self.max_hits as usize {
-            let pipeline_shape =
-                CompositeShapeRef(&query_pipeline.as_composite_shape(&query_filter));
+            let composite = query_pipeline.as_composite_shape(&query_filter);
+            let pipeline_shape = CompositeShapeRef(&composite);
 
             let hit = pipeline_shape
                 .cast_shape(


### PR DESCRIPTION
fix "temporaries freed while still in use" across a couple of function uses.

## Solution

I took the approach of keeping the clones of things like `DebugName` from the `.name` function, etc and instead stored the value so it could be referenced, since the usage relies on deref coercion to go from `DebugName` to `&str`.


The examples run after this fix