### PR TITLE
add ApplyPosToTransform component to include an entity in  sync

### DIFF
--- a/src/physics_transform/mod.rs
+++ b/src/physics_transform/mod.rs
@@ -229,6 +229,14 @@ pub fn transform_to_position(
     }
 }
 
+/// Marker component indicating that the `position_to_transform` system should be applied
+/// to this entity.
+///
+/// By default, the `position_to_transform` system only runs for entities that have a
+/// [`RigidBody`] component
+#[derive(Component)]
+pub struct ApplyPosToTransform;
+
 type PosToTransformComponents = (
     &'static mut Transform,
     &'static Position,
@@ -236,7 +244,7 @@ type PosToTransformComponents = (
     Option<&'static ChildOf>,
 );
 
-type PosToTransformFilter = (With<RigidBody>, Or<(Changed<Position>, Changed<Rotation>)>);
+type PosToTransformFilter = (Or<(With<RigidBody>, With<ApplyPosToTransform>)>, Or<(Changed<Position>, Changed<Rotation>)>);
 
 type ParentComponents = (
     &'static GlobalTransform,


### PR DESCRIPTION
# Objective

There are situations (networking) where the Position/Rotation components are networked, but not RigidBody. For example for other players' entities I only network Position/Rotation but not physics components since I don't need to simulate their behaviour.
In those cases it would be useful to have a way to run the `position_to_transform` system on these entities.


## Solution

Add `ApplyPosToTransform` component for this purpose.
