### PR TITLE
Make `SpatialQueryPlugin` configurable

### DIFF
--- a/migration-guides/0.6-to-main.md
+++ b/migration-guides/0.6-to-main.md
@@ -6,6 +6,7 @@ since the latest release. These guides are evolving and may not be polished yet.
 See [migration-guides/README.md](./README.md) and existing entries for information about Avian's
 migration guide process and what to put here.
 
-## `SpatialQueryPlugin` schedule now can be configured
+## `SpatialQueryPlugin` schedule is configurable
 
-Similar to other plugins, it now stores a schedule label and affected by the label passed into `PhysicsPlugin::new`.
+Similar to many other plugins, the `SpatialQueryPlugin` now stores a schedule label,
+which by default is also passed via `PhysicsPlugins::new`.

--- a/migration-guides/0.6-to-main.md
+++ b/migration-guides/0.6-to-main.md
@@ -5,3 +5,7 @@ since the latest release. These guides are evolving and may not be polished yet.
 
 See [migration-guides/README.md](./README.md) and existing entries for information about Avian's
 migration guide process and what to put here.
+
+## `SpatialQueryPlugin` schedule now can be configured
+
+Similar to other plugins, it now stores a schedule label and affected by the label passed into `PhysicsPlugin::new`.

--- a/src/dynamics/rigid_body/mass_properties/mod.rs
+++ b/src/dynamics/rigid_body/mass_properties/mod.rs
@@ -459,6 +459,7 @@ mod tests {
     fn create_app() -> App {
         let mut app = App::new();
         app.add_plugins((MinimalPlugins, PhysicsPlugins::default(), TransformPlugin));
+        app.finish();
         app
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,6 +210,7 @@
 //!     - [`PhysicsSchedule`] and [`PhysicsStepSystems`]
 //!     - [`SubstepSchedule`]
 //!     - [`SolverSystems`] and [`SubstepSolverSystems`](dynamics::solver::schedule::SubstepSolverSystems)
+//!     - [`SpatialQuerySystems`]
 //!     - Many more internal system sets
 //! - [Configure the schedule used for running physics](PhysicsPlugins#custom-schedule)
 //! - [Pausing, resuming and stepping physics](Physics#pausing-resuming-and-stepping-physics)
@@ -781,7 +782,7 @@ impl PluginGroup for PhysicsPlugins {
             .add(BroadPhaseCorePlugin)
             .add(BvhBroadPhasePlugin::<()>::default())
             .add(JointPlugin)
-            .add(SpatialQueryPlugin)
+            .add(SpatialQueryPlugin::new(self.schedule))
             .add(PhysicsTransformPlugin::new(self.schedule))
             .add(PhysicsInterpolationPlugin::default())
     }

--- a/src/schedule/mod.rs
+++ b/src/schedule/mod.rs
@@ -100,7 +100,6 @@ impl Plugin for PhysicsSchedulePlugin {
                     PhysicsStepSystems::NarrowPhase,
                     PhysicsStepSystems::Solver,
                     PhysicsStepSystems::Sleeping,
-                    PhysicsStepSystems::SpatialQuery,
                     PhysicsStepSystems::Finalize,
                     PhysicsStepSystems::Last,
                 )
@@ -208,10 +207,6 @@ pub enum PhysicsStepSystems {
     Solver,
     /// Responsible for controlling when bodies should be deactivated and marked as [`Sleeping`].
     Sleeping,
-    /// Responsible for spatial queries like [raycasting](`RayCaster`) and shapecasting.
-    ///
-    /// See [`SpatialQueryPlugin`].
-    SpatialQuery,
     /// Responsible for logic that runs after the core physics step and prepares for the next one.
     Finalize,
     /// Runs at the end of the [`PhysicsSchedule`].

--- a/src/schedule/mod.rs
+++ b/src/schedule/mod.rs
@@ -186,7 +186,7 @@ pub type PhysicsSet = PhysicsSystems;
 /// 3. Narrow phase
 /// 4. Solver
 /// 5. Sleeping
-/// 6. Spatial queries
+/// 6. Finalize
 /// 7. Last
 #[derive(SystemSet, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum PhysicsStepSystems {

--- a/src/spatial_query/mod.rs
+++ b/src/spatial_query/mod.rs
@@ -202,7 +202,9 @@ impl Plugin for SpatialQueryPlugin {
             self.schedule,
             SpatialQuerySystems.after(TransformSystems::Propagate),
         )
-        .add_systems(
+        );
+
+        app.add_systems(
             self.schedule,
             (
                 update_ray_caster_positions,
@@ -223,7 +225,7 @@ impl Plugin for SpatialQueryPlugin {
     }
 }
 
-/// Responsible for spatial queries like [raycasting](`RayCaster`) and shapecasting.
+/// Responsible for updating spatial query components like [`RayCaster`] and [`ShapeCaster`].
 ///
 /// See [`SpatialQueryPlugin`].
 #[derive(SystemSet, Clone, Copy, Debug, PartialEq, Eq, Hash)]

--- a/src/spatial_query/mod.rs
+++ b/src/spatial_query/mod.rs
@@ -198,7 +198,11 @@ impl Default for SpatialQueryPlugin {
 
 impl Plugin for SpatialQueryPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(
+        app.configure_sets(
+            self.schedule,
+            SpatialQuerySystems.after(TransformSystems::Propagate),
+        )
+        .add_systems(
             self.schedule,
             (
                 update_ray_caster_positions,

--- a/src/spatial_query/mod.rs
+++ b/src/spatial_query/mod.rs
@@ -201,7 +201,6 @@ impl Plugin for SpatialQueryPlugin {
         app.configure_sets(
             self.schedule,
             SpatialQuerySystems.after(TransformSystems::Propagate),
-        )
         );
 
         app.add_systems(

--- a/src/spatial_query/mod.rs
+++ b/src/spatial_query/mod.rs
@@ -168,19 +168,38 @@ pub use shape_caster::*;
 pub use system_param::*;
 
 use crate::prelude::*;
-use bevy::prelude::*;
+use bevy::{
+    ecs::{intern::Interned, schedule::ScheduleLabel},
+    prelude::*,
+};
 
 /// Handles component-based [spatial queries](spatial_query) like [raycasting](spatial_query#raycasting)
 /// and [shapecasting](spatial_query#shapecasting) with [`RayCaster`] and [`ShapeCaster`].
-pub struct SpatialQueryPlugin;
+pub struct SpatialQueryPlugin {
+    schedule: Interned<dyn ScheduleLabel>,
+}
+
+impl SpatialQueryPlugin {
+    /// Creates a [`SpatialQueryPlugin`] with the schedule that is used for running the [`PhysicsSchedule`].
+    ///
+    /// The default schedule is `FixedPostUpdate`.
+    pub fn new(schedule: impl ScheduleLabel) -> Self {
+        Self {
+            schedule: schedule.intern(),
+        }
+    }
+}
+
+impl Default for SpatialQueryPlugin {
+    fn default() -> Self {
+        Self::new(FixedPostUpdate)
+    }
+}
 
 impl Plugin for SpatialQueryPlugin {
     fn build(&self, app: &mut App) {
-        let physics_schedule = app
-            .get_schedule_mut(PhysicsSchedule)
-            .expect("add PhysicsSchedule first");
-
-        physics_schedule.add_systems(
+        app.add_systems(
+            self.schedule,
             (
                 update_ray_caster_positions,
                 #[cfg(all(
@@ -190,7 +209,7 @@ impl Plugin for SpatialQueryPlugin {
                 (update_shape_caster_positions, raycast, shapecast).chain(),
             )
                 .chain()
-                .in_set(PhysicsStepSystems::SpatialQuery),
+                .in_set(SpatialQuerySystems),
         );
     }
 
@@ -199,6 +218,12 @@ impl Plugin for SpatialQueryPlugin {
         app.register_physics_diagnostics::<SpatialQueryDiagnostics>();
     }
 }
+
+/// Responsible for spatial queries like [raycasting](`RayCaster`) and shapecasting.
+///
+/// See [`SpatialQueryPlugin`].
+#[derive(SystemSet, Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct SpatialQuerySystems;
 
 type RayCasterPositionQueryComponents = (
     &'static mut RayCaster,

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -187,26 +187,27 @@ fn no_ambiguity_errors() {
     #[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash)]
     struct DeterministicSchedule;
 
-    App::new()
-        .add_plugins((
-            MinimalPlugins,
-            PhysicsPlugins::new(DeterministicSchedule)
-                .build()
-                .disable::<ColliderHierarchyPlugin>(),
-            bevy::asset::AssetPlugin::default(),
-            #[cfg(feature = "bevy_scene")]
-            bevy::scene::ScenePlugin,
-            #[cfg(all(feature = "collider-from-mesh", feature = "default-collider"))]
-            bevy::mesh::MeshPlugin,
-        ))
-        .edit_schedule(DeterministicSchedule, |s| {
-            s.set_build_settings(ScheduleBuildSettings {
-                ambiguity_detection: LogLevel::Error,
-                ..default()
-            });
-        })
-        .add_systems(Update, |w: &mut World| {
-            w.run_schedule(DeterministicSchedule);
-        })
-        .update();
+    let mut app = App::new();
+    app.add_plugins((
+        MinimalPlugins,
+        PhysicsPlugins::new(DeterministicSchedule)
+            .build()
+            .disable::<ColliderHierarchyPlugin>(),
+        bevy::asset::AssetPlugin::default(),
+        #[cfg(feature = "bevy_scene")]
+        bevy::scene::ScenePlugin,
+        #[cfg(all(feature = "collider-from-mesh", feature = "default-collider"))]
+        bevy::mesh::MeshPlugin,
+    ))
+    .edit_schedule(DeterministicSchedule, |s| {
+        s.set_build_settings(ScheduleBuildSettings {
+            ambiguity_detection: LogLevel::Error,
+            ..default()
+        });
+    })
+    .add_systems(Update, |w: &mut World| {
+        w.run_schedule(DeterministicSchedule);
+    })
+    .finish();
+    app.update();
 }


### PR DESCRIPTION
# Objective

- Fixes #969.

## Solution

I did what was suggested in #969.
The plugin now accepts a configurable schedule and `SpatialQuerySystems` now its own dedicated label.

The default behavior didn't change.
But now I can disable `SpatialQueryPlugin` from the `PhysicsPlugins` and add it manually with something like `PostUpdate`.
This fixes my problem.

## Testing

I tested it in my game.