### PR TITLE
Show debug gizmos for interpolated transforms

### DIFF
--- a/crates/avian2d/examples/debugdump_2d.rs
+++ b/crates/avian2d/examples/debugdump_2d.rs
@@ -8,7 +8,7 @@ use bevy::prelude::*;
 fn main() {
     let mut app = App::new();
 
-    app.add_plugins((PhysicsPlugins::default(), PhysicsDebugPlugin::default()));
+    app.add_plugins((PhysicsPlugins::default(), PhysicsDebugPlugin));
 
     // Schedules of interest:
     // - PhysicsSchedule

--- a/crates/avian2d/examples/determinism_2d.rs
+++ b/crates/avian2d/examples/determinism_2d.rs
@@ -35,7 +35,7 @@ fn main() {
         .add_plugins((
             DefaultPlugins,
             PhysicsPlugins::default().with_length_unit(0.5),
-            PhysicsDebugPlugin::default(),
+            PhysicsDebugPlugin,
         ))
         .init_resource::<Step>()
         .add_systems(Startup, (setup_scene, setup_ui))

--- a/crates/avian3d/examples/debugdump_3d.rs
+++ b/crates/avian3d/examples/debugdump_3d.rs
@@ -8,7 +8,7 @@ use bevy::prelude::*;
 fn main() {
     let mut app = App::new();
 
-    app.add_plugins((PhysicsPlugins::default(), PhysicsDebugPlugin::default()));
+    app.add_plugins((PhysicsPlugins::default(), PhysicsDebugPlugin));
 
     // Schedules of interest:
     // - PhysicsSchedule

--- a/crates/avian3d/examples/distance_joint_3d.rs
+++ b/crates/avian3d/examples/distance_joint_3d.rs
@@ -8,7 +8,7 @@ fn main() {
             DefaultPlugins,
             ExampleCommonPlugin,
             PhysicsPlugins::default(),
-            PhysicsDebugPlugin::default(),
+            PhysicsDebugPlugin,
         ))
         .add_systems(Startup, setup)
         .run();

--- a/crates/examples_common_2d/src/lib.rs
+++ b/crates/examples_common_2d/src/lib.rs
@@ -42,7 +42,7 @@ impl Plugin for ExampleCommonPlugin {
         // Add the physics debug plugin automatically if the `use-debug-plugin` feature is enabled
         // and the plugin is not already added.
         if !app.is_plugin_added::<PhysicsDebugPlugin>() {
-            app.add_plugins(PhysicsDebugPlugin::default());
+            app.add_plugins(PhysicsDebugPlugin);
         }
     }
 }

--- a/crates/examples_common_3d/src/lib.rs
+++ b/crates/examples_common_3d/src/lib.rs
@@ -42,7 +42,7 @@ impl Plugin for ExampleCommonPlugin {
         // Add the physics debug plugin automatically if the `use-debug-plugin` feature is enabled
         // and the plugin is not already added.
         if !app.is_plugin_added::<PhysicsDebugPlugin>() {
-            app.add_plugins(PhysicsDebugPlugin::default());
+            app.add_plugins(PhysicsDebugPlugin);
         }
     }
 }

--- a/src/debug_render/configuration.rs
+++ b/src/debug_render/configuration.rs
@@ -21,7 +21,7 @@ use bevy::{color::palettes::css::*, prelude::*};
 ///             DefaultPlugins,
 ///             PhysicsPlugins::default(),
 ///             // Enables debug rendering
-///             PhysicsDebugPlugin::default(),
+///             PhysicsDebugPlugin,
 ///         ))
 ///         // Overwrite default debug rendering configuration (optional)
 ///         .insert_gizmo_config(
@@ -396,7 +396,7 @@ impl PhysicsGizmos {
 ///             DefaultPlugins,
 ///             PhysicsPlugins::default(),
 ///             // Enables debug rendering
-///             PhysicsDebugPlugin::default(),
+///             PhysicsDebugPlugin,
 ///         ))
 ///         .run();
 /// }

--- a/src/debug_render/mod.rs
+++ b/src/debug_render/mod.rs
@@ -59,7 +59,7 @@ use bevy::{
 ///             DefaultPlugins,
 ///             PhysicsPlugins::default(),
 ///             // Enables debug rendering
-///             PhysicsDebugPlugin::default(),
+///             PhysicsDebugPlugin,
 ///         ))
 ///         // Overwrite default debug rendering configuration (optional)
 ///         .insert_gizmo_config(


### PR DESCRIPTION
# Objective

Debug gizmos are outdated by one frame

## Solution

Use GlobalTransform. This will also factor in interpolation to have less jittery debugs.
I believe this implementation still leaves the gizmos of `ColliderAabb` outdated by one frame, but that's alright for now.

## Additional Info

Before:

https://github.com/user-attachments/assets/4c0f23b7-422a-4a99-93cb-78a889172ff2

After:

https://github.com/user-attachments/assets/85f655eb-0472-46a5-aca8-78cfe233a514

## Migration

- `PhysicsDebugPlugin` now always runs in `PostUpdate`. Replace all calls to `PhysicsDebugPlugin::new(SomeSchedule)` with `PhysicsDebugPlugin` (or `PhysicsDebugPlugin::default()` if you prefer)
