### PR TITLE
Add public `IslandNode::island_id` getter

### DIFF
--- a/src/dynamics/solver/islands/mod.rs
+++ b/src/dynamics/solver/islands/mod.rs
@@ -1286,12 +1286,7 @@ pub struct IslandNode<Id> {
 
 impl<Id> IslandNode<Id> {
     /// A placeholder [`IslandNode`] that has not been initialized yet.
-    pub const PLACEHOLDER: Self = Self {
-        island_id: IslandId::PLACEHOLDER,
-        prev: None,
-        next: None,
-        is_visited: false,
-    };
+    pub const PLACEHOLDER: Self = Self::new(IslandId::PLACEHOLDER);
 
     /// Creates a new [`IslandNode`] with the given island ID.
     #[inline]


### PR DESCRIPTION
# Objective

Fixes #853.

It can sometimes be useful to access the island IDs of bodies or joints, but the ID is currently private.

## Solution

Add a public `IslandNode::island_id` getter. Also added some `new` constructors.