### PR TITLE
Fix issue with `RayCaster` when max_hits is set to 1

### DIFF
--- a/src/spatial_query/ray_caster.rs
+++ b/src/spatial_query/ray_caster.rs
@@ -262,13 +262,17 @@ impl RayCaster {
         hits.clear();
 
         if self.max_hits == 1 {
-            query_pipeline.cast_ray(
+            let first_hit = query_pipeline.cast_ray(
                 self.global_origin(),
                 self.global_direction(),
                 self.max_distance,
                 self.solid,
                 &self.query_filter,
             );
+
+            if let Some(hit) = first_hit {
+                hits.push(hit);
+            }
         } else {
             let ray = parry::query::Ray::new(
                 self.global_origin().into(),


### PR DESCRIPTION
# Objective

Fixes #868 

## Solution

Make sure the ray cast result is pushed into the `RayHits` component.

<!--
Note: If your PR contains breaking changes relative to the latest release,
      remember to add a migration guide! See `migration-guides/README.md`.
-->

## Testing

I tested this locally against my own project, and it fixed the issue.

You can test this yourself by spawning a `RayCaster` with max_hits set to 1, and ensuring that the `RayHits` component gets updated with the result.

Are there unit tests or similar that I can add a test case to?
