### PR TITLE
Disable mass property warning for collider constructors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "accesskit"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c0690ad6e6f9597b8439bd3c95e8c6df5cd043afd950c6d68f3b37df641e27c"
+checksum = "cf203f9d3bd8f29f98833d1fbef628df18f759248a547e7e01cfbf63cda36a99"
 dependencies = [
  "enumn",
  "serde",
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.30.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec27574c1baeb7747c802a194566b46b602461e81dc4957949580ea8da695038"
+checksum = "bdd06f5fea9819250fffd4debf926709f3593ac22f8c1541a2573e5ee0ca01cd"
 dependencies = [
  "accesskit",
  "hashbrown 0.15.5",
@@ -24,9 +24,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_macos"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf962bfd305aed21133d06128ab3f4a6412031a5b8505534d55af869788af272"
+checksum = "93fbaf15815f39084e0cb24950c232f0e3634702c2dfbf182ae3b4919a4a1d45"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -38,9 +38,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_windows"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4cd727229c389e32c1a78fe9f74dc62d7c9fb6eac98cfa1a17efde254fb2d98"
+checksum = "792991159fa9ba57459de59e12e918bb90c5346fea7d40ac1a11f8632b41e63a"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -52,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_winit"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822493d0e54e6793da77525bb7235a19e4fef8418194aaf25a988bc93740d683"
+checksum = "cd9db0ea66997e3f4eae4a5f2c6b6486cf206642639ee629dbbb860ace1dec87"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -291,7 +291,7 @@ dependencies = [
  "avian_derive",
  "bevy",
  "bevy_heavy",
- "bevy_math 0.17.0",
+ "bevy_math 0.17.2",
  "bevy_mod_debugdump",
  "bevy_transform_interpolation",
  "bitflags 2.9.4",
@@ -322,7 +322,7 @@ dependencies = [
  "avian_derive",
  "bevy",
  "bevy_heavy",
- "bevy_math 0.17.0",
+ "bevy_math 0.17.2",
  "bevy_mod_debugdump",
  "bevy_transform_interpolation",
  "bitflags 2.9.4",
@@ -367,55 +367,55 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bevy"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb3771e0e660166f25978f8e75f2ac0db1bf89a9012c82b54c2be182b0e9e6d"
+checksum = "342f7e9335416dc98642d5747c4ed8a6ad9f7244a36d5b2b7a1b7910e4d8f524"
 dependencies = [
  "bevy_internal",
 ]
 
 [[package]]
 name = "bevy_a11y"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc92afb623dfe88dafb9d6cdf2fdb9ec4a215de00147c2f48c1b89f664ebb9af"
+checksum = "3917cd35096fb2fe176632740b68a4b53cb61006cfff13d66ef47ee2c2478d53"
 dependencies = [
  "accesskit",
- "bevy_app 0.17.0",
- "bevy_derive 0.17.0",
- "bevy_ecs 0.17.0",
- "bevy_reflect 0.17.0",
+ "bevy_app 0.17.2",
+ "bevy_derive 0.17.2",
+ "bevy_ecs 0.17.2",
+ "bevy_reflect 0.17.2",
  "serde",
 ]
 
 [[package]]
 name = "bevy_android"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a2ef5ade8911905299801f1e2c4e5ccadbe2f36c97ec56de0a8a48dc7a795b0"
+checksum = "c2a9dd9488c77fa2ea31b5da2f978aab7f1cc82e6d2c3be0adf637d9fd7cb6c8"
 dependencies = [
  "android-activity",
 ]
 
 [[package]]
 name = "bevy_animation"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31cf0eb2893f9b7387d2c09fcc44b01468ef8267d6eb03af38f4a680f361e66"
+checksum = "00d2eadb9c20d87ab3a5528a8df483492d5b8102d3f2d61c7b1ed23f40a79166"
 dependencies = [
  "bevy_animation_macros",
- "bevy_app 0.17.0",
- "bevy_asset 0.17.0",
- "bevy_color 0.17.0",
- "bevy_derive 0.17.0",
- "bevy_ecs 0.17.0",
- "bevy_math 0.17.0",
- "bevy_mesh 0.17.0",
- "bevy_platform 0.17.0",
- "bevy_reflect 0.17.0",
- "bevy_time 0.17.0",
- "bevy_transform 0.17.0",
- "bevy_utils 0.17.0",
+ "bevy_app 0.17.2",
+ "bevy_asset 0.17.2",
+ "bevy_color 0.17.2",
+ "bevy_derive 0.17.2",
+ "bevy_ecs 0.17.2",
+ "bevy_math 0.17.2",
+ "bevy_mesh 0.17.2",
+ "bevy_platform 0.17.2",
+ "bevy_reflect 0.17.2",
+ "bevy_time 0.17.2",
+ "bevy_transform 0.17.2",
+ "bevy_utils 0.17.2",
  "blake3",
  "derive_more 2.0.1",
  "downcast-rs",
@@ -432,11 +432,11 @@ dependencies = [
 
 [[package]]
 name = "bevy_animation_macros"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5621873846f2eb70d2762ff5a6f238f082994c621a4184fb9cd72b701419b95"
+checksum = "aec80b84926f730f6df81b9bc07255c120f57aaf7ac577f38d12dd8e1a0268ad"
 dependencies = [
- "bevy_macro_utils 0.17.0",
+ "bevy_macro_utils 0.17.2",
  "quote",
  "syn",
 ]
@@ -466,16 +466,16 @@ dependencies = [
 
 [[package]]
 name = "bevy_app"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2868fc7515a87c9c8e3cd19eba1baf36aaf17658b7b2e252e5e746b51ea12c1"
+checksum = "9f582409b4ed3850d9b66ee94e71a0e2c20e7068121d372530060c4dfcba66fa"
 dependencies = [
- "bevy_derive 0.17.0",
- "bevy_ecs 0.17.0",
- "bevy_platform 0.17.0",
- "bevy_reflect 0.17.0",
- "bevy_tasks 0.17.0",
- "bevy_utils 0.17.0",
+ "bevy_derive 0.17.2",
+ "bevy_ecs 0.17.2",
+ "bevy_platform 0.17.2",
+ "bevy_reflect 0.17.2",
+ "bevy_tasks 0.17.2",
+ "bevy_utils 0.17.2",
  "cfg-if",
  "console_error_panic_hook",
  "ctrlc",
@@ -529,22 +529,22 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d35fef16c0e21821cdcb52bf8a31b890836d748ec0931e68bdebdadc2228a4eb"
+checksum = "9e6ee42e74a64a46ab91bd1c0155f8abe5b732bdb948a9b26e541456cc7940e5"
 dependencies = [
  "async-broadcast",
  "async-fs",
  "async-lock",
  "atomicow",
  "bevy_android",
- "bevy_app 0.17.0",
- "bevy_asset_macros 0.17.0",
- "bevy_ecs 0.17.0",
- "bevy_platform 0.17.0",
- "bevy_reflect 0.17.0",
- "bevy_tasks 0.17.0",
- "bevy_utils 0.17.0",
+ "bevy_app 0.17.2",
+ "bevy_asset_macros 0.17.2",
+ "bevy_ecs 0.17.2",
+ "bevy_platform 0.17.2",
+ "bevy_reflect 0.17.2",
+ "bevy_tasks 0.17.2",
+ "bevy_utils 0.17.2",
  "bitflags 2.9.4",
  "blake3",
  "crossbeam-channel",
@@ -581,11 +581,11 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset_macros"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f100a9801d7fa8d3d8267e991bcd23e3a7b07481841f2f1f3f468fdb17e6a28a"
+checksum = "d03711d2c087227f64ba85dd38a99d4d6893f80d2475c2e77fb90a883760a055"
 dependencies = [
- "bevy_macro_utils 0.17.0",
+ "bevy_macro_utils 0.17.2",
  "proc-macro2",
  "quote",
  "syn",
@@ -593,22 +593,22 @@ dependencies = [
 
 [[package]]
 name = "bevy_camera"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d09a1c05bb181996d5cdef5c06787ff1686300312a23ee03a5215ac909bb895f"
+checksum = "b70d79ccbd8bfefc79f33a104dfd82ae2f5276ce04d6df75787bfa3edc4c4c1a"
 dependencies = [
- "bevy_app 0.17.0",
- "bevy_asset 0.17.0",
- "bevy_color 0.17.0",
- "bevy_derive 0.17.0",
- "bevy_ecs 0.17.0",
- "bevy_image 0.17.0",
- "bevy_math 0.17.0",
- "bevy_mesh 0.17.0",
- "bevy_reflect 0.17.0",
- "bevy_transform 0.17.0",
- "bevy_utils 0.17.0",
- "bevy_window 0.17.0",
+ "bevy_app 0.17.2",
+ "bevy_asset 0.17.2",
+ "bevy_color 0.17.2",
+ "bevy_derive 0.17.2",
+ "bevy_ecs 0.17.2",
+ "bevy_image 0.17.2",
+ "bevy_math 0.17.2",
+ "bevy_mesh 0.17.2",
+ "bevy_reflect 0.17.2",
+ "bevy_transform 0.17.2",
+ "bevy_utils 0.17.2",
+ "bevy_window 0.17.2",
  "derive_more 2.0.1",
  "downcast-rs",
  "serde",
@@ -635,12 +635,12 @@ dependencies = [
 
 [[package]]
 name = "bevy_color"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cacbef44641f375a38f9a33e5e52ce7501e4a7cbe57aaebb97755d261bb021d"
+checksum = "94dc78477c1c208c0cd221c64e907aba8ba165f39bebb72adc6180e1a13e8938"
 dependencies = [
- "bevy_math 0.17.0",
- "bevy_reflect 0.17.0",
+ "bevy_math 0.17.2",
+ "bevy_reflect 0.17.2",
  "bytemuck",
  "derive_more 2.0.1",
  "encase 0.11.2",
@@ -651,25 +651,25 @@ dependencies = [
 
 [[package]]
 name = "bevy_core_pipeline"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f098b5d263a27c677645297b3e99f138d41b49a1d9304dcd61b9522393adf5a7"
+checksum = "0c866a2fe33ec27a612d883223d30f1857aa852766b21a9603628735dace632f"
 dependencies = [
- "bevy_app 0.17.0",
- "bevy_asset 0.17.0",
+ "bevy_app 0.17.2",
+ "bevy_asset 0.17.2",
  "bevy_camera",
- "bevy_color 0.17.0",
- "bevy_derive 0.17.0",
- "bevy_ecs 0.17.0",
- "bevy_image 0.17.0",
- "bevy_math 0.17.0",
- "bevy_platform 0.17.0",
- "bevy_reflect 0.17.0",
- "bevy_render 0.17.0",
+ "bevy_color 0.17.2",
+ "bevy_derive 0.17.2",
+ "bevy_ecs 0.17.2",
+ "bevy_image 0.17.2",
+ "bevy_math 0.17.2",
+ "bevy_platform 0.17.2",
+ "bevy_reflect 0.17.2",
+ "bevy_render 0.17.2",
  "bevy_shader",
- "bevy_transform 0.17.0",
- "bevy_utils 0.17.0",
- "bevy_window 0.17.0",
+ "bevy_transform 0.17.2",
+ "bevy_utils 0.17.2",
+ "bevy_window 0.17.2",
  "bitflags 2.9.4",
  "nonmax",
  "radsort",
@@ -691,11 +691,11 @@ dependencies = [
 
 [[package]]
 name = "bevy_derive"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6c870f499944058f30ecd8549b0a1babe3cd375519bbe1c071fecc4fdd3f65c"
+checksum = "b8c733807158f8fcac68e23222e69ed91a6492ae9410fc2c145b9bb182cfd63e"
 dependencies = [
- "bevy_macro_utils 0.17.0",
+ "bevy_macro_utils 0.17.2",
  "quote",
  "syn",
 ]
@@ -719,16 +719,16 @@ dependencies = [
 
 [[package]]
 name = "bevy_diagnostic"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b742710ea0e05cc4ffed296a3bd8d0d26c1f48f796c1c147e1431787677aabbb"
+checksum = "f12fa32312818c08aa4035bebe9fb3f62aaf7efae33688e718dd6ee6c0147493"
 dependencies = [
  "atomic-waker",
- "bevy_app 0.17.0",
- "bevy_ecs 0.17.0",
- "bevy_platform 0.17.0",
- "bevy_tasks 0.17.0",
- "bevy_time 0.17.0",
+ "bevy_app 0.17.2",
+ "bevy_ecs 0.17.2",
+ "bevy_platform 0.17.2",
+ "bevy_tasks 0.17.2",
+ "bevy_time 0.17.2",
  "const-fnv1a-hash",
  "log",
  "serde",
@@ -764,17 +764,17 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "409f306ea880aab9281870a5009ce20dc2c4ca6dda732bae08d4e1d7021a342a"
+checksum = "69d929d32190cfcde6efd2df493601c4dbc18a691fd9775a544c951c3c112e1a"
 dependencies = [
  "arrayvec",
- "bevy_ecs_macros 0.17.0",
- "bevy_platform 0.17.0",
- "bevy_ptr 0.17.0",
- "bevy_reflect 0.17.0",
- "bevy_tasks 0.17.0",
- "bevy_utils 0.17.0",
+ "bevy_ecs_macros 0.17.2",
+ "bevy_platform 0.17.2",
+ "bevy_ptr 0.17.2",
+ "bevy_reflect 0.17.2",
+ "bevy_tasks 0.17.2",
+ "bevy_utils 0.17.2",
  "bitflags 2.9.4",
  "bumpalo",
  "concurrent-queue",
@@ -804,11 +804,11 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs_macros"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f9670b6e3bdafdd04e32e7d04d3cb9cfdf26df5e8e49edfb19b1e33b7f6adf"
+checksum = "6eeddfb80a2e000663e87be9229c26b4da92bddbc06c8776bc0d1f4a7f679079"
 dependencies = [
- "bevy_macro_utils 0.17.0",
+ "bevy_macro_utils 0.17.2",
  "proc-macro2",
  "quote",
  "syn",
@@ -826,78 +826,78 @@ dependencies = [
 
 [[package]]
 name = "bevy_encase_derive"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71ad991ae057e173376660c27e621f8bac97ebbb3f2e9efed7be791f3e1ed5a"
+checksum = "7449e5903594a00f007732ba232af0c527ad4e6e3d29bc3e195ec78dbd20c8b2"
 dependencies = [
- "bevy_macro_utils 0.17.0",
+ "bevy_macro_utils 0.17.2",
  "encase_derive_impl 0.11.2",
 ]
 
 [[package]]
 name = "bevy_gizmos"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921939092009906ae4bda23c4285ec0d262202ae0f9b1348789f612e6b6ee8a4"
+checksum = "0d3f174faa13041634060dd99f6f59c29997fd62f40252f0466c2ebea8603d4d"
 dependencies = [
- "bevy_app 0.17.0",
- "bevy_asset 0.17.0",
+ "bevy_app 0.17.2",
+ "bevy_asset 0.17.2",
  "bevy_camera",
- "bevy_color 0.17.0",
+ "bevy_color 0.17.2",
  "bevy_core_pipeline",
- "bevy_ecs 0.17.0",
+ "bevy_ecs 0.17.2",
  "bevy_gizmos_macros",
- "bevy_image 0.17.0",
+ "bevy_image 0.17.2",
  "bevy_light",
- "bevy_math 0.17.0",
- "bevy_mesh 0.17.0",
+ "bevy_math 0.17.2",
+ "bevy_mesh 0.17.2",
  "bevy_pbr",
- "bevy_reflect 0.17.0",
- "bevy_render 0.17.0",
+ "bevy_reflect 0.17.2",
+ "bevy_render 0.17.2",
  "bevy_shader",
  "bevy_sprite_render",
- "bevy_time 0.17.0",
- "bevy_transform 0.17.0",
- "bevy_utils 0.17.0",
+ "bevy_time 0.17.2",
+ "bevy_transform 0.17.2",
+ "bevy_utils 0.17.2",
  "bytemuck",
  "tracing",
 ]
 
 [[package]]
 name = "bevy_gizmos_macros"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a321e873257460402d0b515be0745117779f0ba6c847a04b298d84ecb826ba5f"
+checksum = "714273aa7f285c0aaa874b7fbe37fe4e6e45355e3e6f3321aefa1b78cda259e0"
 dependencies = [
- "bevy_macro_utils 0.17.0",
+ "bevy_macro_utils 0.17.2",
  "quote",
  "syn",
 ]
 
 [[package]]
 name = "bevy_gltf"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b3d762ebbfa5fc45ba59591b8d57283f73684c1c539fb4ed91203007099518"
+checksum = "13d67e954b20551818f7cdb33f169ab4db64506ada66eb4d60d3cb8861103411"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
- "bevy_app 0.17.0",
- "bevy_asset 0.17.0",
+ "bevy_app 0.17.2",
+ "bevy_asset 0.17.2",
  "bevy_camera",
- "bevy_color 0.17.0",
- "bevy_ecs 0.17.0",
- "bevy_image 0.17.0",
+ "bevy_color 0.17.2",
+ "bevy_ecs 0.17.2",
+ "bevy_image 0.17.2",
  "bevy_light",
- "bevy_math 0.17.0",
- "bevy_mesh 0.17.0",
+ "bevy_math 0.17.2",
+ "bevy_mesh 0.17.2",
  "bevy_pbr",
- "bevy_platform 0.17.0",
- "bevy_reflect 0.17.0",
- "bevy_render 0.17.0",
+ "bevy_platform 0.17.2",
+ "bevy_reflect 0.17.2",
+ "bevy_render 0.17.2",
  "bevy_scene",
- "bevy_tasks 0.17.0",
- "bevy_transform 0.17.0",
+ "bevy_tasks 0.17.2",
+ "bevy_transform 0.17.2",
  "fixedbitset",
  "gltf",
  "itertools 0.14.0",
@@ -915,8 +915,8 @@ version = "0.2.0"
 source = "git+https://github.com/Jondolf/bevy_heavy#f566d3214c4774b2617f4b95378b1c0ee4cc9e7e"
 dependencies = [
  "approx",
- "bevy_math 0.17.0",
- "bevy_reflect 0.17.0",
+ "bevy_math 0.17.2",
+ "bevy_reflect 0.17.2",
  "glam_matrix_extras",
  "serde",
 ]
@@ -949,18 +949,18 @@ dependencies = [
 
 [[package]]
 name = "bevy_image"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9cc02c8d42612a7065730a43a0c2367bc057f5119e5d5913189afa7d1c4fe6"
+checksum = "168de8239b2aedd2eeef9f76ae1909b2fdf859b11dcdb4d4d01b93f5f2c771be"
 dependencies = [
- "bevy_app 0.17.0",
- "bevy_asset 0.17.0",
- "bevy_color 0.17.0",
- "bevy_ecs 0.17.0",
- "bevy_math 0.17.0",
- "bevy_platform 0.17.0",
- "bevy_reflect 0.17.0",
- "bevy_utils 0.17.0",
+ "bevy_app 0.17.2",
+ "bevy_asset 0.17.2",
+ "bevy_color 0.17.2",
+ "bevy_ecs 0.17.2",
+ "bevy_math 0.17.2",
+ "bevy_platform 0.17.2",
+ "bevy_reflect 0.17.2",
+ "bevy_utils 0.17.2",
  "bitflags 2.9.4",
  "bytemuck",
  "futures-lite",
@@ -995,15 +995,15 @@ dependencies = [
 
 [[package]]
 name = "bevy_input"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5379bbe8be413e8765ab36080cf2156f9398c87cd1c475411b3caf07b6b20d"
+checksum = "3cf4074b2d0d6680b4deb308ded7b4e8b1b99181c0502e2632e78af815b26f01"
 dependencies = [
- "bevy_app 0.17.0",
- "bevy_ecs 0.17.0",
- "bevy_math 0.17.0",
- "bevy_platform 0.17.0",
- "bevy_reflect 0.17.0",
+ "bevy_app 0.17.2",
+ "bevy_ecs 0.17.2",
+ "bevy_math 0.17.2",
+ "bevy_platform 0.17.2",
+ "bevy_reflect 0.17.2",
  "derive_more 2.0.1",
  "log",
  "serde",
@@ -1013,87 +1013,87 @@ dependencies = [
 
 [[package]]
 name = "bevy_input_focus"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cffb8c47b5b70288887dbf45c31041fcf7ac05926d7c4b0976318006f089e585"
+checksum = "70761eba0f616a1caa761457bff2b8ae80c9916f39d167fab8c2d5c98d2b8951"
 dependencies = [
- "bevy_app 0.17.0",
- "bevy_ecs 0.17.0",
- "bevy_input 0.17.0",
- "bevy_math 0.17.0",
+ "bevy_app 0.17.2",
+ "bevy_ecs 0.17.2",
+ "bevy_input 0.17.2",
+ "bevy_math 0.17.2",
  "bevy_picking",
- "bevy_reflect 0.17.0",
- "bevy_window 0.17.0",
+ "bevy_reflect 0.17.2",
+ "bevy_window 0.17.2",
  "log",
  "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "bevy_internal"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9138862f86ca93618def4e04660904b8a0d0633e0f55d81ce865a96d2c4688b5"
+checksum = "f43985739584f3a5d43026aa1edd772f064830be46c497518f05f7dfbc886bba"
 dependencies = [
  "bevy_a11y",
  "bevy_android",
  "bevy_animation",
- "bevy_app 0.17.0",
- "bevy_asset 0.17.0",
+ "bevy_app 0.17.2",
+ "bevy_asset 0.17.2",
  "bevy_camera",
- "bevy_color 0.17.0",
+ "bevy_color 0.17.2",
  "bevy_core_pipeline",
- "bevy_derive 0.17.0",
- "bevy_diagnostic 0.17.0",
- "bevy_ecs 0.17.0",
+ "bevy_derive 0.17.2",
+ "bevy_diagnostic 0.17.2",
+ "bevy_ecs 0.17.2",
  "bevy_gizmos",
  "bevy_gltf",
- "bevy_image 0.17.0",
- "bevy_input 0.17.0",
+ "bevy_image 0.17.2",
+ "bevy_input 0.17.2",
  "bevy_input_focus",
  "bevy_light",
- "bevy_log 0.17.0",
- "bevy_math 0.17.0",
- "bevy_mesh 0.17.0",
+ "bevy_log 0.17.2",
+ "bevy_math 0.17.2",
+ "bevy_mesh 0.17.2",
  "bevy_pbr",
  "bevy_picking",
- "bevy_platform 0.17.0",
- "bevy_ptr 0.17.0",
- "bevy_reflect 0.17.0",
- "bevy_render 0.17.0",
+ "bevy_platform 0.17.2",
+ "bevy_ptr 0.17.2",
+ "bevy_reflect 0.17.2",
+ "bevy_render 0.17.2",
  "bevy_scene",
  "bevy_shader",
  "bevy_sprite",
  "bevy_sprite_render",
  "bevy_state",
- "bevy_tasks 0.17.0",
+ "bevy_tasks 0.17.2",
  "bevy_text",
- "bevy_time 0.17.0",
- "bevy_transform 0.17.0",
+ "bevy_time 0.17.2",
+ "bevy_transform 0.17.2",
  "bevy_ui",
  "bevy_ui_render",
- "bevy_utils 0.17.0",
- "bevy_window 0.17.0",
+ "bevy_utils 0.17.2",
+ "bevy_window 0.17.2",
  "bevy_winit",
 ]
 
 [[package]]
 name = "bevy_light"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57829d2f3f74a9ed9815a54ed51af2577a712745d81ae8a375739a0996b2cdd8"
+checksum = "cad00ab66d1e93edb928be66606a71066f3b1cbc9f414720e290ef5361eb6237"
 dependencies = [
- "bevy_app 0.17.0",
- "bevy_asset 0.17.0",
+ "bevy_app 0.17.2",
+ "bevy_asset 0.17.2",
  "bevy_camera",
- "bevy_color 0.17.0",
- "bevy_ecs 0.17.0",
- "bevy_image 0.17.0",
- "bevy_math 0.17.0",
- "bevy_mesh 0.17.0",
- "bevy_platform 0.17.0",
- "bevy_reflect 0.17.0",
- "bevy_transform 0.17.0",
- "bevy_utils 0.17.0",
+ "bevy_color 0.17.2",
+ "bevy_ecs 0.17.2",
+ "bevy_image 0.17.2",
+ "bevy_math 0.17.2",
+ "bevy_mesh 0.17.2",
+ "bevy_platform 0.17.2",
+ "bevy_reflect 0.17.2",
+ "bevy_transform 0.17.2",
+ "bevy_utils 0.17.2",
  "tracing",
 ]
 
@@ -1116,15 +1116,15 @@ dependencies = [
 
 [[package]]
 name = "bevy_log"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655630c5ae5e872b9dcead6e9a28103de5bb01c29bdfe5ce76ee7506ea545c4e"
+checksum = "4ae217a035714a37b779487f82edc4c7c1223f7088d7ad94054f29f524d61c51"
 dependencies = [
  "android_log-sys",
- "bevy_app 0.17.0",
- "bevy_ecs 0.17.0",
- "bevy_platform 0.17.0",
- "bevy_utils 0.17.0",
+ "bevy_app 0.17.2",
+ "bevy_ecs 0.17.2",
+ "bevy_platform 0.17.2",
+ "bevy_utils 0.17.2",
  "tracing",
  "tracing-log",
  "tracing-oslog 0.3.0",
@@ -1147,9 +1147,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_macro_utils"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6217369a5c60e9b23dcdfcb36f2adfc1ec84a67b5bafa79333937a5e0598dda6"
+checksum = "17dbc3f8948da58b3c17767d20fd3cd35fe4721ed19a9a3204a6f1d6c9951bdd"
 dependencies = [
  "parking_lot",
  "proc-macro2",
@@ -1179,12 +1179,12 @@ dependencies = [
 
 [[package]]
 name = "bevy_math"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e007ac325ff9e6dc2c60d572d94b17dbbee8ca53f3be16ed06fd1340c1548f0f"
+checksum = "f7a41e368ffa95ae2a353197d1ae3993f4d3d471444d80b65c932db667ea7b9e"
 dependencies = [
  "approx",
- "bevy_reflect 0.17.0",
+ "bevy_reflect 0.17.2",
  "derive_more 2.0.1",
  "glam 0.30.8",
  "itertools 0.14.0",
@@ -1224,20 +1224,20 @@ dependencies = [
 
 [[package]]
 name = "bevy_mesh"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f0d9ba38f107f3185fd4899e4ad760122f6b7ab9efa8e1df14082fe7157067"
+checksum = "b6255244b71153b305fddb4e6f827cb97ed51f276b6e632f5fc46538647948f6"
 dependencies = [
- "bevy_app 0.17.0",
- "bevy_asset 0.17.0",
- "bevy_derive 0.17.0",
- "bevy_ecs 0.17.0",
- "bevy_image 0.17.0",
- "bevy_math 0.17.0",
+ "bevy_app 0.17.2",
+ "bevy_asset 0.17.2",
+ "bevy_derive 0.17.2",
+ "bevy_ecs 0.17.2",
+ "bevy_image 0.17.2",
+ "bevy_math 0.17.2",
  "bevy_mikktspace 0.17.0-dev",
- "bevy_platform 0.17.0",
- "bevy_reflect 0.17.0",
- "bevy_transform 0.17.0",
+ "bevy_platform 0.17.2",
+ "bevy_reflect 0.17.2",
+ "bevy_transform 0.17.2",
  "bitflags 2.9.4",
  "bytemuck",
  "derive_more 2.0.1",
@@ -1282,28 +1282,28 @@ dependencies = [
 
 [[package]]
 name = "bevy_pbr"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08482b0f8dcebc56279d4f11606dcdde0d6858cb5f29a86a9d1a5f0d760fe51"
+checksum = "cf8c76337a6ae9d73d50be168aeee974d05fdeda9129a413eaff719e3b7b5fea"
 dependencies = [
- "bevy_app 0.17.0",
- "bevy_asset 0.17.0",
+ "bevy_app 0.17.2",
+ "bevy_asset 0.17.2",
  "bevy_camera",
- "bevy_color 0.17.0",
+ "bevy_color 0.17.2",
  "bevy_core_pipeline",
- "bevy_derive 0.17.0",
- "bevy_diagnostic 0.17.0",
- "bevy_ecs 0.17.0",
- "bevy_image 0.17.0",
+ "bevy_derive 0.17.2",
+ "bevy_diagnostic 0.17.2",
+ "bevy_ecs 0.17.2",
+ "bevy_image 0.17.2",
  "bevy_light",
- "bevy_math 0.17.0",
- "bevy_mesh 0.17.0",
- "bevy_platform 0.17.0",
- "bevy_reflect 0.17.0",
- "bevy_render 0.17.0",
+ "bevy_math 0.17.2",
+ "bevy_mesh 0.17.2",
+ "bevy_platform 0.17.2",
+ "bevy_reflect 0.17.2",
+ "bevy_render 0.17.2",
  "bevy_shader",
- "bevy_transform 0.17.0",
- "bevy_utils 0.17.0",
+ "bevy_transform 0.17.2",
+ "bevy_utils 0.17.2",
  "bitflags 2.9.4",
  "bytemuck",
  "derive_more 2.0.1",
@@ -1318,22 +1318,22 @@ dependencies = [
 
 [[package]]
 name = "bevy_picking"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0b992eacf88acbf8f45dafe2894cab5b89525bb506a454c0ccae920ab17b38"
+checksum = "3a232a8ea4dc9b83c08226f56b868acb1ead06946a95d8b9c8cbbcc860cd8090"
 dependencies = [
- "bevy_app 0.17.0",
- "bevy_asset 0.17.0",
+ "bevy_app 0.17.2",
+ "bevy_asset 0.17.2",
  "bevy_camera",
- "bevy_derive 0.17.0",
- "bevy_ecs 0.17.0",
- "bevy_input 0.17.0",
- "bevy_math 0.17.0",
- "bevy_platform 0.17.0",
- "bevy_reflect 0.17.0",
- "bevy_time 0.17.0",
- "bevy_transform 0.17.0",
- "bevy_window 0.17.0",
+ "bevy_derive 0.17.2",
+ "bevy_ecs 0.17.2",
+ "bevy_input 0.17.2",
+ "bevy_math 0.17.2",
+ "bevy_platform 0.17.2",
+ "bevy_reflect 0.17.2",
+ "bevy_time 0.17.2",
+ "bevy_transform 0.17.2",
+ "bevy_window 0.17.2",
  "tracing",
  "uuid",
 ]
@@ -1358,9 +1358,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_platform"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c000f9765bfabeb5469a4d6f3577a2d1fc7e0c46309c32b61860143e14f88ee1"
+checksum = "10cf8cda162688c95250e74cffaa1c3a04597f105d4ca35554106f107308ea57"
 dependencies = [
  "critical-section",
  "foldhash 0.2.0",
@@ -1385,9 +1385,9 @@ checksum = "df7370d0e46b60e071917711d0860721f5347bc958bf325975ae6913a5dfcf01"
 
 [[package]]
 name = "bevy_ptr"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66652590ead8412d2b63dd73ff63af61aa5a59e7fc4a5bbe6c799b214cd1dd41"
+checksum = "28ab4074e7b781bab84e9b0a41ede245d673d1f75646ce0db27643aedcfb3a85"
 
 [[package]]
 name = "bevy_reflect"
@@ -1417,15 +1417,15 @@ dependencies = [
 
 [[package]]
 name = "bevy_reflect"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0870478f18be825606564bf83919931372947d6a377dd00829812edbe12bb544"
+checksum = "333df3f5947b7e62728eb5c0b51d679716b16c7c5283118fed4563f13230954e"
 dependencies = [
  "assert_type_match",
- "bevy_platform 0.17.0",
- "bevy_ptr 0.17.0",
- "bevy_reflect_derive 0.17.0",
- "bevy_utils 0.17.0",
+ "bevy_platform 0.17.2",
+ "bevy_ptr 0.17.2",
+ "bevy_reflect_derive 0.17.2",
+ "bevy_utils 0.17.2",
  "derive_more 2.0.1",
  "disqualified",
  "downcast-rs",
@@ -1458,11 +1458,11 @@ dependencies = [
 
 [[package]]
 name = "bevy_reflect_derive"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a90e99abc2190b0f8bd80c6e78dcbe4520bebd3be285865720ae3aca515a57f"
+checksum = "0205dce9c5a4d8d041b263bcfd96e9d9d6f3d49416e12db347ab5778b3071fe1"
 dependencies = [
- "bevy_macro_utils 0.17.0",
+ "bevy_macro_utils 0.17.2",
  "indexmap",
  "proc-macro2",
  "quote",
@@ -1523,31 +1523,31 @@ dependencies = [
 
 [[package]]
 name = "bevy_render"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aeb61265a8374e8cbe79f75e88fb97f19e01c9dca78a2a2d338530e84bea574"
+checksum = "70d6a5d47ebb247e4ecaaf4a3b0310b7c518728ff2362c69f4220d0d3228e17d"
 dependencies = [
  "async-channel",
- "bevy_app 0.17.0",
- "bevy_asset 0.17.0",
+ "bevy_app 0.17.2",
+ "bevy_asset 0.17.2",
  "bevy_camera",
- "bevy_color 0.17.0",
- "bevy_derive 0.17.0",
- "bevy_diagnostic 0.17.0",
- "bevy_ecs 0.17.0",
- "bevy_encase_derive 0.17.0",
- "bevy_image 0.17.0",
- "bevy_math 0.17.0",
- "bevy_mesh 0.17.0",
- "bevy_platform 0.17.0",
- "bevy_reflect 0.17.0",
- "bevy_render_macros 0.17.0",
+ "bevy_color 0.17.2",
+ "bevy_derive 0.17.2",
+ "bevy_diagnostic 0.17.2",
+ "bevy_ecs 0.17.2",
+ "bevy_encase_derive 0.17.2",
+ "bevy_image 0.17.2",
+ "bevy_math 0.17.2",
+ "bevy_mesh 0.17.2",
+ "bevy_platform 0.17.2",
+ "bevy_reflect 0.17.2",
+ "bevy_render_macros 0.17.2",
  "bevy_shader",
- "bevy_tasks 0.17.0",
- "bevy_time 0.17.0",
- "bevy_transform 0.17.0",
- "bevy_utils 0.17.0",
- "bevy_window 0.17.0",
+ "bevy_tasks 0.17.2",
+ "bevy_time 0.17.2",
+ "bevy_transform 0.17.2",
+ "bevy_utils 0.17.2",
+ "bevy_window 0.17.2",
  "bitflags 2.9.4",
  "bytemuck",
  "derive_more 2.0.1",
@@ -1584,11 +1584,11 @@ dependencies = [
 
 [[package]]
 name = "bevy_render_macros"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911fb2516b725c0f2303767ad6546d987a81aaa3fd39049674b6597182582aa1"
+checksum = "a7e8b553adf0a4f9f059c5c2dcb52d9ac09abede1c322a92b43b9f4bb11c3843"
 dependencies = [
- "bevy_macro_utils 0.17.0",
+ "bevy_macro_utils 0.17.2",
  "proc-macro2",
  "quote",
  "syn",
@@ -1596,19 +1596,19 @@ dependencies = [
 
 [[package]]
 name = "bevy_scene"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4791c6873526eead008c9dab804326c8376dce786417882935b832471ae0a35"
+checksum = "e601ffeebbdaba1193f823dbdc9fc8787a24cf83225a72fee4def5c27a18778a"
 dependencies = [
- "bevy_app 0.17.0",
- "bevy_asset 0.17.0",
+ "bevy_app 0.17.2",
+ "bevy_asset 0.17.2",
  "bevy_camera",
- "bevy_derive 0.17.0",
- "bevy_ecs 0.17.0",
- "bevy_platform 0.17.0",
- "bevy_reflect 0.17.0",
- "bevy_transform 0.17.0",
- "bevy_utils 0.17.0",
+ "bevy_derive 0.17.2",
+ "bevy_ecs 0.17.2",
+ "bevy_platform 0.17.2",
+ "bevy_reflect 0.17.2",
+ "bevy_transform 0.17.2",
+ "bevy_utils 0.17.2",
  "derive_more 2.0.1",
  "serde",
  "thiserror 2.0.17",
@@ -1617,13 +1617,13 @@ dependencies = [
 
 [[package]]
 name = "bevy_shader"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3aeb3206ceca7f9d73422d551f09afbc4d8c1e53d3228a308873d06b298f20"
+checksum = "3cef8f8e53776d286eb62bb60164f30671f07005ff407e94ec1176e9426d1477"
 dependencies = [
- "bevy_asset 0.17.0",
- "bevy_platform 0.17.0",
- "bevy_reflect 0.17.0",
+ "bevy_asset 0.17.2",
+ "bevy_platform 0.17.2",
+ "bevy_reflect 0.17.2",
  "naga 26.0.0",
  "naga_oil 0.19.1",
  "serde",
@@ -1634,23 +1634,23 @@ dependencies = [
 
 [[package]]
 name = "bevy_sprite"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234b4fb4ea18a24861562309df5c99833ff701cdbba551f945ed105bf3f2f1a4"
+checksum = "74bb52fa52caa1cc8d95acf45e52efc0c72b59755c2f0801a30fdab367921db0"
 dependencies = [
- "bevy_app 0.17.0",
- "bevy_asset 0.17.0",
+ "bevy_app 0.17.2",
+ "bevy_asset 0.17.2",
  "bevy_camera",
- "bevy_color 0.17.0",
- "bevy_derive 0.17.0",
- "bevy_ecs 0.17.0",
- "bevy_image 0.17.0",
- "bevy_math 0.17.0",
- "bevy_mesh 0.17.0",
- "bevy_reflect 0.17.0",
+ "bevy_color 0.17.2",
+ "bevy_derive 0.17.2",
+ "bevy_ecs 0.17.2",
+ "bevy_image 0.17.2",
+ "bevy_math 0.17.2",
+ "bevy_mesh 0.17.2",
+ "bevy_reflect 0.17.2",
  "bevy_text",
- "bevy_transform 0.17.0",
- "bevy_window 0.17.0",
+ "bevy_transform 0.17.2",
+ "bevy_window 0.17.2",
  "radsort",
  "tracing",
  "wgpu-types 26.0.0",
@@ -1658,28 +1658,28 @@ dependencies = [
 
 [[package]]
 name = "bevy_sprite_render"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bdb7be6812beb218eba6c5d2e8b537a3d3d9f002d6331a715c88fff8c6f60d"
+checksum = "31bb90a9139b04568bd30b2492ba61234092d95a7f7e3c84b55369b16d7e261b"
 dependencies = [
- "bevy_app 0.17.0",
- "bevy_asset 0.17.0",
+ "bevy_app 0.17.2",
+ "bevy_asset 0.17.2",
  "bevy_camera",
- "bevy_color 0.17.0",
+ "bevy_color 0.17.2",
  "bevy_core_pipeline",
- "bevy_derive 0.17.0",
- "bevy_ecs 0.17.0",
- "bevy_image 0.17.0",
- "bevy_math 0.17.0",
- "bevy_mesh 0.17.0",
- "bevy_platform 0.17.0",
- "bevy_reflect 0.17.0",
- "bevy_render 0.17.0",
+ "bevy_derive 0.17.2",
+ "bevy_ecs 0.17.2",
+ "bevy_image 0.17.2",
+ "bevy_math 0.17.2",
+ "bevy_mesh 0.17.2",
+ "bevy_platform 0.17.2",
+ "bevy_reflect 0.17.2",
+ "bevy_render 0.17.2",
  "bevy_shader",
  "bevy_sprite",
  "bevy_text",
- "bevy_transform 0.17.0",
- "bevy_utils 0.17.0",
+ "bevy_transform 0.17.2",
+ "bevy_utils 0.17.2",
  "bitflags 2.9.4",
  "bytemuck",
  "derive_more 2.0.1",
@@ -1690,27 +1690,27 @@ dependencies = [
 
 [[package]]
 name = "bevy_state"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "083f2779368af40202eaeec28c5c04d4e5afc606630f616bc730414ff0a90652"
+checksum = "fe4e955f36cdc7b31556e4619a653dcf65d46967d90d36fb788f746c8e89257e"
 dependencies = [
- "bevy_app 0.17.0",
- "bevy_ecs 0.17.0",
- "bevy_platform 0.17.0",
- "bevy_reflect 0.17.0",
+ "bevy_app 0.17.2",
+ "bevy_ecs 0.17.2",
+ "bevy_platform 0.17.2",
+ "bevy_reflect 0.17.2",
  "bevy_state_macros",
- "bevy_utils 0.17.0",
+ "bevy_utils 0.17.2",
  "log",
  "variadics_please",
 ]
 
 [[package]]
 name = "bevy_state_macros"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde0770d9789927303615188d4315eb98cb8969620de92b23d84da22d6865d51"
+checksum = "5c3e4e32b1b96585740a2b447661af7db1b9d688db5e4d96da50461cd8f5ce63"
 dependencies = [
- "bevy_macro_utils 0.17.0",
+ "bevy_macro_utils 0.17.2",
  "quote",
  "syn",
 ]
@@ -1737,15 +1737,15 @@ dependencies = [
 
 [[package]]
 name = "bevy_tasks"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43dc8e8aa47b8b3e96f1deb0f6eafddb6a9e54e5c849be0e99e02c18e03df24"
+checksum = "18839182775f30d26f0f84d9de85d25361bb593c99517a80b64ede6cbaf41adc"
 dependencies = [
  "async-channel",
  "async-executor",
  "async-task",
  "atomic-waker",
- "bevy_platform 0.17.0",
+ "bevy_platform 0.17.2",
  "concurrent-queue",
  "crossbeam-queue",
  "derive_more 2.0.1",
@@ -1756,21 +1756,21 @@ dependencies = [
 
 [[package]]
 name = "bevy_text"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda1dbf03a3ca9ca8f8b9fc566bbb3b97a46b59505f5d002d977baa4c25766be"
+checksum = "cc1b759cf2ed8992132bd541ebb9ffcfa777d2faf3596d418fb25984bc6677d8"
 dependencies = [
- "bevy_app 0.17.0",
- "bevy_asset 0.17.0",
- "bevy_color 0.17.0",
- "bevy_derive 0.17.0",
- "bevy_ecs 0.17.0",
- "bevy_image 0.17.0",
- "bevy_log 0.17.0",
- "bevy_math 0.17.0",
- "bevy_platform 0.17.0",
- "bevy_reflect 0.17.0",
- "bevy_utils 0.17.0",
+ "bevy_app 0.17.2",
+ "bevy_asset 0.17.2",
+ "bevy_color 0.17.2",
+ "bevy_derive 0.17.2",
+ "bevy_ecs 0.17.2",
+ "bevy_image 0.17.2",
+ "bevy_log 0.17.2",
+ "bevy_math 0.17.2",
+ "bevy_platform 0.17.2",
+ "bevy_reflect 0.17.2",
+ "bevy_utils 0.17.2",
  "cosmic-text",
  "serde",
  "smallvec",
@@ -1797,14 +1797,14 @@ dependencies = [
 
 [[package]]
 name = "bevy_time"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ede8152f23667c8739425743e0580a38c9946441a64e297352c8ed0e92019f"
+checksum = "1a52edd3d30ed94074f646ba1c9914e407af9abe5b6fb7a4322c855341a536cc"
 dependencies = [
- "bevy_app 0.17.0",
- "bevy_ecs 0.17.0",
- "bevy_platform 0.17.0",
- "bevy_reflect 0.17.0",
+ "bevy_app 0.17.2",
+ "bevy_ecs 0.17.2",
+ "bevy_platform 0.17.2",
+ "bevy_reflect 0.17.2",
  "crossbeam-channel",
  "log",
  "serde",
@@ -1830,17 +1830,17 @@ dependencies = [
 
 [[package]]
 name = "bevy_transform"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48873010710b9111d4ee6c40cc4f5d3cf877d2bfec6d54baf34b0eb32533c8c7"
+checksum = "7995ae14430b1a268d1e4f098ab770e8af880d2df5e4e37161b47d8d9e9625bd"
 dependencies = [
- "bevy_app 0.17.0",
- "bevy_ecs 0.17.0",
- "bevy_log 0.17.0",
- "bevy_math 0.17.0",
- "bevy_reflect 0.17.0",
- "bevy_tasks 0.17.0",
- "bevy_utils 0.17.0",
+ "bevy_app 0.17.2",
+ "bevy_ecs 0.17.2",
+ "bevy_log 0.17.2",
+ "bevy_math 0.17.2",
+ "bevy_reflect 0.17.2",
+ "bevy_tasks 0.17.2",
+ "bevy_utils 0.17.2",
  "derive_more 2.0.1",
  "serde",
  "thiserror 2.0.17",
@@ -1849,7 +1849,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform_interpolation"
 version = "0.2.0"
-source = "git+https://github.com/Jondolf/bevy_transform_interpolation#b7b76f6cf644407aa9ee9fbcb5f03b4dd204b4d3"
+source = "git+https://github.com/Jondolf/bevy_transform_interpolation#9c91120185787a4d3277bdb5230b270185ebfbe9"
 dependencies = [
  "bevy",
  "serde",
@@ -1857,28 +1857,28 @@ dependencies = [
 
 [[package]]
 name = "bevy_ui"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58044ec68910bbe85db13bbda343eaef966b03d602d46f8d8ef31f6de731d84a"
+checksum = "cc999815a67a6b2fc911df9eea27af703ff656aed6fd31d8606dced701f07fd6"
 dependencies = [
  "accesskit",
  "bevy_a11y",
- "bevy_app 0.17.0",
- "bevy_asset 0.17.0",
+ "bevy_app 0.17.2",
+ "bevy_asset 0.17.2",
  "bevy_camera",
- "bevy_color 0.17.0",
- "bevy_derive 0.17.0",
- "bevy_ecs 0.17.0",
- "bevy_image 0.17.0",
- "bevy_input 0.17.0",
- "bevy_math 0.17.0",
- "bevy_platform 0.17.0",
- "bevy_reflect 0.17.0",
+ "bevy_color 0.17.2",
+ "bevy_derive 0.17.2",
+ "bevy_ecs 0.17.2",
+ "bevy_image 0.17.2",
+ "bevy_input 0.17.2",
+ "bevy_math 0.17.2",
+ "bevy_platform 0.17.2",
+ "bevy_reflect 0.17.2",
  "bevy_sprite",
  "bevy_text",
- "bevy_transform 0.17.0",
- "bevy_utils 0.17.0",
- "bevy_window 0.17.0",
+ "bevy_transform 0.17.2",
+ "bevy_utils 0.17.2",
+ "bevy_window 0.17.2",
  "derive_more 2.0.1",
  "serde",
  "smallvec",
@@ -1889,30 +1889,30 @@ dependencies = [
 
 [[package]]
 name = "bevy_ui_render"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cac85806bda161862891e85f3e9dbf772cfb3fbd038b3f7ffdae4d677a094a5"
+checksum = "adae9770089e04339d003afe7abe7153fe71600d81c828f964c7ac329b04d5b9"
 dependencies = [
- "bevy_app 0.17.0",
- "bevy_asset 0.17.0",
+ "bevy_app 0.17.2",
+ "bevy_asset 0.17.2",
  "bevy_camera",
- "bevy_color 0.17.0",
+ "bevy_color 0.17.2",
  "bevy_core_pipeline",
- "bevy_derive 0.17.0",
- "bevy_ecs 0.17.0",
- "bevy_image 0.17.0",
- "bevy_math 0.17.0",
- "bevy_mesh 0.17.0",
- "bevy_platform 0.17.0",
- "bevy_reflect 0.17.0",
- "bevy_render 0.17.0",
+ "bevy_derive 0.17.2",
+ "bevy_ecs 0.17.2",
+ "bevy_image 0.17.2",
+ "bevy_math 0.17.2",
+ "bevy_mesh 0.17.2",
+ "bevy_platform 0.17.2",
+ "bevy_reflect 0.17.2",
+ "bevy_render 0.17.2",
  "bevy_shader",
  "bevy_sprite",
  "bevy_sprite_render",
  "bevy_text",
- "bevy_transform 0.17.0",
+ "bevy_transform 0.17.2",
  "bevy_ui",
- "bevy_utils 0.17.0",
+ "bevy_utils 0.17.2",
  "bytemuck",
  "derive_more 2.0.1",
  "tracing",
@@ -1930,11 +1930,11 @@ dependencies = [
 
 [[package]]
 name = "bevy_utils"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f44ff1544531d9a4948c7e6b93ebdb77840d1da5683a25272d9f526ae62d3d"
+checksum = "080254083c74d5f6eb0649d7cd6181bda277e8fe3c509ec68990a5d56ec23f24"
 dependencies = [
- "bevy_platform 0.17.0",
+ "bevy_platform 0.17.2",
  "disqualified",
  "thread_local",
 ]
@@ -1961,16 +1961,16 @@ dependencies = [
 
 [[package]]
 name = "bevy_window"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "863f6173be21db1eef645895d927652fb43cc830779ba941821e4a4ae81f1755"
+checksum = "f582478606d6b6e5c53befbe7612f038fdfb73f8a27f7aae644406637347acd4"
 dependencies = [
- "bevy_app 0.17.0",
- "bevy_ecs 0.17.0",
- "bevy_input 0.17.0",
- "bevy_math 0.17.0",
- "bevy_platform 0.17.0",
- "bevy_reflect 0.17.0",
+ "bevy_app 0.17.2",
+ "bevy_ecs 0.17.2",
+ "bevy_input 0.17.2",
+ "bevy_math 0.17.2",
+ "bevy_platform 0.17.2",
+ "bevy_reflect 0.17.2",
  "log",
  "raw-window-handle",
  "serde",
@@ -1978,26 +1978,26 @@ dependencies = [
 
 [[package]]
 name = "bevy_winit"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568b97a70fd08f7d661ca2f464873249c10eb4e3476be66d966d1f5e37e7e121"
+checksum = "eb0ccf2faca4b4c156a26284d1bbf90a8cac8568a273adcd6c1a270c1342f3df"
 dependencies = [
  "accesskit",
  "accesskit_winit",
  "approx",
  "bevy_a11y",
  "bevy_android",
- "bevy_app 0.17.0",
- "bevy_derive 0.17.0",
- "bevy_ecs 0.17.0",
- "bevy_input 0.17.0",
+ "bevy_app 0.17.2",
+ "bevy_derive 0.17.2",
+ "bevy_ecs 0.17.2",
+ "bevy_input 0.17.2",
  "bevy_input_focus",
- "bevy_log 0.17.0",
- "bevy_math 0.17.0",
- "bevy_platform 0.17.0",
- "bevy_reflect 0.17.0",
- "bevy_tasks 0.17.0",
- "bevy_window 0.17.0",
+ "bevy_log 0.17.2",
+ "bevy_math 0.17.2",
+ "bevy_platform 0.17.2",
+ "bevy_reflect 0.17.2",
+ "bevy_tasks 0.17.2",
+ "bevy_window 0.17.2",
  "cfg-if",
  "tracing",
  "wasm-bindgen",
@@ -2120,18 +2120,18 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.2"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
+checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.10.1"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f154e572231cb6ba2bd1176980827e3d5dc04cc183a75dea38109fbdd672d29"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2178,9 +2178,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.39"
+version = "1.2.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
+checksum = "e1d05d92f4b1fd76aad469d46cdd858ca761576082cd37df81416691e50199fb"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2836,9 +2836,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
+checksum = "0399f9d26e5191ce32c498bebd31e7a3ceabc2745f0ac54af3f335126c3f24b3"
 
 [[package]]
 name = "fixedbitset"
@@ -2848,9 +2848,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+checksum = "dc5a4e564e38c699f2880d3fda590bedc2e69f3f84cd48b457bd892ce61d0aa9"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2870,9 +2870,9 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "font-types"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a596f5713680923a2080d86de50fe472fb290693cf0f701187a1c8b36996b7"
+checksum = "511e2c18a516c666d27867d2f9821f76e7d591f762e9fc41dd6cc5c90fe54b0b"
 dependencies = [
  "bytemuck",
 ]
@@ -3120,10 +3120,10 @@ dependencies = [
 [[package]]
 name = "glam_matrix_extras"
 version = "0.1.0"
-source = "git+https://github.com/Jondolf/glam_matrix_extras#8acbb7b48d3a824e63b495444dc992703d9a8d7c"
+source = "git+https://github.com/Jondolf/glam_matrix_extras#6e27652b13ea7fe68e939e8a4d48ed8825e5d910"
 dependencies = [
  "approx",
- "bevy_reflect 0.17.0",
+ "bevy_reflect 0.17.2",
  "glam 0.30.8",
  "libm",
  "serde",
@@ -3547,7 +3547,7 @@ checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
  "bitflags 2.9.4",
  "libc",
- "redox_syscall 0.5.17",
+ "redox_syscall 0.5.18",
 ]
 
 [[package]]
@@ -3570,11 +3570,10 @@ checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
 
 [[package]]
 name = "lock_api"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
@@ -3675,9 +3674,9 @@ dependencies = [
 
 [[package]]
 name = "moxcms"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd32fa8935aeadb8a8a6b6b351e40225570a37c43de67690383d87ef170cd08"
+checksum = "1cc7d85f3d741164e8972ad355e26ac6e51b20fcae5f911c7da8f2d8bbbb3f33"
 dependencies = [
  "num-traits",
  "pxfm",
@@ -4242,9 +4241,9 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -4252,15 +4251,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.17",
+ "redox_syscall 0.5.18",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -4756,9 +4755,9 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.29.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04ca636dac446b5664bd16c069c00a9621806895b8bb02c2dc68542b23b8f25d"
+checksum = "6717cf23b488adf64b9d711329542ba34de147df262370221940dfabc2c91358"
 dependencies = [
  "bytemuck",
  "font-types",
@@ -4781,9 +4780,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.17"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.9.4",
 ]
@@ -5057,9 +5056,9 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "skrifa"
-version = "0.31.3"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbeb4ca4399663735553a09dd17ce7e49a0a0203f03b706b39628c4d913a8607"
+checksum = "8c31071dedf532758ecf3fed987cdb4bd9509f900e026ab684b4ecb81ea49841"
 dependencies = [
  "bytemuck",
  "read-fonts",
@@ -5186,9 +5185,9 @@ checksum = "0193cc4331cfd2f3d2011ef287590868599a2f33c3e69bc22c1a3d3acf9e02fb"
 
 [[package]]
 name = "swash"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f745de914febc7c9ab4388dfaf94bbc87e69f57bb41133a9b0c84d4be49856f3"
+checksum = "47846491253e976bdd07d0f9cc24b7daf24720d11309302ccbbc6e6b6e53550a"
 dependencies = [
  "skrifa",
  "yazi",
@@ -5482,9 +5481,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "typewit"

--- a/src/dynamics/rigid_body/mass_properties/mod.rs
+++ b/src/dynamics/rigid_body/mass_properties/mod.rs
@@ -407,6 +407,15 @@ fn update_mass_properties(
     }
 }
 
+#[cfg(feature = "default-collider")]
+type ShouldWarn = (
+    Without<ColliderConstructor>,
+    Without<ColliderConstructorHierarchy>,
+);
+
+#[cfg(not(feature = "default-collider"))]
+type ShouldWarn = ();
+
 /// Logs warnings when dynamic bodies have invalid [`Mass`] or [`AngularInertia`].
 fn warn_invalid_mass(
     mut bodies: Query<
@@ -416,7 +425,10 @@ fn warn_invalid_mass(
             Ref<ComputedMass>,
             Ref<ComputedAngularInertia>,
         ),
-        Or<(Changed<ComputedMass>, Changed<ComputedAngularInertia>)>,
+        (
+            Or<(Changed<ComputedMass>, Changed<ComputedAngularInertia>)>,
+            ShouldWarn,
+        ),
     >,
 ) {
     for (entity, rb, mass, inertia) in &mut bodies {


### PR DESCRIPTION
# Objective

Rigid bodies with a `ColliderConstructor` or `ColliderConstructorHierarchy` often emit a warning for invalid mass properties before the collider has actually been generated. Annoying!

## Solution

Skip the warning for rigid bodies with a `ColliderConstructor` or `ColliderConstructorHierarchy`. Once the colliders have been generated, the mass is changed, which will automatically check for invalid mass again.