### PR TITLE
New pub methods to facilitate external query implementations

### DIFF
--- a/src/spatial_query/shape_caster.rs
+++ b/src/spatial_query/shape_caster.rs
@@ -370,7 +370,7 @@ impl ShapeCaster {
         let shape_direction = self.global_direction().adjust_precision().into();
 
         while hits.len() < self.max_hits as usize {
-            let composite = query_pipeline.as_composite_shape(&query_filter);
+            let composite = query_pipeline.as_composite_shape_internal(&query_filter);
             let pipeline_shape = CompositeShapeRef(&composite);
 
             let hit = pipeline_shape


### PR DESCRIPTION
# Objective

- Enable downstream library users to access all of the `SpatialQueryPipeline` constituents needed to implement methods like `cast_shape`. 

## Solution

- New methods `dispatcher_ref() { self.dispatcher.as_ref() }` and `entity(index) { self.proxies[index].entity }` implemented rather than just making the fields `pub` to ensure downstreams can only use the values, not mess with them in any ways that could compromise correctness
- New type-erased (` -> impl TypedCompositeShape`, so that the return types don't have to be made `pub`) versions of the existing `as_composite_shape*` methods, renaming the existing ones by adding `_internal`. I think it would be possible to replace the existing versions with these new ones altogether, but I worried that might prove unnecessarily restrictive in future. Alternatively could just make the existing methods and their return types public.

---

## Changelog

### Added
- New public methods on `SpatialQueryPipeline` that allow downstream crates to implement additional spatial queries
  - `as_composite_shape`/`as_composite_shape_with_predicate` return composite shapes representing the Avian world, usable with parry's bvh/spatial query machinery
  - `dispatcher_ref` returns a reference to the QueryDispatcher used by the pipeline
  - `entity(idx)` fetches the `Entity` referred to by the given index in the pipeline's BVH. Useful for interpreting the results of parry queries, which refer to colliders by their index within the BVH
