### PR TITLE
`SpatialQuery` take `ColliderTrees` using `Res` instead of `ResMut`

### DIFF
--- a/src/spatial_query/system_param.rs
+++ b/src/spatial_query/system_param.rs
@@ -60,7 +60,7 @@ use parry::query::ShapeCastOptions;
 pub struct SpatialQuery<'w, 's> {
     colliders: Query<'w, 's, (&'static Position, &'static Rotation, &'static Collider)>,
     aabbs: Query<'w, 's, &'static ColliderAabb>,
-    collider_trees: ResMut<'w, ColliderTrees>,
+    collider_trees: Res<'w, ColliderTrees>,
 }
 
 impl SpatialQuery<'_, '_> {


### PR DESCRIPTION
# Objective

`SpatialQuery` has this field::

```rust
collider_trees: ResMut<'w, ColliderTrees>,
```

But it only ever uses it for `self.collider_trees.iter_trees()` - which is a non-`&mut` method. Having it take the resource as mutable (in Bevy's level - not in Rust's level) needlessly prevents Bevy from parallelizing multiple systems that use `SpatialQuery`.

## Solution

Change it to be `Res`.

## Testing

I ran the `cast_ray_predicate` example, which uses `SpatialQuery`, and it seems to run fine.