### PR TITLE
Add system that asserts physics components are finite

### DIFF
--- a/src/schedule/mod.rs
+++ b/src/schedule/mod.rs
@@ -290,13 +290,13 @@ fn update_last_physics_tick(
     last_physics_tick.0 = system_change_tick.this_run();
 }
 
-#[cfg(debug_assertions)]
 /// Debug system that checks for NaNs and infinities in Avian components and
 /// reports the last location they were written to.
-pub fn assert_components_finite(
+#[cfg(debug_assertions)]
+fn assert_components_finite(
     pos_query: Query<(Entity, Ref<Position>)>,
-    vel_query: Query<(Entity, Ref<LinearVelocity>)>,
-    ang_query: Query<(Entity, Ref<AngularVelocity>)>,
+    lin_vel_query: Query<(Entity, Ref<LinearVelocity>)>,
+    ang_vel_query: Query<(Entity, Ref<AngularVelocity>)>,
 ) {
     macro_rules! assert_finite {
         ($ent:expr, $val:ident, $ty:ty) => {
@@ -312,10 +312,10 @@ pub fn assert_components_finite(
     for (entity, position) in pos_query {
         assert_finite!(entity, position, Position);
     }
-    for (entity, velocity) in vel_query {
+    for (entity, velocity) in lin_vel_query {
         assert_finite!(entity, velocity, LinearVelocity);
     }
-    for (entity, angular_velocity) in ang_query {
-        assert_finite!(entity, angular_velocity, AngularVelocity);
+    for (entity, velocity) in ang_vel_query {
+        assert_finite!(entity, velocity, AngularVelocity);
     }
 }


### PR DESCRIPTION
# Objective

A lot of people (me included) have had to track down NaNs or infinities that causes avian internals to crash, and they can be difficult to track down because they cause crashes a lot later than they are introduced.

## Solution

Add a system when running with debug assertions that checks relevant components during `PhysicsSystems::First`.

For bugs in Avian internals we can potentially also schedule this system in other places.

### Questions
* I placed it in `PhysicsSchedulePlugin` because it feels more general purpose than the rest of `PhysicsDebugPlugin` and because it needs `self.schedule`, but I'm not sure if that's the best location for it?
* We could make the system use `assert!` instead of `debug_assert!` and make it runnable outside of `debug_assertions`?

## Testing

I modified one of the examples to introduce an infinity during Update and saw that it was caught.