### PR TITLE
Fix panic when despawning joints after despawning their bodies

### DIFF
--- a/src/dynamics/solver/islands/mod.rs
+++ b/src/dynamics/solver/islands/mod.rs
@@ -733,7 +733,8 @@ impl PhysicsIslands {
         Some(island)
     }
 
-    /// Removes a joint from the island manager. Returns a reference to the island that the joint was removed from.
+    /// Removes a joint from the island manager. Returns a reference to the island
+    /// that the joint was removed from, if the island still exists.
     ///
     /// This will unlink the joint from the island and update the island's joint list.
     /// The [`PhysicsIsland::constraints_removed`] counter is incremented.
@@ -751,7 +752,7 @@ impl PhysicsIslands {
         body_islands: &mut Query<&mut BodyIslandNode, Or<(With<Disabled>, Without<Disabled>)>>,
         contact_graph: &ContactGraph,
         joint_graph: &mut JointGraph,
-    ) -> &PhysicsIsland {
+    ) -> Option<&PhysicsIsland> {
         let joint = joint_graph.get_mut_by_id(joint_id).unwrap();
 
         debug_assert!(joint.island.island_id != IslandId::PLACEHOLDER);
@@ -774,12 +775,7 @@ impl PhysicsIslands {
             next_island.prev = joint_island.prev;
         }
 
-        let island = self
-            .islands
-            .get_mut(joint_island.island_id.0 as usize)
-            .unwrap_or_else(|| {
-                panic!("Island {} does not exist", joint_island.island_id);
-            });
+        let island = self.islands.get_mut(joint_island.island_id.0 as usize)?;
 
         if island.head_joint == Some(joint_id) {
             // The joint is the head of the island.
@@ -805,7 +801,7 @@ impl PhysicsIslands {
             );
         }
 
-        island
+        Some(island)
     }
 
     /// Merges the [`PhysicsIsland`]s associated with the given bodies. Returns the ID of the resulting island.

--- a/src/dynamics/solver/joint_graph/plugin.rs
+++ b/src/dynamics/solver/joint_graph/plugin.rs
@@ -175,14 +175,14 @@ fn remove_joint_from_graph<E: EntityEvent, B: Bundle>(
     };
 
     // Remove the joint from the island.
-    if let Some(islands) = &mut islands {
-        let island = islands.remove_joint(
+    if let Some(islands) = &mut islands
+        && let Some(island) = islands.remove_joint(
             joint.id,
             &mut body_islands,
             &contact_graph,
             &mut joint_graph,
-        );
-
+        )
+    {
         // Wake up the island if it was sleeping.
         if island.is_sleeping {
             commands.queue(WakeIslands(vec![island.id]));
@@ -314,14 +314,14 @@ fn on_change_joint_entities<T: Component + EntityConstraint<2>>(
 
         if body1 != old_edge.body1 || body2 != old_edge.body2 {
             // Remove the joint from the island.
-            if let Some(islands) = &mut islands {
-                let island = islands.remove_joint(
+            if let Some(islands) = &mut islands
+                && let Some(island) = islands.remove_joint(
                     old_edge.id,
                     &mut body_islands,
                     &contact_graph,
                     &mut joint_graph,
-                );
-
+                )
+            {
                 // Wake up the island if it was sleeping.
                 if island.is_sleeping {
                     islands_to_wake.push(island.id);


### PR DESCRIPTION
# Objective

Fixes #835.

Removing a joint after its body has been removed results in a panic, as the island no longer exists.

## Solution

Return early if the island doesn't exist. This isn't the best fix (ideally we should remove the joint from the island as soon as the bodies are removed, but this is tricky currently), however it seems to fix the most imminent problem of crashes.

## Testing

Ran the example in #835. Crashed before, but not anymore.