### PR TITLE
Update 3D character examples link

### DIFF
--- a/src/dynamics/rigid_body/mod.rs
+++ b/src/dynamics/rigid_body/mod.rs
@@ -118,11 +118,9 @@ use derive_more::From;
 ///
 /// Avian does not have a built-in character controller, so if you need one,
 /// you will need to implement it yourself or use a third party option.
-/// You can take a look at the [`basic_dynamic_character`] and [`basic_kinematic_character`]
-/// examples for a simple implementation.
+/// You can take a look at the [3D Examples] for implementations of basic kinematic and dynamic character controllers.
 ///
-/// [`basic_dynamic_character`]: https://github.com/avianphysics/avian/blob/42fb8b21c756a7f4dd91071597dc251245ddaa8f/crates/avian3d/examples/basic_dynamic_character.rs
-/// [`basic_kinematic_character`]: https://github.com/avianphysics/avian/blob/42fb8b21c756a7f4dd91071597dc251245ddaa8f/crates/avian3d/examples/basic_kinematic_character.rs
+/// [3D Examples]: https://github.com/avianphysics/avian/tree/081d2de15f526ada89bf642e3c3277c2c7784488/crates/avian3d/examples
 ///
 /// # Mass Properties
 ///


### PR DESCRIPTION
# Objective

Update broken links in RigidBody documentation, at the bottom of the Movement section:
https://docs.rs/avian3d/latest/avian3d/dynamics/rigid_body/enum.RigidBody.html#movement

Broken links are displayed as `basic_kinematic_character` and `basic_dynamic_character`.

## Solution

No breaking changes.

Replaced the broken links with a single link to the examples directory in the avian3d crate, using a github permalink.  I am confused why the original links broke as they appear to be permalinks as well.  Maybe something damaged the git history where these links originally lived - a rebase, or some other damage to the history.

## Testing

Changes were tested (and can be tested by reviewers) by generating the docs with cargo:
`cargo doc -p avian3d`
and jumping to <project_dir>/target/doc/avian3d/dynamics/rigid_body/enum.RigidBody.html#movement

---
