### PR TITLE
Fixes Colliders not properly removing their collisions when they get disabled, moved and enabled.

### DIFF
--- a/src/collision/narrow_phase/mod.rs
+++ b/src/collision/narrow_phase/mod.rs
@@ -441,6 +441,9 @@ fn remove_collider(
         if let Ok(mut colliding_entities) = colliding_entities_query.get_mut(other_entity) {
             colliding_entities.remove(&entity);
         }
+        if let Ok(mut colliding_entities) = colliding_entities_query.get_mut(entity) {
+            colliding_entities.remove(&other_entity);
+        }
 
         let has_island = contact_edge.island.is_some();
 


### PR DESCRIPTION
# Objective
Whenever a Collider is disabled and moved away from a position, the collisions that it was triggering will come back to being active as soon as the Disabled component gets removed again, even if the collisions aren't happening.

## Testing
Steps to test:
- Add a Collider Sensor and add some other Colliders within it so that the collisions activate.
- Disable the Collider Sensor. The collisions will deactivate.
- Now move the Collider Sensor away and then re-enable it.
  - Previous to the patch the collisions activate again, even if they're not really colliding.
  - With the patch the collisions stay disabled.

Video of bugged behavior:

https://github.com/user-attachments/assets/7d3ee145-8543-4f85-84f4-3c2255297e7a

The pink area is a simple system that propels colliding bodies upward, and as you can see in the video it works even when they're not in contact. PR solves the issue completely.