### PR TITLE
Don't update the diagnostics UI if it isn't visible.

### DIFF
--- a/src/diagnostics/ui.rs
+++ b/src/diagnostics/ui.rs
@@ -35,7 +35,7 @@ impl Plugin for PhysicsDiagnosticsUiPlugin {
                     update_diagnostic_row_visibility,
                     update_diagnostic_group_visibility,
                 )
-                    .run_if(diagnostics_are_enabled)
+                    .run_if(diagnostics_are_enabled),
             )
                 .chain(),
         );


### PR DESCRIPTION
I noticed that UI layout and text measurement was taking around 1.5ms every frame in my application, even when no UI was visible. I added logging and traced it back to the Avian physics diagnostics UI. It turns out that, if the physics diagnostics UI plugin is present, Avian updates that UI every frame even if it isn't visible.

This commit introduces a simple run condition to avoid doing that.