### PR TITLE
Make `update_child_collider_position` pub

### DIFF
--- a/src/collision/collider/collider_transform/plugin.rs
+++ b/src/collision/collider/collider_transform/plugin.rs
@@ -64,7 +64,7 @@ impl Plugin for ColliderTransformPlugin {
 }
 
 #[allow(clippy::type_complexity)]
-pub(crate) fn update_child_collider_position(
+pub fn update_child_collider_position(
     mut collider_query: Query<
         (
             &ColliderTransform,


### PR DESCRIPTION
# Objective

In lightyear I replicate Position instead of Transform because Transform takes more bandwidth and because the internal systems (prediction) runs on Position.
However at the end of the frame the children's Position is not correct since the `update_child_collider_position` system only runs in `PhysicsSystems::First`.


## Solution

Make the system pub so that I can schedule it at the end of physics

