### PR TITLE
Gate island validation behind `validate` feature

### DIFF
--- a/crates/avian2d/Cargo.toml
+++ b/crates/avian2d/Cargo.toml
@@ -71,6 +71,9 @@ bevy_diagnostic = []
 # Enables the `PhysicsDiagnosticsUiPlugin` for visualizing physics diagnostics data with a debug UI.
 diagnostic_ui = ["bevy_diagnostic", "bevy/bevy_ui"]
 
+# Enables additional correctness checks and validation at the cost of worse performance.
+validate = []
+
 [lib]
 name = "avian2d"
 path = "../../src/lib.rs"

--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -73,6 +73,9 @@ bevy_diagnostic = []
 # Enables the `PhysicsDiagnosticsUiPlugin` for visualizing physics diagnostics data with a debug UI.
 diagnostic_ui = ["bevy_diagnostic", "bevy/bevy_ui"]
 
+# Enables additional correctness checks and validation at the cost of worse performance.
+validate = []
+
 [lib]
 name = "avian3d"
 path = "../../src/lib.rs"

--- a/src/dynamics/solver/islands/mod.rs
+++ b/src/dynamics/solver/islands/mod.rs
@@ -568,7 +568,7 @@ impl PhysicsIslands {
 
         island.contact_count += 1;
 
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "validate")]
         {
             // Validate the island.
             island.validate(
@@ -587,6 +587,10 @@ impl PhysicsIslands {
     /// The [`PhysicsIsland::constraints_removed`] counter is incremented.
     ///
     /// Called when a contact is destroyed or no longer touching.
+    #[expect(
+        unused_variables,
+        reason = "additional parameters are needed with the `validate` feature"
+    )]
     pub fn remove_contact(
         &mut self,
         contact_id: ContactId,
@@ -647,7 +651,7 @@ impl PhysicsIslands {
         island.contact_count -= 1;
         island.constraints_removed += 1;
 
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "validate")]
         {
             // Validate the island.
             island.validate(&body_islands.as_readonly(), contact_graph, joint_graph);
@@ -716,7 +720,7 @@ impl PhysicsIslands {
 
         island.joint_count += 1;
 
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "validate")]
         {
             // Validate the island.
             island.validate(
@@ -737,6 +741,10 @@ impl PhysicsIslands {
     /// The joint should be removed from the [`JointGraph`] in concert with calling this method.
     ///
     /// Called when a joint is destroyed or no longer connected to the bodies.
+    #[expect(
+        unused_variables,
+        reason = "additional parameters are needed with the `validate` feature"
+    )]
     pub fn remove_joint(
         &mut self,
         joint_id: JointId,
@@ -787,7 +795,7 @@ impl PhysicsIslands {
         island.joint_count -= 1;
         island.constraints_removed += 1;
 
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "validate")]
         {
             // Validate the island.
             island.validate(
@@ -967,7 +975,7 @@ impl PhysicsIslands {
             big.sleep_timer = small.sleep_timer.max(big.sleep_timer);
         }
 
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "validate")]
         {
             // Validate the big island.
             big.validate(
@@ -1008,7 +1016,7 @@ impl PhysicsIslands {
             return;
         }
 
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "validate")]
         {
             // Validate the island before splitting.
             island.validate(
@@ -1246,7 +1254,7 @@ impl PhysicsIslands {
                 }
             }
 
-            #[cfg(debug_assertions)]
+            #[cfg(feature = "validate")]
             {
                 // Validate the new island.
                 island.validate(
@@ -1341,6 +1349,7 @@ impl BodyIslandNode {
         debug_assert!(island.body_count > 0);
         island.body_count -= 1;
 
+        #[cfg(feature = "validate")]
         let mut island_removed = false;
 
         if island.head_body == Some(ctx.entity) {
@@ -1355,13 +1364,17 @@ impl BodyIslandNode {
                 world
                     .resource_mut::<PhysicsIslands>()
                     .remove_island(island_id);
-                island_removed = true;
+
+                #[cfg(feature = "validate")]
+                {
+                    island_removed = true;
+                }
             }
         } else if island.tail_body == Some(ctx.entity) {
             island.tail_body = prev_body_entity;
         }
 
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "validate")]
         if !island_removed {
             // Validate the island.
             world.commands().queue(move |world: &mut World| {

--- a/src/dynamics/solver/joint_graph/plugin.rs
+++ b/src/dynamics/solver/joint_graph/plugin.rs
@@ -204,7 +204,7 @@ fn on_add_joint(mut world: DeferredWorld, ctx: HookContext) {
         // Joint already exists, remove the old one.
         world.commands().entity(entity).remove_by_id(old_joint);
 
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "validate")]
         {
             use disqualified::ShortName;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@
 //! | `parallel`             | Enables some extra multithreading, which improves performance for larger simulations but can add some overhead for smaller ones.                    | Yes             |
 //! | `simd`                 | Enables [SIMD] optimizations.                                                                                                                       | No              |
 //! | `serialize`            | Enables support for serialization and deserialization using Serde.                                                                                  | No              |
+//! | `validate`             | Enables additional correctness checks and validation at the cost of worse performance.                                                              | No              |
 //!
 //! [`bevy_picking`]: bevy::picking
 //! [physics diagnostics]: diagnostics


### PR DESCRIPTION
# Objective

Island validation is currently enabled if `debug_assertions` are enabled. However, it can be very costly, destroying the performance of debug builds.

Validation should be behind its own feature flag.

## Solution

Add a `validate` feature, and gate island validation behind it.