### PR TITLE
Improve tunneling prevention by solving static contacts last

### DIFF
--- a/src/tests/determinism_2d.rs
+++ b/src/tests/determinism_2d.rs
@@ -60,7 +60,7 @@ fn cross_platform_determinism_2d() {
     let hash = compute_hash(app.world(), query);
 
     // Update this value if simulation behavior changes.
-    let expected = 0x543aed6d;
+    let expected = 0x4fbe94b5;
 
     assert!(
         hash == expected,


### PR DESCRIPTION
# Objective

Currently, static contacts are mixed with dynamic contacts starting from the second graph color. To improve tunneling prevention, it'd be better to reserve some colors just for static contacts, and to solve them last.

## Solution

- Increase the `GRAPH_COLOR_COUNT` from 12 to 24
- Reserve some colors just for static contacts, and build static colors from the end to give them higher priority

In the future, we could consider using dedicated one-body contact constraints for the static colors to further optimize things.