### PR TITLE
Add PartialEq bound on Sleeping

### DIFF
--- a/src/dynamics/rigid_body/sleeping.rs
+++ b/src/dynamics/rigid_body/sleeping.rs
@@ -54,7 +54,7 @@ use bevy::prelude::*;
 /// [simulation islands]: crate::dynamics::solver::islands
 /// [`IslandPlugin`]: crate::dynamics::solver::islands::IslandPlugin
 /// [`IslandSleepingPlugin`]: crate::dynamics::solver::islands::IslandSleepingPlugin
-#[derive(Component, Clone, Copy, Debug, Default, Reflect)]
+#[derive(Component, Clone, Copy, Debug, Default, PartialEq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component, Debug, Default)]


### PR DESCRIPTION
I would like to also enable rollback for the Sleeping component, so that on any rollback we restore Sleeping to what it was at the time of rollback. 

My `add_rollback` has a `PartialEq` bound because usually I need to compare the current value of the component with the past value, so it would be convenient for me if Sleeping implemented `PartialEq`
