### PR TITLE
Bump version to 0.6.0-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "avian2d"
-version = "0.5.0"
+version = "0.6.0-dev"
 dependencies = [
  "approx",
  "arrayvec",
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "avian3d"
-version = "0.5.0"
+version = "0.6.0-dev"
 dependencies = [
  "approx",
  "avian_derive",

--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ First, add `avian2d` or `avian3d` to your dependencies in `Cargo.toml`:
 ```toml
 # For 2D applications:
 [dependencies]
-avian2d = "0.4"
+avian2d = "0.5"
 
 # For 3D applications:
 [dependencies]
-avian3d = "0.4"
+avian3d = "0.5"
 
 # If you want to use the most up-to-date version, you can follow the main branch:
 [dependencies]
@@ -159,13 +159,13 @@ cargo run --example cubes --no-default-features --features "3d f64 parry-f64"
 
 ## Version Table
 
-| Bevy    | Avian  |
-| ------- | ------ |
-| 0.18    | main   |
-| 0.17    | 0.4    |
-| 0.16    | 0.3    |
-| 0.15    | 0.2    |
-| 0.14    | 0.1    |
+| Bevy    | Avian     |
+| ------- | --------- |
+| 0.18    | 0.5, main |
+| 0.17    | 0.4       |
+| 0.16    | 0.3       |
+| 0.15    | 0.2       |
+| 0.14    | 0.1       |
 
 Avian provides [migration guides](./migration-guides) for each version.
 

--- a/crates/avian2d/Cargo.toml
+++ b/crates/avian2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avian2d"
-version = "0.5.0"
+version = "0.6.0-dev"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Joona Aalto <jondolf.dev@gmail.com>"]

--- a/crates/avian3d/Cargo.toml
+++ b/crates/avian3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avian3d"
-version = "0.5.0"
+version = "0.6.0-dev"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Joona Aalto <jondolf.dev@gmail.com>"]

--- a/migration-guides/0.4-to-0.5.md
+++ b/migration-guides/0.4-to-0.5.md
@@ -1,0 +1,5 @@
+# Migrating From v0.4 to v0.5
+
+**Avian 0.5** migrated from Bevy 0.17 to 0.18. See [Bevy's migration guide](https://bevy.org/learn/migration-guides/0-17-to-0-18/) for migrating to the new version.
+
+This release contains no breaking changes for Avian itself.

--- a/migration-guides/0.5-to-main.md
+++ b/migration-guides/0.5-to-main.md
@@ -1,4 +1,4 @@
-# Migrating From v0.4 to `main`
+# Migrating From v0.5 to `main`
 
 This file contains migration guides for breaking changes that have happened on the `main` branch
 since the latest release. These guides are evolving and may not be polished yet.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,11 +21,11 @@
 //! ```toml
 //! # For 2D applications:
 //! [dependencies]
-//! avian2d = "0.4"
+//! avian2d = "0.5"
 //!
 //! # For 3D applications:
 //! [dependencies]
-//! avian3d = "0.4"
+//! avian3d = "0.5"
 //!
 //! # If you want to use the most up-to-date version, you can follow the main branch:
 //! [dependencies]
@@ -39,7 +39,7 @@
 //! [dependencies]
 //! # Add 3D Avian with double-precision floating point numbers.
 //! # `parry-f64` enables collision detection using Parry.
-//! avian3d = { version = "0.4", default-features = false, features = ["3d", "f64", "parry-f64", "xpbd_joints"] }
+//! avian3d = { version = "0.5", default-features = false, features = ["3d", "f64", "parry-f64", "xpbd_joints"] }
 //! ```
 //!
 //! ## Feature Flags


### PR DESCRIPTION
# Objective

We released [v0.5](https://github.com/avianphysics/avian/releases/tag/v0.5.0), so it's time to bump version numbers and update migration guides.