### PR TITLE
Fix 3D `collider-from-mesh` feature

### DIFF
--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -52,7 +52,7 @@ parry-f64 = ["f64", "dep:parry3d-f64", "default-collider"]
 # Enables the XPBD constraint solver for joints.
 xpbd_joints = []
 
-collider-from-mesh = ["bevy/bevy_mesh", "3d"]
+collider-from-mesh = ["bevy/bevy_mesh", "bevy/bevy_mikktspace", "3d"]
 bevy_scene = ["bevy/bevy_scene"]
 bevy_picking = ["bevy/bevy_picking"]
 serialize = [


### PR DESCRIPTION
# Objective

`Mesh::generate_tangents` requires the `bevy_mikktspace` feature. Avian currently doesn't compile if `collider-from-mesh` is enabled but `bevy/bevy_mikktspace` isn't.

## Solution

Enable `bevy_mikktspace` for `collider-from-mesh` in 3D.