### PR TITLE
Change `insert` to `try_insert` for removal of disabled entities

### DIFF
--- a/src/dynamics/solver/islands/mod.rs
+++ b/src/dynamics/solver/islands/mod.rs
@@ -91,7 +91,7 @@ impl Plugin for IslandPlugin {
                 if rb.is_dynamic() || rb.is_kinematic() {
                     commands
                         .entity(trigger.entity)
-                        .insert(BodyIslandNode::default());
+                        .try_insert(BodyIslandNode::default());
                 }
             },
         );
@@ -113,7 +113,7 @@ impl Plugin for IslandPlugin {
                 if rb.is_dynamic() || rb.is_kinematic() {
                     commands
                         .entity(trigger.entity)
-                        .insert(BodyIslandNode::default());
+                        .try_insert(BodyIslandNode::default());
                 }
             },
         );


### PR DESCRIPTION
# Objective

Removing a disabled entity panics when the `IslandPlugin` is enabled, because of an `insert` on a non-existent entity.

## Solution

Change the `insert` to `try_insert`.