### PR TITLE
Bump derive_more to v2

### DIFF
--- a/crates/avian2d/Cargo.toml
+++ b/crates/avian2d/Cargo.toml
@@ -95,7 +95,7 @@ parry2d = { version = "0.21", optional = true }
 parry2d-f64 = { version = "0.21", optional = true }
 nalgebra = { version = "0.33", features = ["convert-glam029"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
-derive_more = "1"
+derive_more = "2"
 thiserror = "2"
 arrayvec = "0.7"
 smallvec = "1.15"

--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -97,7 +97,7 @@ parry3d = { version = "0.21", optional = true }
 parry3d-f64 = { version = "0.21", optional = true }
 nalgebra = { version = "0.33", features = ["convert-glam029"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
-derive_more = "1"
+derive_more = "2"
 thiserror = "2"
 smallvec = "1.15"
 itertools = "0.13"


### PR DESCRIPTION
# Objective

Stop receiving a weird error `could not compile derive_more: at least one derive feature must be enabled`.

## Solution

Update `derive_more` to v2. This is aligned with they version used by Bevy in `0.17`.