### PR TITLE
Fix `move_and_slide` referencing mutable reference of cloned normal

### DIFF
--- a/src/character_controller/move_and_slide.rs
+++ b/src/character_controller/move_and_slide.rs
@@ -551,10 +551,11 @@ impl<'w, 's> MoveAndSlide<'w, 's> {
             // We need to add the sweep hit's plane explicitly, as `contact_manifolds` sometimes returns nothing
             // due to a Parry bug. Otherwise, `contact_manifolds` would pick up this normal anyways.
             // TODO: Remove this once the collision bug is fixed.
+            let mut first_normal = Dir::new_unchecked(sweep_hit.normal1.f32());
             let hit_response = on_hit(MoveAndSlideHitData {
                 entity: sweep_hit.entity,
                 point,
-                normal: &mut Dir::new_unchecked(sweep_hit.normal1.f32()),
+                normal: &mut first_normal,
                 collision_distance: sweep_hit.collision_distance,
                 distance: sweep_hit.distance,
                 position: &mut position,
@@ -562,7 +563,7 @@ impl<'w, 's> MoveAndSlide<'w, 's> {
             });
 
             if hit_response == MoveAndSlideHitResponse::Accept {
-                planes.push(Dir::new_unchecked(sweep_hit.normal1.f32()));
+                planes.push(first_normal);
             } else if hit_response == MoveAndSlideHitResponse::Abort {
                 break;
             }


### PR DESCRIPTION
# Objective

`move_and_slide` calls `on_hit` with a mutable reference to a clone of the hit normal, and the normal that ends up being used is always the original one. This means that if the user modifies the normal, it does nothing!

## Solution

Use the potentially mutated normal instead.