### PR TITLE
Update scale when the collider changes, not just when the transform changes.

### DIFF
--- a/src/collision/collider/backend.rs
+++ b/src/collision/collider/backend.rs
@@ -622,9 +622,12 @@ fn update_aabb<C: AnyCollider>(
 pub fn update_collider_scale<C: ScalableCollider>(
     mut colliders: ParamSet<(
         // Root bodies
-        Query<(&Transform, &mut C), (Without<ChildOf>, Changed<Transform>)>,
+        Query<(&Transform, &mut C), (Without<ChildOf>, Or<(Changed<Transform>, Changed<C>)>)>,
         // Child colliders
-        Query<(&ColliderTransform, &mut C), (With<ChildOf>, Changed<ColliderTransform>)>,
+        Query<
+            (&ColliderTransform, &mut C),
+            (With<ChildOf>, Or<(Changed<ColliderTransform>, Changed<C>)>),
+        >,
     )>,
     config: Res<PhysicsTransformConfig>,
 ) {


### PR DESCRIPTION
When an object's transform changes, Avian needs to sync the scale over to the corresponding Rapier collider. Avian already contains logic that handles the scenario when (1) a new collider is added (the on-add hook in `ColliderBackendPlugin::build`; (2) a transform in the hierarchy is updated (`update_collider_scale`). But it doesn't handle the case in which an existing collider is *changed*, as changes don't cause the on-add hooks to fire. This was causing scale to revert to 1.0 whenever a collider changed.

This commit fixes the issue by adding `Changed<C> where C: ScalableCollider` to the query filter in `update_collider_scale`.