### PR TITLE
Fix `CollisionLayers` and `ActiveCollisionHooks` updates

### DIFF
--- a/src/collider_tree/update.rs
+++ b/src/collider_tree/update.rs
@@ -116,8 +116,8 @@ impl<C: AnyCollider> Plugin for ColliderTreeUpdatePlugin<C> {
         // 6. On replace `RigidBody`, move attached colliders to new tree.
         // 7. On add `Sensor`, set sensor proxy flag.
         // 8. On remove `Sensor`, unset sensor proxy flag.
-        // 9. On replace `CollisionLayers`, update proxy layers.
-        // 10. On replace `ActiveCollisionHooks`, set proxy flag.
+        // 9. On insert `CollisionLayers`, update proxy layers.
+        // 10. On insert `ActiveCollisionHooks`, set proxy flag.
         // 11. On replace `RigidBodyDisabled`, set/unset proxy flag.
 
         // Case 1


### PR DESCRIPTION
# Objective

`CollisionLayers` and `ActiveCollisionHooks` are updated in a  `Replace` observer, but that gives the old value!

## Solution

Change them to `Insert` observers.

## Testing

Tested inserting different layers at runtime in `collision_layers` example.